### PR TITLE
refactor: remove unused dependency org.apache.commons:commons-text

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     implementation 'org.javatuples:javatuples:1.2'
     implementation 'org.apache.commons:commons-csv:1.9.0'
     implementation 'commons-io:commons-io:2.11.0'
-    implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.tukaani:xz:1.9'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     implementation 'org.simplejavamail:simple-java-mail:7.5.0'


### PR DESCRIPTION
I found no usages of org.apache.commons:commons-text -> remove the dependency.