### PR TITLE
fix: correctly map PangoLineageEquals filters

### DIFF
--- a/lapis2/docker-compose.yml
+++ b/lapis2/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: ghcr.io/genspectrum/lapis-v2:${LAPIS_TAG}
     ports:
       - "8080:8080"
-    command: --silo.url=http://silo:8080
+    command: --silo.url=http://silo:8081
   silo:
     image: ghcr.io/genspectrum/lapis-silo:${SILO_TAG}
     ports:
-      - ":8080"
+      - ":8081"

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -22,7 +22,8 @@ sealed class SiloFilterExpression(val type: String)
 
 data class StringEquals(val column: String, val value: String) : SiloFilterExpression("StringEquals")
 
-data class PangoLineageEquals(val pangoLineage: String) : SiloFilterExpression("PangoLineage")
+data class PangoLineageEquals(val value: String, val includeSublineages: Boolean) :
+    SiloFilterExpression("PangoLineage")
 
 data class NucleotideSymbolEquals(val position: Int, val symbol: String) : SiloFilterExpression("NucleotideEquals")
 

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/AggregatedModelTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/AggregatedModelTest.kt
@@ -64,6 +64,15 @@ class AggregatedModelTest {
         }
     }
 
+    @Test
+    fun `given invalid Pango lineage ending with a dot then handleRequest should throw an exception`() {
+        val filterParameter = mapOf("pangoLineage" to "A.1.2.")
+
+        assertThrows<IllegalArgumentException> {
+            underTest.handleRequest(filterParameter)
+        }
+    }
+
     @ParameterizedTest(name = "nucleotideMutations: {0}")
     @MethodSource("getNucleotideMutationWithWrongSyntax")
     fun `given nucleotideMutations with wrong syntax then handleRequest should throw an exception`(
@@ -112,7 +121,15 @@ class AggregatedModelTest {
             ),
             Arguments.of(
                 mapOf("pangoLineage" to "A.1.2.3"),
-                And(listOf(PangoLineageEquals("A.1.2.3"))),
+                And(listOf(PangoLineageEquals("A.1.2.3", includeSublineages = false))),
+            ),
+            Arguments.of(
+                mapOf("pangoLineage" to "A.1.2.3*"),
+                And(listOf(PangoLineageEquals("A.1.2.3", includeSublineages = true))),
+            ),
+            Arguments.of(
+                mapOf("pangoLineage" to "A.1.2.3.*"),
+                And(listOf(PangoLineageEquals("A.1.2.3", includeSublineages = true))),
             ),
             Arguments.of(
                 mapOf(
@@ -122,7 +139,7 @@ class AggregatedModelTest {
                 ),
                 And(
                     listOf(
-                        PangoLineageEquals("A.1.2.3"),
+                        PangoLineageEquals("A.1.2.3", includeSublineages = false),
                         StringEquals("some_metadata", "ABC"),
                         StringEquals("other_metadata", "DEF"),
                     ),

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloFilterTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloFilterTest.kt
@@ -60,11 +60,22 @@ class SiloFilterTest {
                 """,
             ),
             Arguments.of(
-                PangoLineageEquals("ABC"),
+                PangoLineageEquals("ABC", includeSublineages = false),
                 """
                 {
                     "type": "PangoLineage",
-                    "pangoLineage": "ABC"
+                    "value": "ABC",
+                    "includeSublineages": false
+                }
+                """,
+            ),
+            Arguments.of(
+                PangoLineageEquals("ABC", includeSublineages = true),
+                """
+                {
+                    "type": "PangoLineage",
+                    "value": "ABC",
+                    "includeSublineages": true
                 }
                 """,
             ),

--- a/siloLapisTests/test/aggregatedQueries/pangoLineageIsB_1_1_7.json
+++ b/siloLapisTests/test/aggregatedQueries/pangoLineageIsB_1_1_7.json
@@ -1,0 +1,9 @@
+{
+  "testCaseName": "Pango lineage is B.1.1.7",
+  "lapisRequest": {
+    "pangoLineage": "B.1.1.7"
+  },
+  "expected": {
+    "count": 48
+  }
+}

--- a/siloLapisTests/test/aggregatedQueries/pangoLineageIsB_1_1_7endingWithDotIncludingSublineages.json
+++ b/siloLapisTests/test/aggregatedQueries/pangoLineageIsB_1_1_7endingWithDotIncludingSublineages.json
@@ -1,0 +1,9 @@
+{
+  "testCaseName": "Pango lineage B.1.1.7.* yields the same result as B.1.1.7*",
+  "lapisRequest": {
+    "pangoLineage": "B.1.1.7.*"
+  },
+  "expected": {
+    "count": 49
+  }
+}

--- a/siloLapisTests/test/aggregatedQueries/pangoLineageIsB_1_1_7includingSublineages.json
+++ b/siloLapisTests/test/aggregatedQueries/pangoLineageIsB_1_1_7includingSublineages.json
@@ -1,0 +1,9 @@
+{
+  "testCaseName": "Pango lineage is B.1.1.7* (including sublineages)",
+  "lapisRequest": {
+    "pangoLineage": "B.1.1.7*"
+  },
+  "expected": {
+    "count": 49
+  }
+}


### PR DESCRIPTION
resolves #201 

This depends on https://github.com/GenSpectrum/LAPIS-SILO/pull/64.