### PR TITLE
refactor: simplify reading the config

### DIFF
--- a/docs/source/tutorials/developers_and_maintainers/setup_monkeypox_instance.rst
+++ b/docs/source/tutorials/developers_and_maintainers/setup_monkeypox_instance.rst
@@ -66,16 +66,15 @@ First, create a file ``lapis-proc-config.yml`` with the following content (pleas
 
 .. code-block:: bash
 
-    default:
-      vineyard:
-        host: lapis_db
-        port: 5432
-        dbname: postgres
-        username: lapis_proc
-        password: <missing>
-        schema: public
-      workdir: /data
-      maxNumberWorkers: 20
+    vineyard:
+      host: lapis_db
+      port: 5432
+      dbname: postgres
+      username: lapis_proc
+      password: <missing>
+      schema: public
+    workdir: /data
+    maxNumberWorkers: 20
 
 
 Then, execute the following command:
@@ -102,18 +101,17 @@ To start the API server, create a file ``lapis-api-config.yml`` with the followi
 
 .. code-block:: bash
 
-    default:
-      vineyard:
-        host: lapis_db
-        port: 5432
-        dbname: postgres
-        username: lapis_api
-        password: <missing>
-        schema: public
-      cacheEnabled: false
-      redisHost:
-      redisPort:
-      apiOpennessLevel: OPEN
+    vineyard:
+      host: lapis_db
+      port: 5432
+      dbname: postgres
+      username: lapis_api
+      password: <missing>
+      schema: public
+    cacheEnabled: false
+    redisHost:
+    redisPort:
+    apiOpennessLevel: OPEN
 
 Then, execute the following command:
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
     implementation 'com.sun.xml.bind:jaxb-impl:4.0.0'
 
-    implementation 'org.yaml:snakeyaml:1.30'
     implementation 'org.postgresql:postgresql:42.5.0'
     implementation 'com.mchange:c3p0:0.9.5.5'
     implementation 'org.javatuples:javatuples:1.2'
@@ -36,6 +35,7 @@ dependencies {
     implementation 'org.jooq:jooq:3.17.7'
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.github.luben:zstd-jni:1.5.2-3'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0'
 
     antlr 'org.antlr:antlr4:4.10.1'
     implementation 'org.antlr:antlr4-runtime:4.10.1'

--- a/server/src/main/java/ch/ethz/lapis/LapisMain.java
+++ b/server/src/main/java/ch/ethz/lapis/LapisMain.java
@@ -33,8 +33,8 @@ public class LapisMain {
             System.out.println("Please run with '--config <path/to/config>'");
             System.exit(1);
         }
-        Path configFilePath = Path.of(args[1]);
-        LapisConfig lapisConfig = configurationManager.loadConfiguration(configFilePath, "lapis");
+
+        LapisConfig lapisConfig = configurationManager.loadConfiguration(Path.of(args[1]));
 
         (new LapisMain()).run(Arrays.copyOfRange(args, 2, args.length), lapisConfig);
     }

--- a/server/src/main/java/ch/ethz/lapis/core/ConfigurationManager.java
+++ b/server/src/main/java/ch/ethz/lapis/core/ConfigurationManager.java
@@ -1,77 +1,22 @@
 package ch.ethz.lapis.core;
 
 import ch.ethz.lapis.LapisConfig;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import org.yaml.snakeyaml.Yaml;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 
 
 public class ConfigurationManager {
 
-    private static final String ENV_PREFIX = "HARVESTER_";
+    private final ObjectMapper objectMapper;
 
-    /**
-     * Loads the configuration from both the config file and from environment variables
-     */
-    public LapisConfig loadConfiguration(Path configPath, String programName)
-        throws IOException {
-        Map<String, ?> fileConfigMaps1 = readConfigMapsFromYaml(configPath);
-        Map<String, ?> envConfigMaps1 = readConfigMapFromEnvironmentVariables();
-
-        Map<String, Object> fileConfigMaps = new HashMap<>();
-        Map<String, Object> envConfigMaps = new HashMap<>();
-        fileConfigMaps1.forEach((key, value) -> fileConfigMaps.put(key.toLowerCase(), value));
-        envConfigMaps1.forEach((key, value) -> envConfigMaps.put(key.toLowerCase(), value));
-
-        Map<String, ?> fileDefaultConfig = (Map<String, ?>) fileConfigMaps.get("default");
-        Map<String, ?> fileProgramConfig = (Map<String, ?>) fileConfigMaps.get(programName);
-        Map<String, ?> envDefaultConfig = (Map<String, ?>) envConfigMaps.get("default");
-        Map<String, ?> envProgramConfig = (Map<String, ?>) envConfigMaps.get(programName);
-
-        Map merged = Utils.nullableMapDeepMerge(fileDefaultConfig, envDefaultConfig);
-        merged = Utils.nullableMapDeepMerge(merged, fileProgramConfig);
-        merged = Utils.nullableMapDeepMerge(merged, envProgramConfig);
-
-        JsonMapper objectMapper = JsonMapper.builder()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
-            .build();
-
-        return objectMapper.convertValue(merged, LapisConfig.class);
+    public ConfigurationManager() {
+        objectMapper = new ObjectMapper(new YAMLFactory());
     }
 
-    private Map<String, ?> readConfigMapsFromYaml(Path configPath) throws IOException {
-        Yaml yaml = new Yaml();
-        return yaml.load(Files.readString(configPath));
-    }
-
-    private Map<String, ?> readConfigMapFromEnvironmentVariables() {
-        Map<String, String> envs = System.getenv();
-        Map configMaps = new HashMap<>();
-        envs.forEach((prefixedKey, value) -> {
-            if (!prefixedKey.startsWith(ENV_PREFIX)) {
-                return;
-            }
-            String key = prefixedKey.substring(ENV_PREFIX.length());
-            String[] keyParts = key.split("_");
-            Map curMap = configMaps;
-            for (int i = 0; i < keyParts.length; i++) {
-                String keyPart = keyParts[i];
-                if (i < keyParts.length - 1) { // Not the last level
-                    curMap.putIfAbsent(keyPart, new HashMap());
-                    curMap = (Map) curMap.get(keyPart);
-                } else { // The last leveL: assign the actual value
-                    curMap.put(keyPart, value);
-                }
-            }
-        });
-        return configMaps;
+    public LapisConfig loadConfiguration(Path configPath) throws IOException {
+        return objectMapper.readValue(configPath.toFile(), LapisConfig.class);
     }
 }

--- a/server/src/main/java/ch/ethz/lapis/core/Utils.java
+++ b/server/src/main/java/ch/ethz/lapis/core/Utils.java
@@ -2,32 +2,8 @@ package ch.ethz.lapis.core;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
-import java.util.List;
-import java.util.Map;
 
 public class Utils {
-
-    public static String nullableBlankToNull(String s) {
-        if (s == null || s.isBlank()) {
-            return null;
-        }
-        return s;
-    }
-
-    public static Float nullableFloatValue(String s) {
-        if (s == null || s.isBlank()) {
-            return null;
-        }
-        try {
-            return Float.parseFloat(s);
-        } catch (NumberFormatException ignored) {
-            return null;
-        }
-    }
-
-
     public static Integer nullableIntegerValue(String s) {
         if (s == null || s.isBlank()) {
             return null;
@@ -39,51 +15,10 @@ public class Utils {
         }
     }
 
-
-    public static LocalDate nullableLocalDateValue(String s) {
-        if (s == null || s.isBlank()) {
-            return null;
-        }
-        try {
-            return LocalDate.parse(s);
-        } catch (DateTimeParseException ignored) {
-            return null;
-        }
-    }
-
-
-    /**
-     * Code based on https://stackoverflow.com/a/29698326/8376759 (CC BY-SA 3.0 license)
-     */
-    public static Map nullableMapDeepMerge(Map original, Map newMap) {
-        if (original == null) {
-            return newMap;
-        }
-        if (newMap == null) {
-            return original;
-        }
-        for (Object key : newMap.keySet()) {
-            if (newMap.get(key) instanceof Map newChild && original.get(key) instanceof Map originalChild) {
-                original.put(key, nullableMapDeepMerge(originalChild, newChild));
-            } else if (newMap.get(key) instanceof List newChild && original.get(key) instanceof List originalChild) {
-                for (Object each : newChild) {
-                    if (!originalChild.contains(each)) {
-                        originalChild.add(each);
-                    }
-                }
-            } else {
-                original.put(key, newMap.get(key));
-            }
-        }
-        return original;
-    }
-
-
     public static String getStackTraceString(Throwable e) {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         e.printStackTrace(pw);
         return sw.toString();
     }
-
 }

--- a/server/src/test/java/ch/ethz/lapis/core/ConfigurationManagerTest.java
+++ b/server/src/test/java/ch/ethz/lapis/core/ConfigurationManagerTest.java
@@ -1,0 +1,41 @@
+package ch.ethz.lapis.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import ch.ethz.lapis.LapisConfig;
+import ch.ethz.lapis.api.entity.OpennessLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+
+class ConfigurationManagerTest {
+
+    private ConfigurationManager configurationManager;
+
+    @BeforeEach
+    void setup() {
+        configurationManager = new ConfigurationManager();
+    }
+
+    @Test
+    void readConfiguration() throws IOException, URISyntaxException {
+        LapisConfig lapisConfig = configurationManager.loadConfiguration(
+            Path.of(getClass().getResource("/config.test.yml").toURI())
+        );
+
+        assertThat(lapisConfig.getVineyard().getHost(), is("<db host>"));
+        assertThat(lapisConfig.getVineyard().getPort(), is(123));
+        assertThat(lapisConfig.getVineyard().getDbname(), is("<db name>"));
+        assertThat(lapisConfig.getVineyard().getUsername(), is("<db user name>"));
+        assertThat(lapisConfig.getVineyard().getPassword(), is("<db user password>"));
+        assertThat(lapisConfig.getVineyard().getSchema(), is("<db schema>"));
+        assertThat(lapisConfig.getApiOpennessLevel(), is(OpennessLevel.GISAID));
+        assertThat(lapisConfig.getCacheEnabled(), is(false));
+        assertThat(lapisConfig.getRedisHost(), is("<redis host>"));
+        assertThat(lapisConfig.getRedisPort(), is(456));
+    }
+}

--- a/server/src/test/resources/config.test.yml
+++ b/server/src/test/resources/config.test.yml
@@ -1,11 +1,11 @@
 vineyard:
   host: <db host>
-  port: <db port>
+  port: 123
   dbname: <db name>
   username: <db user name>
   password: <db user password>
   schema: <db schema>
-apiOpennessLevel: <"OPEN" or "GISAID">
+apiOpennessLevel: "GISAID"
 cacheEnabled: false
-redisHost:
-redisPort:
+redisHost: <redis host>
+redisPort: 456


### PR DESCRIPTION
Reading the config from environment variables is unused -> remove it.

Reading the config thus effectively becomes a one-liner, making snakeyaml obsolete, because we can simply use jackson with it's yaml module.

@chaoran-chen The config files for the productive servers need to be adapted, too, they are probably not stored in this repo, are they?