### PR TITLE
provide example config.yml

### DIFF
--- a/docs/developer/getting_started.md
+++ b/docs/developer/getting_started.md
@@ -22,25 +22,5 @@ To run the unit tests, call:
 
 This section describes how to start the API on a developer's local machine.
 
-After building it as described above, the program has to be executed with the following arguments:
-
-```
---config <path-to-config-file> Lapis --api
-```
-
-where the config file is a YAML file with the following content:
-
-```
-default:
-  vineyard:
-    host: <db host>
-    port: <db port>
-    dbname: <db name>
-    username: <db user name>
-    password: <db user password>
-    schema: <db schema>
-  apiOpennessLevel: <"OPEN" or "GISAID">
-  cacheEnabled: false
-  redisHost:
-  redisPort:
-```
+After building it as described above, the program can be started with `server/startServer.sh`.
+The script assumes that the .jar file is present and that `server/config.yml.example` is copied to `server/config.yml`.

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,2 +1,3 @@
 .gradle
 build/
+/config.yml

--- a/server/config.yml.example
+++ b/server/config.yml.example
@@ -1,0 +1,12 @@
+default:
+  vineyard:
+    host: <db host>
+    port: <db port>
+    dbname: <db name>
+    username: <db user name>
+    password: <db user password>
+    schema: <db schema>
+  apiOpennessLevel: <"OPEN" or "GISAID">
+  cacheEnabled: false
+  redisHost:
+  redisPort:

--- a/server/startServer.sh
+++ b/server/startServer.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+java -jar build/libs/lapis-1.0-SNAPSHOT.jar --config config.yml Lapis --api


### PR DESCRIPTION
This seems more convenient than storing an example config in the docs.