### PR TITLE
Implement advanced variant queries for SARS-COV-2

### DIFF
--- a/lapis2/build.gradle
+++ b/lapis2/build.gradle
@@ -9,6 +9,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.spring' version '1.8.20'
     id 'org.jlleitschuh.gradle.ktlint' version "11.3.1"
     id 'org.springdoc.openapi-gradle-plugin' version "1.6.0"
+    id 'antlr'
 }
 
 group = 'org.genspectrum'
@@ -27,6 +28,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     implementation 'io.github.microutils:kotlin-logging-jvm:3.0.5'
+    antlr 'org.antlr:antlr4:4.11.1'
+    implementation 'org.antlr:antlr4-runtime:4.11.1'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: "org.mockito"
@@ -35,14 +38,26 @@ dependencies {
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
 }
 
+
 compileKotlin {
+    dependsOn generateGrammarSource
     compilerOptions {
         freeCompilerArgs.add("-Xexport-kdoc")
         jvmTarget.set(JvmTarget.JVM_19)
     }
 }
 
+tasks.named('runKtlintCheckOverMainSourceSet') {
+    mustRunAfter("generateGrammarSource")
+}
+
+tasks.named('compileTestKotlin') {
+    mustRunAfter("generateGrammarSource")
+    mustRunAfter("generateTestGrammarSource")
+}
+
 tasks.named('test') {
+    dependsOn generateGrammarSource
     useJUnitPlatform()
     testLogging {
         events TestLogEvent.FAILED

--- a/lapis2/build.gradle
+++ b/lapis2/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     }
     testImplementation 'com.ninja-squad:springmockk:4.0.2'
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
 }
 
 

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -13,61 +13,61 @@ expr:
   ;
 
 single:
-  nucleotide_mutation_query
-  | pangolineage_query
-  | n_of_query
-  | nucleotide_insertion_query
-  | aa_mutation_query
-  | aa_insertion_query
-  | nextclade_pangolineage_query
-  | nextstrain_clade_lineage_query
-  | gisaid_clade_lineage_query
+  nucleotideMutationQuery
+  | pangolineageQuery
+  | nOfQuery
+  | nucleotideInsertionQuery
+  | aaMutationQuery
+  | aaInsertionQuery
+  | nextcladePangolineageQuery
+  | nextstrainCladeLineageQuery
+  | gisaidCladeLineageQuery
   ;
 
-nucleotide_mutation_query : nucleotide_mutation_query_first_symbol? position nucleotide_mutation_query_second_symbol?;
-nucleotide_mutation_query_first_symbol: nucleotide_symbol;
-nucleotide_mutation_query_second_symbol: possible_ambigous_nucleotide_symbol;
+nucleotideMutationQuery : nucleotideMutationQueryFirstSymbol? position nucleotideMutationQuerySecondSymbol?;
+nucleotideMutationQueryFirstSymbol: nucleotideSymbol;
+nucleotideMutationQuerySecondSymbol: possibleAmbiguousNucleotideSymbol;
 position: NUMBER+;
-nucleotide_symbol: A | C | G | T;
-ambigous_nucleotide_symbol: M | R | W | S | Y | K | V | H | D | B | N | MINUS | DOT;
-possible_ambigous_nucleotide_symbol: nucleotide_symbol | ambigous_nucleotide_symbol;
+nucleotideSymbol: A | C | G | T;
+ambiguousNucleotideSymbol: M | R | W | S | Y | K | V | H | D | B | N | MINUS | DOT;
+possibleAmbiguousNucleotideSymbol: nucleotideSymbol | ambiguousNucleotideSymbol;
 
 
-pangolineage_query: pangolineage pangolineage_include_sublineages?;
-pangolineage: pangolineage_character pangolineage_character? pangolineage_character? pangolineage_number_component*;
-pangolineage_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
-pangolineage_number_component: '.' NUMBER NUMBER? NUMBER?;
-pangolineage_include_sublineages: DOT? ASTERISK;
+pangolineageQuery: pangolineage pangolineageIncludeSublineages?;
+pangolineage: pangolineageCharacter pangolineageCharacter? pangolineageCharacter? pangolineageNumberComponent*;
+pangolineageCharacter: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
+pangolineageNumberComponent: '.' NUMBER NUMBER? NUMBER?;
+pangolineageIncludeSublineages: DOT? ASTERISK;
 
-n_of_query: '[' n_of_match_exactly? n_of_number_of_matchers no_of_of_keyword n_of_exprs ']';
-no_of_of_keyword: '-of:' | '-OF:';
-n_of_match_exactly: 'EXACTLY-' | 'exactly-';
-n_of_number_of_matchers: NUMBER+;
-n_of_exprs: expr (',' expr)*;
+nOfQuery: '[' nOfMatchExactly? nOfNumberOfMatchers nOfOfKeyword nOfExprs ']';
+nOfOfKeyword: '-of:' | '-OF:';
+nOfMatchExactly: 'EXACTLY-' | 'exactly-';
+nOfNumberOfMatchers: NUMBER+;
+nOfExprs: expr (',' expr)*;
 
-nucleotide_insertion_query: insertion_keyword position ':' (possible_ambigous_nucleotide_symbol | '?')+;
-insertion_keyword: 'ins_' | 'INS_';
+nucleotideInsertionQuery: insertionKeyword position ':' (possibleAmbiguousNucleotideSymbol | '?')+;
+insertionKeyword: 'ins_' | 'INS_';
 
-aa_mutation_query: gene ':' aa_symbol? position possible_ambigous_aa_symbol?;
-aa_symbol: A | R | N | D | C | E | Q | G | H | I | L | K | M | F | P | S | T | W | Y | V | ASTERISK;
-ambigous_aa_symbol: X | MINUS | DOT;
-possible_ambigous_aa_symbol: aa_symbol | ambigous_aa_symbol;
-gene: covid_gene;
-covid_gene : E | M | N | S | ORF;
+aaMutationQuery: gene ':' aaSymbol? position possibleAmbiguousAaSymbol?;
+aaSymbol: A | R | N | D | C | E | Q | G | H | I | L | K | M | F | P | S | T | W | Y | V | ASTERISK;
+ambiguousAaSymbol: X | MINUS | DOT;
+possibleAmbiguousAaSymbol: aaSymbol | ambiguousAaSymbol;
+gene: covidGene;
+covidGene : E | M | N | S | ORF;
 
-aa_insertion_query: insertion_keyword gene ':' position ':' (possible_ambigous_aa_symbol | '?')+;
+aaInsertionQuery: insertionKeyword gene ':' position ':' (possibleAmbiguousAaSymbol | '?')+;
 
-nextclade_pangolineage_query: nextclade_pango_lineage_prefix pangolineage_query;
-nextclade_pango_lineage_prefix: 'nextcladePangoLineage:' | 'NEXTCLADEPANGOLINEAGE:';
+nextcladePangolineageQuery: nextcladePangoLineagePrefix pangolineageQuery;
+nextcladePangoLineagePrefix: 'nextcladePangoLineage:' | 'NEXTCLADEPANGOLINEAGE:';
 
-nextstrain_clade_lineage_query: nextstrain_clade_prefix nextstrain_clade_query;
-nextstrain_clade_prefix: 'nextstrainClade:'| 'NEXTSTRAINCLADE:';
-nextstrain_clade_query: NUMBER NUMBER nextstrain_clade_character | 'RECOMBINANT';
-nextstrain_clade_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
+nextstrainCladeLineageQuery: nextstrainCladePrefix nextstrainCladeQuery;
+nextstrainCladePrefix: 'nextstrainClade:'| 'NEXTSTRAINCLADE:';
+nextstrainCladeQuery: NUMBER NUMBER nextstrainCladeCharacter | 'RECOMBINANT';
+nextstrainCladeCharacter: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
 
-gisaid_clade_lineage_query: gisaid_clade_prefix gisaid_clade_query;
-gisaid_clade_prefix: ('gisaid:'| 'GISAID:');
-gisaid_clade_query: gisaid_clade_character gisaid_clade_character?;
+gisaidCladeLineageQuery: gisaidCladePrefix gisaidCladeNomenclature;
+gisaidCladePrefix: ('gisaid:'| 'GISAID:');
+gisaidCladeNomenclature: gisaid_clade_character gisaid_clade_character?;
 gisaid_clade_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
 
 

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -7,6 +7,7 @@ expr:
   single             # Uni
   | '!' expr         # Not
   | expr '&' expr    # And
+  | expr '|' expr    # Or
   ;
 
 single:

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -8,7 +8,7 @@ expr:
   | '!' expr         # Not
   | expr '&' expr    # And
   | expr '|' expr    # Or
-  | '(' expr ')'     # Parentesis
+  | '(' expr ')'     # Parenthesis
   | 'MAYBE(' expr ')' # Maybe
   ;
 

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -16,6 +16,12 @@ single:
   nucleotide_mutation
   | pangolineage_query
   | n_of_query
+  | nucleotide_insertion
+  | aa_mutation
+  | aa_insertion
+  | nextclade_pangolineage_query
+  | nextstrain_clade_lineage_query
+  | gisaid_clade_lineage_query
   ;
 
 nucleotide_mutation : nucleotide_symbol? position ambigous_nucleotide_symbol?;
@@ -33,6 +39,30 @@ n_of_query: '[' n_of_match_exactly? n_of_number_of_matchers '-of:' n_of_exprs ']
 n_of_match_exactly: 'EXACTLY-';
 n_of_number_of_matchers: NUMBER+;
 n_of_exprs: expr (',' expr)*;
+
+nucleotide_insertion: 'ins_' position ':' (ambigous_nucleotide_symbol | '?')+;
+
+aa_mutation: gene ':' aa_symbol? position ambigous_aa_symbol?;
+aa_symbol: A | R | N | D | C | E | Q | G | H | I | L | K | M | F | P | S | T | W | Y | V | ASTERISK;
+ambigous_aa_symbol: aa_symbol | X | MINUS | DOT;
+gene: covid_gene;
+covid_gene : E | M | N | S | ORF;
+
+aa_insertion: 'ins_' gene ':' (ambigous_aa_symbol | '?')+;
+
+nextclade_pangolineage_query: nextclade_pango_lineage_prefix pangolineage_query;
+nextclade_pango_lineage_prefix: 'nextcladePangoLineage:';
+
+nextstrain_clade_lineage_query: nextstrain_clade_prefix nextstrain_clade_query;
+nextstrain_clade_prefix: 'nextstrainClade:';
+nextstrain_clade_query: NUMBER NUMBER nextstrain_clade_character | 'RECOMBINANT';
+nextstrain_clade_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
+
+gisaid_clade_lineage_query: gisaid_clade_prefix gisaid_clade_query;
+gisaid_clade_prefix: 'gisaid:';
+gisaid_clade_query: gisaid_clade_character gisaid_clade_character?;
+gisaid_clade_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
+
 
 // lexer rules
 
@@ -68,3 +98,5 @@ ASTERISK: '*';
 
 NUMBER: [0-9];
 WHITESPACE: [ \r\n\t] -> skip;
+
+ORF: 'ORF1A' | 'ORF1B' | 'ORF3A' | 'ORF6' | 'ORF7A' | 'ORF7B' | 'ORF8' | 'ORF9B';

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -8,6 +8,8 @@ expr:
   | '!' expr         # Not
   | expr '&' expr    # And
   | expr '|' expr    # Or
+  | '(' expr ')'     # Parentesis
+  | 'MAYBE(' expr ')' # Maybe
   ;
 
 single:

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -1,0 +1,53 @@
+grammar VariantQuery;
+
+// parser rules
+
+start: expr EOF;
+expr:
+  single             # Uni
+  | expr '&' expr    # And
+  ;
+
+single:
+  nucleotide_mutation
+  ;
+
+nucleotide_mutation : nucleotide_symbol? position ambigous_nucleotide_symbol?;
+
+position: NUMBER+;
+nucleotide_symbol: A | C | G | T;
+ambigous_nucleotide_symbol: nucleotide_symbol | M | R | W | S | Y | K | V | H | D | B | N | MINUS | DOT;
+
+// lexer rules
+
+A: 'A';
+B: 'B';
+C: 'C';
+D: 'D';
+E: 'E';
+F: 'F';
+G: 'G';
+H: 'H';
+I: 'I';
+J: 'J';
+K: 'K';
+L: 'L';
+M: 'M';
+N: 'N';
+O: 'O';
+P: 'P';
+Q: 'Q';
+R: 'R';
+S: 'S';
+T: 'T';
+U: 'U';
+V: 'V';
+W: 'W';
+X: 'X';
+Y: 'Y';
+Z: 'Z';
+MINUS: '-';
+DOT: '.';
+
+NUMBER: [0-9];
+WHITESPACE: [ \r\n\t] -> skip;

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -5,6 +5,7 @@ grammar VariantQuery;
 start: expr EOF;
 expr:
   single             # Uni
+  | '!' expr         # Not
   | expr '&' expr    # And
   ;
 

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -13,21 +13,25 @@ expr:
   ;
 
 single:
-  nucleotide_mutation
+  nucleotide_mutation_query
   | pangolineage_query
   | n_of_query
-  | nucleotide_insertion
-  | aa_mutation
-  | aa_insertion
+  | nucleotide_insertion_query
+  | aa_mutation_query
+  | aa_insertion_query
   | nextclade_pangolineage_query
   | nextstrain_clade_lineage_query
   | gisaid_clade_lineage_query
   ;
 
-nucleotide_mutation : nucleotide_symbol? position ambigous_nucleotide_symbol?;
+nucleotide_mutation_query : nucleotide_mutation_query_first_symbol? position nucleotide_mutation_query_second_symbol?;
+nucleotide_mutation_query_first_symbol: nucleotide_symbol;
+nucleotide_mutation_query_second_symbol: possible_ambigous_nucleotide_symbol;
 position: NUMBER+;
 nucleotide_symbol: A | C | G | T;
-ambigous_nucleotide_symbol: nucleotide_symbol | M | R | W | S | Y | K | V | H | D | B | N | MINUS | DOT;
+ambigous_nucleotide_symbol: M | R | W | S | Y | K | V | H | D | B | N | MINUS | DOT;
+possible_ambigous_nucleotide_symbol: nucleotide_symbol | ambigous_nucleotide_symbol;
+
 
 pangolineage_query: pangolineage pangolineage_include_sublineages?;
 pangolineage: pangolineage_character pangolineage_character? pangolineage_character? pangolineage_number_component*;
@@ -35,31 +39,34 @@ pangolineage_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | 
 pangolineage_number_component: '.' NUMBER NUMBER? NUMBER?;
 pangolineage_include_sublineages: DOT? ASTERISK;
 
-n_of_query: '[' n_of_match_exactly? n_of_number_of_matchers '-of:' n_of_exprs ']';
-n_of_match_exactly: 'EXACTLY-';
+n_of_query: '[' n_of_match_exactly? n_of_number_of_matchers no_of_of_keyword n_of_exprs ']';
+no_of_of_keyword: '-of:' | '-OF:';
+n_of_match_exactly: 'EXACTLY-' | 'exactly-';
 n_of_number_of_matchers: NUMBER+;
 n_of_exprs: expr (',' expr)*;
 
-nucleotide_insertion: 'ins_' position ':' (ambigous_nucleotide_symbol | '?')+;
+nucleotide_insertion_query: insertion_keyword position ':' (possible_ambigous_nucleotide_symbol | '?')+;
+insertion_keyword: 'ins_' | 'INS_';
 
-aa_mutation: gene ':' aa_symbol? position ambigous_aa_symbol?;
+aa_mutation_query: gene ':' aa_symbol? position possible_ambigous_aa_symbol?;
 aa_symbol: A | R | N | D | C | E | Q | G | H | I | L | K | M | F | P | S | T | W | Y | V | ASTERISK;
-ambigous_aa_symbol: aa_symbol | X | MINUS | DOT;
+ambigous_aa_symbol: X | MINUS | DOT;
+possible_ambigous_aa_symbol: aa_symbol | ambigous_aa_symbol;
 gene: covid_gene;
 covid_gene : E | M | N | S | ORF;
 
-aa_insertion: 'ins_' gene ':' (ambigous_aa_symbol | '?')+;
+aa_insertion_query: insertion_keyword gene ':' position ':' (possible_ambigous_aa_symbol | '?')+;
 
 nextclade_pangolineage_query: nextclade_pango_lineage_prefix pangolineage_query;
-nextclade_pango_lineage_prefix: 'nextcladePangoLineage:';
+nextclade_pango_lineage_prefix: 'nextcladePangoLineage:' | 'NEXTCLADEPANGOLINEAGE:';
 
 nextstrain_clade_lineage_query: nextstrain_clade_prefix nextstrain_clade_query;
-nextstrain_clade_prefix: 'nextstrainClade:';
+nextstrain_clade_prefix: 'nextstrainClade:'| 'NEXTSTRAINCLADE:';
 nextstrain_clade_query: NUMBER NUMBER nextstrain_clade_character | 'RECOMBINANT';
 nextstrain_clade_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
 
 gisaid_clade_lineage_query: gisaid_clade_prefix gisaid_clade_query;
-gisaid_clade_prefix: 'gisaid:';
+gisaid_clade_prefix: ('gisaid:'| 'GISAID:');
 gisaid_clade_query: gisaid_clade_character gisaid_clade_character?;
 gisaid_clade_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
 

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -15,6 +15,7 @@ expr:
 single:
   nucleotide_mutation
   | pangolineage_query
+  | n_of_query
   ;
 
 nucleotide_mutation : nucleotide_symbol? position ambigous_nucleotide_symbol?;
@@ -28,6 +29,10 @@ pangolineage_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | 
 pangolineage_number_component: '.' NUMBER NUMBER? NUMBER?;
 pangolineage_include_sublineages: DOT? ASTERISK;
 
+n_of_query: '[' n_of_match_exactly? n_of_number_of_matchers '-of:' n_of_exprs ']';
+n_of_match_exactly: 'EXACTLY-';
+n_of_number_of_matchers: NUMBER+;
+n_of_exprs: expr (',' expr)*;
 
 // lexer rules
 

--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -14,13 +14,20 @@ expr:
 
 single:
   nucleotide_mutation
+  | pangolineage_query
   ;
 
 nucleotide_mutation : nucleotide_symbol? position ambigous_nucleotide_symbol?;
-
 position: NUMBER+;
 nucleotide_symbol: A | C | G | T;
 ambigous_nucleotide_symbol: nucleotide_symbol | M | R | W | S | Y | K | V | H | D | B | N | MINUS | DOT;
+
+pangolineage_query: pangolineage pangolineage_include_sublineages?;
+pangolineage: pangolineage_character pangolineage_character? pangolineage_character? pangolineage_number_component*;
+pangolineage_character: A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z;
+pangolineage_number_component: '.' NUMBER NUMBER? NUMBER?;
+pangolineage_include_sublineages: DOT? ASTERISK;
+
 
 // lexer rules
 
@@ -52,6 +59,7 @@ Y: 'Y';
 Z: 'Z';
 MINUS: '-';
 DOT: '.';
+ASTERISK: '*';
 
 NUMBER: [0-9];
 WHITESPACE: [ \r\n\t] -> skip;

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
@@ -6,7 +6,7 @@ data class DatabaseSchema(
     val instanceName: String,
     val metadata: List<DatabaseMetadata>,
     val primaryKey: String,
-    val features: List<DatabaseFeature>,
+    val features: List<DatabaseFeature>?,
 )
 
 data class DatabaseMetadata(val name: String, val type: String)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
@@ -2,6 +2,13 @@ package org.genspectrum.lapis.config
 
 data class DatabaseConfig(val schema: DatabaseSchema)
 
-data class DatabaseSchema(val instanceName: String, val metadata: List<DatabaseMetadata>, val primaryKey: String)
+data class DatabaseSchema(
+    val instanceName: String,
+    val metadata: List<DatabaseMetadata>,
+    val primaryKey: String,
+    val features: List<DatabaseFeature>,
+)
 
 data class DatabaseMetadata(val name: String, val type: String)
+
+data class DatabaseFeature(val name: String)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
@@ -6,7 +6,7 @@ data class DatabaseSchema(
     val instanceName: String,
     val metadata: List<DatabaseMetadata>,
     val primaryKey: String,
-    val features: List<DatabaseFeature>?,
+    val features: List<DatabaseFeature> = emptyList(),
 )
 
 data class DatabaseMetadata(val name: String, val type: String)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -13,12 +13,10 @@ data class SequenceFilterFields(val fields: Map<SequenceFilterFieldName, Sequenc
                 .toMap()
             val staticFields = listOf(nucleotideMutationsField)
 
-            val featuresFields = if (databaseConfig.schema.features.isNullOrEmpty()) {
+            val featuresFields = if (databaseConfig.schema.features.isEmpty()) {
                 emptyMap<SequenceFilterFieldName, SequenceFilterFieldType>()
             } else {
-                databaseConfig.schema.features
-                    .map(::mapToSequenceFilterFieldsFromFeatures)
-                    .toMap()
+                databaseConfig.schema.features.associate(::mapToSequenceFilterFieldsFromFeatures)
             }
 
             return SequenceFilterFields(fields = metadataFields + staticFields + featuresFields)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -10,7 +10,12 @@ data class SequenceFilterFields(val fields: Map<FieldName, SequenceFilterFieldTy
             fields = databaseConfig.schema.metadata
                 .map(::mapToSequenceFilterFields)
                 .flatten()
-                .toMap() + nucleotideMutationsField,
+                .toMap() +
+                databaseConfig.schema.features
+                    .map(::mapToSequenceFilterFieldsFromFeatures)
+                    .flatten()
+                    .toMap() +
+                nucleotideMutationsField,
         )
     }
 }
@@ -29,11 +34,19 @@ private fun mapToSequenceFilterFields(databaseMetadata: DatabaseMetadata) = when
     )
 }
 
+private fun mapToSequenceFilterFieldsFromFeatures(databaseFeature: DatabaseFeature) = when (databaseFeature.name) {
+    "sarsCoV2VariantQuery" -> listOf(databaseFeature.name to SequenceFilterFieldType.VariantQuery)
+    else -> throw IllegalArgumentException(
+        "Unknown feature '${databaseFeature.name}'",
+    )
+}
+
 sealed class SequenceFilterFieldType(val openApiType: kotlin.String) {
     object String : SequenceFilterFieldType("string")
     object PangoLineage : SequenceFilterFieldType("string")
     object Date : SequenceFilterFieldType("string")
     object MutationsList : SequenceFilterFieldType("string")
+    object VariantQuery : SequenceFilterFieldType("string")
     data class DateFrom(val associatedField: kotlin.String) : SequenceFilterFieldType("string")
     data class DateTo(val associatedField: kotlin.String) : SequenceFilterFieldType("string")
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -1,8 +1,8 @@
 package org.genspectrum.lapis.config
 
-typealias FieldName = String
+typealias SequenceFilterFieldName = String
 
-data class SequenceFilterFields(val fields: Map<FieldName, SequenceFilterFieldType>) {
+data class SequenceFilterFields(val fields: Map<SequenceFilterFieldName, SequenceFilterFieldType>) {
     companion object {
         private val nucleotideMutationsField = Pair("nucleotideMutations", SequenceFilterFieldType.MutationsList)
 
@@ -14,7 +14,7 @@ data class SequenceFilterFields(val fields: Map<FieldName, SequenceFilterFieldTy
             val staticFields = listOf(nucleotideMutationsField)
 
             val featuresFields = if (databaseConfig.schema.features.isNullOrEmpty()) {
-                emptyMap<FieldName, SequenceFilterFieldType>()
+                emptyMap<SequenceFilterFieldName, SequenceFilterFieldType>()
             } else {
                 databaseConfig.schema.features
                     .map(::mapToSequenceFilterFieldsFromFeatures)
@@ -53,6 +53,6 @@ sealed class SequenceFilterFieldType(val openApiType: kotlin.String) {
     object Date : SequenceFilterFieldType("string")
     object MutationsList : SequenceFilterFieldType("string")
     object VariantQuery : SequenceFilterFieldType("string")
-    data class DateFrom(val associatedField: kotlin.String) : SequenceFilterFieldType("string")
-    data class DateTo(val associatedField: kotlin.String) : SequenceFilterFieldType("string")
+    data class DateFrom(val associatedField: SequenceFilterFieldName) : SequenceFilterFieldType("string")
+    data class DateTo(val associatedField: SequenceFilterFieldName) : SequenceFilterFieldType("string")
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -18,7 +18,6 @@ data class SequenceFilterFields(val fields: Map<FieldName, SequenceFilterFieldTy
             } else {
                 databaseConfig.schema.features
                     .map(::mapToSequenceFilterFieldsFromFeatures)
-                    .flatten()
                     .toMap()
             }
 
@@ -42,7 +41,7 @@ private fun mapToSequenceFilterFields(databaseMetadata: DatabaseMetadata) = when
 }
 
 private fun mapToSequenceFilterFieldsFromFeatures(databaseFeature: DatabaseFeature) = when (databaseFeature.name) {
-    "sarsCoV2VariantQuery" -> listOf("variantQuery" to SequenceFilterFieldType.VariantQuery)
+    "sarsCoV2VariantQuery" -> "variantQuery" to SequenceFilterFieldType.VariantQuery
     else -> throw IllegalArgumentException(
         "Unknown feature '${databaseFeature.name}'",
     )

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -2,6 +2,7 @@ package org.genspectrum.lapis.controller
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import mu.KotlinLogging
+import org.genspectrum.lapis.model.SiloNotImplementedError
 import org.genspectrum.lapis.silo.SiloException
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -14,7 +15,6 @@ private val log = KotlinLogging.logger {}
 
 @ControllerAdvice
 class ExceptionHandler : ResponseEntityExceptionHandler() {
-
     @ExceptionHandler(Throwable::class)
     fun handleUnexpectedException(e: Throwable): ResponseEntity<String> {
         log.error(e) { "Caught unexpected exception: ${e.message}" }
@@ -66,8 +66,9 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
             )
     }
 
-    @ExceptionHandler(NotImplementedError::class)
-    fun handleNotImplementedError(e: NotImplementedError): ResponseEntity<String> {
+    @ExceptionHandler(SiloNotImplementedError::class)
+    fun handleNotImplementedError(e: SiloNotImplementedError): ResponseEntity<String> {
+        log.error(e) { "Caught SiloNotImplementedError: ${e.message}" }
         return ResponseEntity
             .status(HttpStatus.NOT_IMPLEMENTED)
             .contentType(MediaType.APPLICATION_JSON)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -65,6 +65,21 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
                 ),
             )
     }
+
+    @ExceptionHandler(NotImplementedError::class)
+    fun handleNotImplementedError(e: NotImplementedError): ResponseEntity<String> {
+        return ResponseEntity
+            .status(HttpStatus.NOT_IMPLEMENTED)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(
+                jacksonObjectMapper().writeValueAsString(
+                    LapisHttpErrorResponse(
+                        "Not implemented",
+                        "${e.message}",
+                    ),
+                ),
+            )
+    }
 }
 
 data class LapisHttpErrorResponse(val title: String, val message: String)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -22,7 +22,7 @@ class SiloFilterExpressionMapper(
     private val allowedSequenceFilterFields: SequenceFilterFields,
     private val variantQueryFacade: VariantQueryFacade,
 ) {
-    fun map(sequenceFilters: Map<String, String>): SiloFilterExpression {
+    fun map(sequenceFilters: Map<SequenceFilterFieldName, String>): SiloFilterExpression {
         if (sequenceFilters.isEmpty()) {
             return True
         }
@@ -81,7 +81,7 @@ class SiloFilterExpressionMapper(
     private fun mapToVariantQueryFilter(variantQuery: String): SiloFilterExpression {
         if (variantQuery.isBlank()) {
             throw IllegalArgumentException(
-                "variantQuery cannot be empty",
+                "variantQuery must not be empty",
             )
         }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -18,7 +18,10 @@ data class SequenceFilterValue(val type: SequenceFilterFieldType, val value: Str
 typealias SequenceFilterFieldName = String
 
 @Component
-class SiloFilterExpressionMapper(private val allowedSequenceFilterFields: SequenceFilterFields) {
+class SiloFilterExpressionMapper(
+    private val allowedSequenceFilterFields: SequenceFilterFields,
+    private val variantQueryFacade: VariantQueryFacade,
+) {
     fun map(sequenceFilters: Map<String, String>): SiloFilterExpression {
         if (sequenceFilters.isEmpty()) {
             return True
@@ -82,7 +85,7 @@ class SiloFilterExpressionMapper(private val allowedSequenceFilterFields: Sequen
             )
         }
 
-        return VariantQueryFacade().map(variantQuery)
+        return variantQueryFacade.map(variantQuery)
     }
 
     private fun mapToDateBetweenFilter(

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -39,7 +39,8 @@ class SiloFilterExpressionMapper(
             allowedSequenceFiltersWithType.keys.any { it.second in variantQueryTypes }
         ) {
             throw IllegalArgumentException(
-                "variantQuery cannot be used with other variant filters",
+                "variantQuery filter cannot be used with other variant filters such as: " +
+                    "${variantQueryTypes.joinToString(", ")}",
             )
         }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -15,6 +15,8 @@ import java.time.format.DateTimeParseException
 
 data class SequenceFilterValue(val type: SequenceFilterFieldType, val value: String, val originalKey: String)
 
+typealias SequenceFilterFieldName = String
+
 @Component
 class SiloFilterExpressionMapper(private val allowedSequenceFilterFields: SequenceFilterFields) {
     fun map(sequenceFilters: Map<String, String>): SiloFilterExpression {
@@ -22,37 +24,48 @@ class SiloFilterExpressionMapper(private val allowedSequenceFilterFields: Sequen
             return True
         }
 
-        val filterExpressions = sequenceFilters
+        val allowedSequenceFiltersWithType = sequenceFilters
             .map { (key, value) ->
                 val nullableType = allowedSequenceFilterFields.fields[key]
                 val (filterExpressionId, type) = mapToFilterExpressionIdentifier(nullableType, key)
                 filterExpressionId to SequenceFilterValue(type, value, key)
             }
             .groupBy({ it.first }, { it.second })
-            .map { (key, values) ->
-                val (siloColumnName, siloFilterPrimitive) = key
-                when (siloFilterPrimitive) {
-                    SiloFilterPrimitive.StringEquals -> StringEquals(siloColumnName, values[0].value)
-                    SiloFilterPrimitive.PangoLineage -> mapToPangoLineageFilter(siloColumnName, values[0].value)
-                    SiloFilterPrimitive.DateBetween -> mapToDateBetweenFilter(siloColumnName, values)
-                    SiloFilterPrimitive.NucleotideSymbolEquals -> mapToNucleotideFilter(values[0].value)
-                }
+
+        if (allowedSequenceFiltersWithType.keys.any { it.second == Filter.VariantQuery } &&
+            allowedSequenceFiltersWithType.keys.any { it.second in variantQueryTypes }
+        ) {
+            throw IllegalArgumentException(
+                "variantQuery cannot be used with other variant filters",
+            )
+        }
+
+        val filterExpressions = allowedSequenceFiltersWithType.map { (key, values) ->
+            val (siloColumnName, filter) = key
+            when (filter) {
+                Filter.StringEquals -> StringEquals(siloColumnName, values[0].value)
+                Filter.PangoLineage -> mapToPangoLineageFilter(siloColumnName, values[0].value)
+                Filter.DateBetween -> mapToDateBetweenFilter(siloColumnName, values)
+                Filter.NucleotideSymbolEquals -> mapToNucleotideFilter(values[0].value)
+                Filter.VariantQuery -> mapToVariantQueryFilter(values[0].value)
             }
+        }
 
         return And(filterExpressions)
     }
 
     private fun mapToFilterExpressionIdentifier(
         type: SequenceFilterFieldType?,
-        key: String,
-    ): Pair<Pair<String, SiloFilterPrimitive>, SequenceFilterFieldType> {
+        key: SequenceFilterFieldName,
+    ): Pair<Pair<SequenceFilterFieldName, Filter>, SequenceFilterFieldType> {
         val filterExpressionId = when (type) {
-            is SequenceFilterFieldType.DateFrom -> Pair(type.associatedField, SiloFilterPrimitive.DateBetween)
-            is SequenceFilterFieldType.DateTo -> Pair(type.associatedField, SiloFilterPrimitive.DateBetween)
-            SequenceFilterFieldType.Date -> Pair(key, SiloFilterPrimitive.DateBetween)
-            SequenceFilterFieldType.PangoLineage -> Pair(key, SiloFilterPrimitive.PangoLineage)
-            SequenceFilterFieldType.String -> Pair(key, SiloFilterPrimitive.StringEquals)
-            SequenceFilterFieldType.MutationsList -> Pair(key, SiloFilterPrimitive.NucleotideSymbolEquals)
+            is SequenceFilterFieldType.DateFrom -> Pair(type.associatedField, Filter.DateBetween)
+            is SequenceFilterFieldType.DateTo -> Pair(type.associatedField, Filter.DateBetween)
+            SequenceFilterFieldType.Date -> Pair(key, Filter.DateBetween)
+            SequenceFilterFieldType.PangoLineage -> Pair(key, Filter.PangoLineage)
+            SequenceFilterFieldType.String -> Pair(key, Filter.StringEquals)
+            SequenceFilterFieldType.MutationsList -> Pair(key, Filter.NucleotideSymbolEquals)
+            SequenceFilterFieldType.VariantQuery -> Pair(key, Filter.VariantQuery)
 
             null -> throw IllegalArgumentException(
                 "'$key' is not a valid sequence filter key. Valid keys are: " +
@@ -60,6 +73,16 @@ class SiloFilterExpressionMapper(private val allowedSequenceFilterFields: Sequen
             )
         }
         return Pair(filterExpressionId, type)
+    }
+
+    private fun mapToVariantQueryFilter(variantQuery: String): SiloFilterExpression {
+        if (variantQuery.isBlank()) {
+            throw IllegalArgumentException(
+                "variantQuery cannot be empty",
+            )
+        }
+
+        return VariantQueryFacade().map(variantQuery)
     }
 
     private fun mapToDateBetweenFilter(
@@ -155,10 +178,13 @@ class SiloFilterExpressionMapper(private val allowedSequenceFilterFields: Sequen
         }
     }
 
-    private enum class SiloFilterPrimitive {
+    private enum class Filter {
         StringEquals,
         PangoLineage,
         DateBetween,
         NucleotideSymbolEquals,
+        VariantQuery,
     }
+
+    private val variantQueryTypes = listOf(Filter.PangoLineage, Filter.NucleotideSymbolEquals)
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -11,17 +11,18 @@ class SiloQueryModel(
     private val siloFilterExpressionMapper: SiloFilterExpressionMapper,
 ) {
 
-    fun aggregate(sequenceFilters: Map<String, String>) = siloClient.sendQuery(
+    fun aggregate(sequenceFilters: Map<SequenceFilterFieldName, String>) = siloClient.sendQuery(
         SiloQuery(
             SiloAction.aggregated(),
             siloFilterExpressionMapper.map(sequenceFilters),
         ),
     )
 
-    fun computeMutationProportions(minProportion: Double?, sequenceFilters: Map<String, String>) = siloClient.sendQuery(
-        SiloQuery(
-            SiloAction.mutations(minProportion),
-            siloFilterExpressionMapper.map(sequenceFilters),
-        ),
-    )
+    fun computeMutationProportions(minProportion: Double?, sequenceFilters: Map<SequenceFilterFieldName, String>) =
+        siloClient.sendQuery(
+            SiloQuery(
+                SiloAction.mutations(minProportion),
+                siloFilterExpressionMapper.map(sequenceFilters),
+            ),
+        )
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -1,8 +1,8 @@
 package org.genspectrum.lapis.model
 
 import VariantQueryBaseListener
-import VariantQueryParser.Aa_insertionContext
-import VariantQueryParser.Aa_mutationContext
+import VariantQueryParser.Aa_insertion_queryContext
+import VariantQueryParser.Aa_mutation_queryContext
 import VariantQueryParser.AndContext
 import VariantQueryParser.Gisaid_clade_lineage_queryContext
 import VariantQueryParser.MaybeContext
@@ -10,8 +10,8 @@ import VariantQueryParser.N_of_queryContext
 import VariantQueryParser.Nextclade_pangolineage_queryContext
 import VariantQueryParser.Nextstrain_clade_queryContext
 import VariantQueryParser.NotContext
-import VariantQueryParser.Nucleotide_insertionContext
-import VariantQueryParser.Nucleotide_mutationContext
+import VariantQueryParser.Nucleotide_insertion_queryContext
+import VariantQueryParser.Nucleotide_mutation_queryContext
 import VariantQueryParser.OrContext
 import VariantQueryParser.Pangolineage_queryContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
@@ -31,12 +31,12 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         return expressionStack.first()
     }
 
-    override fun enterNucleotide_mutation(ctx: Nucleotide_mutationContext?) {
+    override fun enterNucleotide_mutation_query(ctx: Nucleotide_mutation_queryContext?) {
         if (ctx == null) {
             return
         }
         val position = ctx.position().text.toInt()
-        val secondSymbol = ctx.ambigous_nucleotide_symbol()?.text ?: "-"
+        val secondSymbol = ctx.nucleotide_mutation_query_second_symbol()?.text ?: "-"
 
         val expr = NucleotideSymbolEquals(position, secondSymbol)
         expressionStack.addLast(expr)
@@ -89,15 +89,15 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         expressionStack.addLast(NOf(n, matchExactly, children.reversed()))
     }
 
-    override fun enterNucleotide_insertion(ctx: Nucleotide_insertionContext?) {
+    override fun enterNucleotide_insertion_query(ctx: Nucleotide_insertion_queryContext?) {
         throw NotImplementedError("Nucleotide insertions are not supported yet.")
     }
 
-    override fun enterAa_mutation(ctx: Aa_mutationContext?) {
+    override fun enterAa_mutation_query(ctx: Aa_mutation_queryContext?) {
         throw NotImplementedError("Amino acid mutations are not supported yet.")
     }
 
-    override fun enterAa_insertion(ctx: Aa_insertionContext?) {
+    override fun enterAa_insertion_query(ctx: Aa_insertion_queryContext?) {
         throw NotImplementedError("Amino acid insertions are not supported yet.")
     }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -2,9 +2,11 @@ package org.genspectrum.lapis.model
 
 import VariantQueryBaseListener
 import VariantQueryParser.AndContext
+import VariantQueryParser.NotContext
 import VariantQueryParser.Nucleotide_mutationContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
 
@@ -29,5 +31,10 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
     override fun exitAnd(ctx: AndContext?) {
         val children = listOf(expressionStack.removeLast(), expressionStack.removeLast()).reversed()
         expressionStack.addLast(And(children))
+    }
+
+    override fun exitNot(ctx: NotContext?) {
+        val child = expressionStack.removeLast()
+        expressionStack.addLast(Not(child))
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -1,10 +1,16 @@
 package org.genspectrum.lapis.model
 
 import VariantQueryBaseListener
+import VariantQueryParser.Aa_insertionContext
+import VariantQueryParser.Aa_mutationContext
 import VariantQueryParser.AndContext
+import VariantQueryParser.Gisaid_clade_lineage_queryContext
 import VariantQueryParser.MaybeContext
 import VariantQueryParser.N_of_queryContext
+import VariantQueryParser.Nextclade_pangolineage_queryContext
+import VariantQueryParser.Nextstrain_clade_queryContext
 import VariantQueryParser.NotContext
+import VariantQueryParser.Nucleotide_insertionContext
 import VariantQueryParser.Nucleotide_mutationContext
 import VariantQueryParser.OrContext
 import VariantQueryParser.Pangolineage_queryContext
@@ -81,5 +87,29 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         }
 
         expressionStack.addLast(NOf(n, matchExactly, children.reversed()))
+    }
+
+    override fun enterNucleotide_insertion(ctx: Nucleotide_insertionContext?) {
+        throw NotImplementedError("Nucleotide insertions are not supported yet.")
+    }
+
+    override fun enterAa_mutation(ctx: Aa_mutationContext?) {
+        throw NotImplementedError("Amino acid mutations are not supported yet.")
+    }
+
+    override fun enterAa_insertion(ctx: Aa_insertionContext?) {
+        throw NotImplementedError("Amino acid insertions are not supported yet.")
+    }
+
+    override fun enterNextclade_pangolineage_query(ctx: Nextclade_pangolineage_queryContext?) {
+        throw NotImplementedError("Nextclade pango lineages are not supported yet.")
+    }
+
+    override fun enterNextstrain_clade_query(ctx: Nextstrain_clade_queryContext?) {
+        throw NotImplementedError("Nextstrain clade lineages are not supported yet.")
+    }
+
+    override fun enterGisaid_clade_lineage_query(ctx: Gisaid_clade_lineage_queryContext?) {
+        throw NotImplementedError("Gisaid clade lineages are not supported yet.")
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -27,7 +27,7 @@ import org.genspectrum.lapis.silo.SiloFilterExpression
 class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener {
     private val expressionStack = ArrayDeque<SiloFilterExpression>()
 
-    fun getExpr(): SiloFilterExpression {
+    fun getVariantQueryExpression(): SiloFilterExpression {
         return expressionStack.first()
     }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -49,7 +49,7 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         val pangolineage = ctx.pangolineage().text
         val includeSublineages = ctx.pangolineage_include_sublineages() != null
 
-        val expr = PangoLineageEquals(pangolineage, includeSublineages)
+        val expr = PangoLineageEquals("pangoLineage", pangolineage, includeSublineages)
         expressionStack.addLast(expr)
     }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -2,11 +2,13 @@ package org.genspectrum.lapis.model
 
 import VariantQueryBaseListener
 import VariantQueryParser.AndContext
+import VariantQueryParser.MaybeContext
 import VariantQueryParser.NotContext
 import VariantQueryParser.Nucleotide_mutationContext
 import VariantQueryParser.OrContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.Maybe
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
@@ -43,5 +45,10 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
     override fun exitOr(ctx: OrContext?) {
         val children = listOf(expressionStack.removeLast(), expressionStack.removeLast()).reversed()
         expressionStack.addLast(Or(children))
+    }
+
+    override fun exitMaybe(ctx: MaybeContext?) {
+        val child = expressionStack.removeLast()
+        expressionStack.addLast(Maybe(child))
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -4,10 +4,12 @@ import VariantQueryBaseListener
 import VariantQueryParser.AndContext
 import VariantQueryParser.NotContext
 import VariantQueryParser.Nucleotide_mutationContext
+import VariantQueryParser.OrContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.silo.And
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
+import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.SiloFilterExpression
 
 class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener {
@@ -36,5 +38,10 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
     override fun exitNot(ctx: NotContext?) {
         val child = expressionStack.removeLast()
         expressionStack.addLast(Not(child))
+    }
+
+    override fun exitOr(ctx: OrContext?) {
+        val children = listOf(expressionStack.removeLast(), expressionStack.removeLast()).reversed()
+        expressionStack.addLast(Or(children))
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -90,26 +90,28 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
     }
 
     override fun enterNucleotideInsertionQuery(ctx: NucleotideInsertionQueryContext?) {
-        throw NotImplementedError("Nucleotide insertions are not supported yet.")
+        throw SiloNotImplementedError("Nucleotide insertions are not supported yet.", NotImplementedError())
     }
 
     override fun enterAaMutationQuery(ctx: AaMutationQueryContext?) {
-        throw NotImplementedError("Amino acid mutations are not supported yet.")
+        throw SiloNotImplementedError("Amino acid mutations are not supported yet.", NotImplementedError())
     }
 
     override fun enterAaInsertionQuery(ctx: AaInsertionQueryContext?) {
-        throw NotImplementedError("Amino acid insertions are not supported yet.")
+        throw SiloNotImplementedError("Amino acid insertions are not supported yet.", NotImplementedError())
     }
 
     override fun enterNextcladePangolineageQuery(ctx: NextcladePangolineageQueryContext?) {
-        throw NotImplementedError("Nextclade pango lineages are not supported yet.")
+        throw SiloNotImplementedError("Nextclade pango lineages are not supported yet.", NotImplementedError())
     }
 
     override fun enterNextstrainCladeQuery(ctx: NextstrainCladeQueryContext?) {
-        throw NotImplementedError("Nextstrain clade lineages are not supported yet.")
+        throw SiloNotImplementedError("Nextstrain clade lineages are not supported yet.", NotImplementedError())
     }
 
     override fun enterGisaidCladeLineageQuery(ctx: GisaidCladeLineageQueryContext?) {
-        throw NotImplementedError("Gisaid clade lineages are not supported yet.")
+        throw SiloNotImplementedError("Gisaid clade lineages are not supported yet.", NotImplementedError())
     }
 }
+
+class SiloNotImplementedError(message: String?, cause: Throwable?) : Exception(message, cause)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -1,0 +1,33 @@
+package org.genspectrum.lapis.model
+
+import VariantQueryBaseListener
+import VariantQueryParser.AndContext
+import VariantQueryParser.Nucleotide_mutationContext
+import org.antlr.v4.runtime.tree.ParseTreeListener
+import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.NucleotideSymbolEquals
+import org.genspectrum.lapis.silo.SiloFilterExpression
+
+class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener {
+    private var expressionStack = ArrayDeque<SiloFilterExpression>()
+
+    fun getExpr(): SiloFilterExpression {
+        return expressionStack.first()
+    }
+
+    override fun enterNucleotide_mutation(ctx: Nucleotide_mutationContext?) {
+        if (ctx == null) {
+            return
+        }
+        val position = ctx.position().text.toInt()
+        val secondSymbol = if (ctx.ambigous_nucleotide_symbol() != null) ctx.ambigous_nucleotide_symbol().text else "-"
+
+        val expr = NucleotideSymbolEquals(position, secondSymbol)
+        expressionStack.addLast(expr)
+    }
+
+    override fun exitAnd(ctx: AndContext?) {
+        val children = listOf(expressionStack.removeLast(), expressionStack.removeLast()).reversed()
+        expressionStack.addLast(And(children))
+    }
+}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -3,6 +3,7 @@ package org.genspectrum.lapis.model
 import VariantQueryBaseListener
 import VariantQueryParser.AndContext
 import VariantQueryParser.MaybeContext
+import VariantQueryParser.N_of_queryContext
 import VariantQueryParser.NotContext
 import VariantQueryParser.Nucleotide_mutationContext
 import VariantQueryParser.OrContext
@@ -10,6 +11,7 @@ import VariantQueryParser.Pangolineage_queryContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.silo.And
 import org.genspectrum.lapis.silo.Maybe
+import org.genspectrum.lapis.silo.NOf
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
@@ -63,5 +65,21 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
     override fun exitMaybe(ctx: MaybeContext?) {
         val child = expressionStack.removeLast()
         expressionStack.addLast(Maybe(child))
+    }
+
+    override fun exitN_of_query(ctx: N_of_queryContext?) {
+        if (ctx == null) {
+            return
+        }
+
+        val n = ctx.n_of_number_of_matchers().text.toInt()
+        val matchExactly = ctx.n_of_match_exactly() != null
+
+        val children = mutableListOf<SiloFilterExpression>()
+        for (i in 1..n) {
+            children += expressionStack.removeLast()
+        }
+
+        expressionStack.addLast(NOf(n, matchExactly, children.reversed()))
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -1,19 +1,19 @@
 package org.genspectrum.lapis.model
 
 import VariantQueryBaseListener
-import VariantQueryParser.Aa_insertion_queryContext
-import VariantQueryParser.Aa_mutation_queryContext
+import VariantQueryParser.AaInsertionQueryContext
+import VariantQueryParser.AaMutationQueryContext
 import VariantQueryParser.AndContext
-import VariantQueryParser.Gisaid_clade_lineage_queryContext
+import VariantQueryParser.GisaidCladeLineageQueryContext
 import VariantQueryParser.MaybeContext
-import VariantQueryParser.N_of_queryContext
-import VariantQueryParser.Nextclade_pangolineage_queryContext
-import VariantQueryParser.Nextstrain_clade_queryContext
+import VariantQueryParser.NOfQueryContext
+import VariantQueryParser.NextcladePangolineageQueryContext
+import VariantQueryParser.NextstrainCladeQueryContext
 import VariantQueryParser.NotContext
-import VariantQueryParser.Nucleotide_insertion_queryContext
-import VariantQueryParser.Nucleotide_mutation_queryContext
+import VariantQueryParser.NucleotideInsertionQueryContext
+import VariantQueryParser.NucleotideMutationQueryContext
 import VariantQueryParser.OrContext
-import VariantQueryParser.Pangolineage_queryContext
+import VariantQueryParser.PangolineageQueryContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.silo.And
 import org.genspectrum.lapis.silo.Maybe
@@ -31,23 +31,23 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         return expressionStack.first()
     }
 
-    override fun enterNucleotide_mutation_query(ctx: Nucleotide_mutation_queryContext?) {
+    override fun enterNucleotideMutationQuery(ctx: NucleotideMutationQueryContext?) {
         if (ctx == null) {
             return
         }
         val position = ctx.position().text.toInt()
-        val secondSymbol = ctx.nucleotide_mutation_query_second_symbol()?.text ?: "-"
+        val secondSymbol = ctx.nucleotideMutationQuerySecondSymbol()?.text ?: "-"
 
         val expr = NucleotideSymbolEquals(position, secondSymbol)
         expressionStack.addLast(expr)
     }
 
-    override fun enterPangolineage_query(ctx: Pangolineage_queryContext?) {
+    override fun enterPangolineageQuery(ctx: PangolineageQueryContext?) {
         if (ctx == null) {
             return
         }
         val pangolineage = ctx.pangolineage().text
-        val includeSublineages = ctx.pangolineage_include_sublineages() != null
+        val includeSublineages = ctx.pangolineageIncludeSublineages() != null
 
         val expr = PangoLineageEquals("pangoLineage", pangolineage, includeSublineages)
         expressionStack.addLast(expr)
@@ -73,13 +73,13 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         expressionStack.addLast(Maybe(child))
     }
 
-    override fun exitN_of_query(ctx: N_of_queryContext?) {
+    override fun exitNOfQuery(ctx: NOfQueryContext?) {
         if (ctx == null) {
             return
         }
 
-        val n = ctx.n_of_number_of_matchers().text.toInt()
-        val matchExactly = ctx.n_of_match_exactly() != null
+        val n = ctx.nOfNumberOfMatchers().text.toInt()
+        val matchExactly = ctx.nOfMatchExactly() != null
 
         val children = mutableListOf<SiloFilterExpression>()
         for (i in 1..n) {
@@ -89,27 +89,27 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
         expressionStack.addLast(NOf(n, matchExactly, children.reversed()))
     }
 
-    override fun enterNucleotide_insertion_query(ctx: Nucleotide_insertion_queryContext?) {
+    override fun enterNucleotideInsertionQuery(ctx: NucleotideInsertionQueryContext?) {
         throw NotImplementedError("Nucleotide insertions are not supported yet.")
     }
 
-    override fun enterAa_mutation_query(ctx: Aa_mutation_queryContext?) {
+    override fun enterAaMutationQuery(ctx: AaMutationQueryContext?) {
         throw NotImplementedError("Amino acid mutations are not supported yet.")
     }
 
-    override fun enterAa_insertion_query(ctx: Aa_insertion_queryContext?) {
+    override fun enterAaInsertionQuery(ctx: AaInsertionQueryContext?) {
         throw NotImplementedError("Amino acid insertions are not supported yet.")
     }
 
-    override fun enterNextclade_pangolineage_query(ctx: Nextclade_pangolineage_queryContext?) {
+    override fun enterNextcladePangolineageQuery(ctx: NextcladePangolineageQueryContext?) {
         throw NotImplementedError("Nextclade pango lineages are not supported yet.")
     }
 
-    override fun enterNextstrain_clade_query(ctx: Nextstrain_clade_queryContext?) {
+    override fun enterNextstrainCladeQuery(ctx: NextstrainCladeQueryContext?) {
         throw NotImplementedError("Nextstrain clade lineages are not supported yet.")
     }
 
-    override fun enterGisaid_clade_lineage_query(ctx: Gisaid_clade_lineage_queryContext?) {
+    override fun enterGisaidCladeLineageQuery(ctx: GisaidCladeLineageQueryContext?) {
         throw NotImplementedError("Gisaid clade lineages are not supported yet.")
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -6,12 +6,14 @@ import VariantQueryParser.MaybeContext
 import VariantQueryParser.NotContext
 import VariantQueryParser.Nucleotide_mutationContext
 import VariantQueryParser.OrContext
+import VariantQueryParser.Pangolineage_queryContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.silo.And
 import org.genspectrum.lapis.silo.Maybe
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
+import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
 
 class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener {
@@ -26,9 +28,20 @@ class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener
             return
         }
         val position = ctx.position().text.toInt()
-        val secondSymbol = if (ctx.ambigous_nucleotide_symbol() != null) ctx.ambigous_nucleotide_symbol().text else "-"
+        val secondSymbol = ctx.ambigous_nucleotide_symbol()?.text ?: "-"
 
         val expr = NucleotideSymbolEquals(position, secondSymbol)
+        expressionStack.addLast(expr)
+    }
+
+    override fun enterPangolineage_query(ctx: Pangolineage_queryContext?) {
+        if (ctx == null) {
+            return
+        }
+        val pangolineage = ctx.pangolineage().text
+        val includeSublineages = ctx.pangolineage_include_sublineages() != null
+
+        val expr = PangoLineageEquals(pangolineage, includeSublineages)
         expressionStack.addLast(expr)
     }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -25,7 +25,7 @@ import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
 
 class VariantQueryCustomListener : VariantQueryBaseListener(), ParseTreeListener {
-    private var expressionStack = ArrayDeque<SiloFilterExpression>()
+    private val expressionStack = ArrayDeque<SiloFilterExpression>()
 
     fun getExpr(): SiloFilterExpression {
         return expressionStack.first()

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
@@ -20,6 +20,6 @@ class VariantQueryFacade {
         val walker = ParseTreeWalker()
         walker.walk(listener, parser.start())
 
-        return listener.getExpr()
+        return listener.getVariantQueryExpression()
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
@@ -6,7 +6,9 @@ import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.tree.ParseTreeWalker
 import org.genspectrum.lapis.silo.SiloFilterExpression
+import org.springframework.stereotype.Component
 
+@Component
 class VariantQueryFacade {
 
     fun map(variantQuery: String): SiloFilterExpression {

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
@@ -1,0 +1,23 @@
+package org.genspectrum.lapis.model
+
+import VariantQueryLexer
+import VariantQueryParser
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.tree.ParseTreeWalker
+import org.genspectrum.lapis.silo.SiloFilterExpression
+
+class VariantQueryFacade {
+
+    fun map(variantQuery: String): SiloFilterExpression {
+        val lexer = VariantQueryLexer(CharStreams.fromString(variantQuery))
+        val tokens = CommonTokenStream(lexer)
+        val parser = VariantQueryParser(tokens)
+        val listener = VariantQueryCustomListener()
+
+        val walker = ParseTreeWalker()
+        walker.walk(listener, parser.start())
+
+        return listener.getExpr()
+    }
+}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -44,3 +44,5 @@ data class And(val children: List<SiloFilterExpression>) : SiloFilterExpression(
 data class Or(val children: List<SiloFilterExpression>) : SiloFilterExpression("Or")
 
 data class Not(val child: SiloFilterExpression) : SiloFilterExpression("Not")
+
+data class Maybe(val child: SiloFilterExpression) : SiloFilterExpression("Maybe")

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -40,3 +40,5 @@ data class DateBetween(val column: String, val from: LocalDate?, val to: LocalDa
 object True : SiloFilterExpression("True")
 
 data class And(val children: List<SiloFilterExpression>) : SiloFilterExpression("And")
+
+data class Not(val child: SiloFilterExpression) : SiloFilterExpression("Not")

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -41,4 +41,6 @@ object True : SiloFilterExpression("True")
 
 data class And(val children: List<SiloFilterExpression>) : SiloFilterExpression("And")
 
+data class Or(val children: List<SiloFilterExpression>) : SiloFilterExpression("Or")
+
 data class Not(val child: SiloFilterExpression) : SiloFilterExpression("Not")

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -46,3 +46,6 @@ data class Or(val children: List<SiloFilterExpression>) : SiloFilterExpression("
 data class Not(val child: SiloFilterExpression) : SiloFilterExpression("Not")
 
 data class Maybe(val child: SiloFilterExpression) : SiloFilterExpression("Maybe")
+
+data class NOf(val numberOfMatchers: Int, val matchExactly: Boolean, val children: List<SiloFilterExpression>) :
+    SiloFilterExpression("NOf")

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -48,4 +48,4 @@ data class Not(val child: SiloFilterExpression) : SiloFilterExpression("Not")
 data class Maybe(val child: SiloFilterExpression) : SiloFilterExpression("Maybe")
 
 data class NOf(val numberOfMatchers: Int, val matchExactly: Boolean, val children: List<SiloFilterExpression>) :
-    SiloFilterExpression("NOf")
+    SiloFilterExpression("N-Of")

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigTest.kt
@@ -27,5 +27,11 @@ class DatabaseConfigTest {
                 DatabaseMetadata(name = "pangoLineage", type = "pango_lineage"),
             ),
         )
+        assertThat(
+            underTest.schema.features,
+            containsInAnyOrder(
+                DatabaseFeature(name = "sarsCoV2VariantQuery"),
+            ),
+        )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigTest.kt
@@ -35,3 +35,31 @@ class DatabaseConfigTest {
         )
     }
 }
+
+@SpringBootTest(
+    properties =
+    [
+        "lapis.databaseConfig.path=src/test/resources/config/testDatabaseConfigWithoutFeatures.yaml",
+    ],
+)
+class DatabaseConfigWithoutFeaturesTest {
+    @Autowired
+    private lateinit var underTest: DatabaseConfig
+
+    @Test
+    fun `a config without features can be read`() {
+        assertThat(underTest.schema.instanceName, `is`("sars_cov-2_minimal_test_config"))
+        assertThat(underTest.schema.primaryKey, `is`("gisaid_epi_isl"))
+        assertThat(
+            underTest.schema.metadata,
+            containsInAnyOrder(
+                DatabaseMetadata(name = "gisaid_epi_isl", type = "string"),
+                DatabaseMetadata(name = "date", type = "date"),
+                DatabaseMetadata(name = "region", type = "string"),
+                DatabaseMetadata(name = "country", type = "string"),
+                DatabaseMetadata(name = "pangoLineage", type = "pango_lineage"),
+            ),
+        )
+        assertThat(underTest.schema.features, `is`(emptyList()))
+    }
+}

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.assertThrows
 class SequenceFilterFieldsTest {
     @Test
     fun `given database config without fields then is empty`() {
-        val input = databaseConfigWithFields()
+        val input = databaseConfigWithFields(emptyList(), emptyList())
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -20,7 +20,10 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with a string field then contains a string field`() {
-        val input = databaseConfigWithFields(DatabaseMetadata("fieldName", "string"))
+        val input = databaseConfigWithFields(
+            listOf(DatabaseMetadata("fieldName", "string")),
+            emptyList(),
+        )
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -30,7 +33,10 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with a pango_lineage field then contains a pango_lineage field`() {
-        val input = databaseConfigWithFields(DatabaseMetadata("pango lineage", "pango_lineage"))
+        val input = databaseConfigWithFields(
+            listOf(DatabaseMetadata("pango lineage", "pango_lineage")),
+            emptyList(),
+        )
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -40,7 +46,7 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with a date field then contains date, dateFrom and dateTo fields`() {
-        val input = databaseConfigWithFields(DatabaseMetadata("dateField", "date"))
+        val input = databaseConfigWithFields(listOf(DatabaseMetadata("dateField", "date")), emptyList())
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -52,17 +58,35 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with an unknown field type then throws exception`() {
-        val input = databaseConfigWithFields(DatabaseMetadata("fieldName", "unknown type"))
+        val input = databaseConfigWithFields(
+            listOf(DatabaseMetadata("fieldName", "unknown type")),
+            emptyList(),
+        )
 
         val exception = assertThrows<IllegalArgumentException> { SequenceFilterFields.fromDatabaseConfig(input) }
         assertThat(exception.message, `is`("Unknown field type 'unknown type' for field 'fieldName'"))
     }
 
-    private fun databaseConfigWithFields(vararg databaseMetadata: DatabaseMetadata) = DatabaseConfig(
+    @Test
+    fun `given database config with a feature of 'sarsCoV2VariantQuery' then contains variationQuery`() {
+        val input = databaseConfigWithFields(emptyList(), listOf(DatabaseFeature("sarsCoV2VariantQuery")))
+
+        val underTest = SequenceFilterFields.fromDatabaseConfig(input)
+
+        assertThat(underTest.fields, aMapWithSize(2))
+        assertThat(underTest.fields, hasEntry("nucleotideMutations", SequenceFilterFieldType.MutationsList))
+        assertThat(underTest.fields, hasEntry("variantQuery", SequenceFilterFieldType.VariantQuery))
+    }
+
+    private fun databaseConfigWithFields(
+        databaseMetadata: List<DatabaseMetadata>,
+        databaseFeatures: List<DatabaseFeature>,
+    ) = DatabaseConfig(
         DatabaseSchema(
             "test config",
-            databaseMetadata.asList(),
+            databaseMetadata,
             "test primary key",
+            databaseFeatures,
         ),
     )
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.assertThrows
 class SequenceFilterFieldsTest {
     @Test
     fun `given database config without fields then is empty`() {
-        val input = databaseConfigWithFields(emptyList(), emptyList())
+        val input = databaseConfigWithFields(emptyList())
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -20,10 +20,7 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with a string field then contains a string field`() {
-        val input = databaseConfigWithFields(
-            listOf(DatabaseMetadata("fieldName", "string")),
-            emptyList(),
-        )
+        val input = databaseConfigWithFields(listOf(DatabaseMetadata("fieldName", "string")))
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -33,10 +30,7 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with a pango_lineage field then contains a pango_lineage field`() {
-        val input = databaseConfigWithFields(
-            listOf(DatabaseMetadata("pango lineage", "pango_lineage")),
-            emptyList(),
-        )
+        val input = databaseConfigWithFields(listOf(DatabaseMetadata("pango lineage", "pango_lineage")))
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -46,7 +40,7 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with a date field then contains date, dateFrom and dateTo fields`() {
-        val input = databaseConfigWithFields(listOf(DatabaseMetadata("dateField", "date")), emptyList())
+        val input = databaseConfigWithFields(listOf(DatabaseMetadata("dateField", "date")))
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -58,17 +52,14 @@ class SequenceFilterFieldsTest {
 
     @Test
     fun `given database config with an unknown field type then throws exception`() {
-        val input = databaseConfigWithFields(
-            listOf(DatabaseMetadata("fieldName", "unknown type")),
-            emptyList(),
-        )
+        val input = databaseConfigWithFields(listOf(DatabaseMetadata("fieldName", "unknown type")))
 
         val exception = assertThrows<IllegalArgumentException> { SequenceFilterFields.fromDatabaseConfig(input) }
         assertThat(exception.message, `is`("Unknown field type 'unknown type' for field 'fieldName'"))
     }
 
     @Test
-    fun `given database config with a feature of 'sarsCoV2VariantQuery' then contains variationQuery`() {
+    fun `given database config with a feature of 'sarsCoV2VariantQuery' then contains variantQuery`() {
         val input = databaseConfigWithFields(emptyList(), listOf(DatabaseFeature("sarsCoV2VariantQuery")))
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
@@ -80,7 +71,7 @@ class SequenceFilterFieldsTest {
 
     private fun databaseConfigWithFields(
         databaseMetadata: List<DatabaseMetadata>,
-        databaseFeatures: List<DatabaseFeature>,
+        databaseFeatures: List<DatabaseFeature> = emptyList(),
     ) = DatabaseConfig(
         DatabaseSchema(
             "test config",

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
@@ -4,6 +4,7 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.MockKAnnotations
 import io.mockk.MockKMatcherScope
 import io.mockk.every
+import org.genspectrum.lapis.model.SiloNotImplementedError
 import org.genspectrum.lapis.response.AggregatedResponse
 import org.genspectrum.lapis.silo.SiloException
 import org.junit.jupiter.api.BeforeEach
@@ -90,6 +91,25 @@ class ExceptionHandlerTest(@Autowired val mockMvc: MockMvc) {
                     """
                     {
                       "title":"Bad request",
+                      "message":"SomeMessage"
+                    }
+                    """,
+                ),
+            )
+    }
+
+    @Test
+    fun `throw NOT_IMPLEMENTED(501) with additional info for request of a not implemented resource in SILO`() {
+        every { validControllerCall() } throws SiloNotImplementedError("SomeMessage", Exception("SomeCause"))
+
+        mockMvc.perform(get(validRoute))
+            .andExpect(status().isNotImplemented)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(
+                content().json(
+                    """
+                    {
+                      "title":"Not implemented",
                       "message":"SomeMessage"
                     }
                     """,

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -37,7 +37,7 @@ class SiloFilterExpressionMapperTest {
 
     @BeforeEach
     fun setup() {
-        underTest = SiloFilterExpressionMapper(sequenceFilterFields)
+        underTest = SiloFilterExpressionMapper(sequenceFilterFields, VariantQueryFacade())
     }
 
     @Test

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -174,7 +174,10 @@ class SiloFilterExpressionMapperTest {
         )
 
         val exception = assertThrows<IllegalArgumentException> { underTest.map(filterParameter) }
-        assertThat(exception.message, containsString("variantQuery cannot be used with other variant filters"))
+        assertThat(
+            exception.message,
+            containsString("variantQuery filter cannot be used with other variant filters such as: "),
+        )
     }
 
     @Test
@@ -185,7 +188,10 @@ class SiloFilterExpressionMapperTest {
         )
 
         val exception = assertThrows<IllegalArgumentException> { underTest.map(filterParameter) }
-        assertThat(exception.message, containsString("variantQuery cannot be used with other variant filters"))
+        assertThat(
+            exception.message,
+            containsString("variantQuery filter cannot be used with other variant filters such as: "),
+        )
     }
 
     companion object {

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -30,6 +30,7 @@ class SiloFilterExpressionMapperTest {
             "nucleotideMutations" to SequenceFilterFieldType.MutationsList,
             "some_metadata" to SequenceFilterFieldType.String,
             "other_metadata" to SequenceFilterFieldType.String,
+            "variantQuery" to SequenceFilterFieldType.VariantQuery,
         ),
     )
 
@@ -312,8 +313,8 @@ class SiloFilterExpressionMapperTest {
                 ),
                 And(
                     listOf(
-                        StringEquals("some_metadata", "ABC"),
                         NucleotideSymbolEquals(300, "G"),
+                        StringEquals("some_metadata", "ABC"),
                     ),
                 ),
             ),

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -163,7 +163,7 @@ class SiloFilterExpressionMapperTest {
         val filterParameter = mapOf("variantQuery" to "")
 
         val exception = assertThrows<IllegalArgumentException> { underTest.map(filterParameter) }
-        assertThat(exception.message, containsString("variantQuery cannot be empty"))
+        assertThat(exception.message, containsString("variantQuery must not be empty"))
     }
 
     @Test

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -217,7 +217,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with a 'Insertion' expression the map should throw an error`() {
+    fun `given a variantQuery with a 'Insertion' expression the map should throw an error`() {
         val variantQuery = "ins_1234:GAG"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
@@ -229,7 +229,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a valid variant variantQuery with a 'AA mutation' expression the map should throw an error`() {
+    fun `given a variant variantQuery with a 'AA mutation' expression the map should throw an error`() {
         val variantQuery = "S:N501Y"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
@@ -241,7 +241,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a valid variant variantQuery with a 'AA insertion' expression the map should throw an error`() {
+    fun `given a valid variantQuery with a 'AA insertion' expression the map should throw an error`() {
         val variantQuery = "ins_S:N501EPE"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
@@ -253,7 +253,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a valid variant variantQuery with a 'nextclade pango lineage' expression the map should throw an error`() {
+    fun `given a valid variantQuery with a 'nextclade pango lineage' expression the map should throw an error`() {
         val variantQuery = "nextcladePangoLineage:BA.5*"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
@@ -265,7 +265,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a valid variant variantQuery with a 'Nextstrain clade lineage' expression the map should throw an error`() {
+    fun `given a valid variantQuery with a 'Nextstrain clade lineage' expression the map should throw an error`() {
         val variantQuery = "nextstrainClade:22B"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
@@ -277,7 +277,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a valid variant variantQuery with a 'Gisaid clade lineage' expression the map should throw an error`() {
+    fun `given a valid variantQuery with a 'Gisaid clade lineage' expression the map should throw an error`() {
         val variantQuery = "gisaid:AB"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -2,6 +2,7 @@ package org.genspectrum.lapis.model
 
 import org.genspectrum.lapis.silo.And
 import org.genspectrum.lapis.silo.Maybe
+import org.genspectrum.lapis.silo.NOf
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
@@ -10,6 +11,7 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class VariantQueryFacadeTest {
     private lateinit var underTest: VariantQueryFacade
@@ -20,7 +22,64 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant query with a single entry then map should return the corresponding SiloQuery`() {
+    fun `given a complex variant query then map should return the corresponding SiloQuery`() {
+        val variantQuery = "300G & (400- | 500B) & !600 & MAYBE(700B | 800-) & [3-of: 123A, 234T, 345G] & A.1.2.3*"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult =
+            And(
+                listOf(
+                    And(
+                        listOf(
+                            And(
+                                listOf(
+                                    And(
+                                        listOf(
+                                            And(
+                                                listOf(
+                                                    NucleotideSymbolEquals(300, "G"),
+                                                    Or(
+                                                        listOf(
+                                                            NucleotideSymbolEquals(400, "-"),
+                                                            NucleotideSymbolEquals(500, "B"),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                            Not(NucleotideSymbolEquals(600, "-")),
+                                        ),
+                                    ),
+                                    Maybe(
+                                        Or(
+                                            listOf(
+                                                NucleotideSymbolEquals(700, "B"),
+                                                NucleotideSymbolEquals(800, "-"),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            NOf(
+                                3,
+                                matchExactly = false,
+                                listOf(
+                                    NucleotideSymbolEquals(123, "A"),
+                                    NucleotideSymbolEquals(234, "T"),
+                                    NucleotideSymbolEquals(345, "G"),
+                                ),
+                            ),
+                        ),
+                    ),
+                    PangoLineageEquals("pangoLineage", "A.1.2.3", true),
+                ),
+            )
+
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variantQuery with a single entry then map should return the corresponding SiloQuery`() {
         val variantQuery = "300G"
 
         val result = underTest.map(variantQuery)
@@ -30,7 +89,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with an 'And' expression the map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with an 'And' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "300G & 400"
 
         val result = underTest.map(variantQuery)
@@ -45,7 +104,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with two 'And' expression the map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with two 'And' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "300G & 400- & 500B"
 
         val result = underTest.map(variantQuery)
@@ -65,7 +124,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with a 'Not' expression the map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with a 'Not' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "!300G"
 
         val result = underTest.map(variantQuery)
@@ -75,7 +134,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with an 'Or' expression the map should return the corresponding SiloQuery`() {
+    fun `given a variant variantQuery with an 'Or' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "300G | 400"
 
         val result = underTest.map(variantQuery)
@@ -90,7 +149,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with an bracket expression the map should return the corresponding SiloQuery`() {
+    fun `given a variant variantQuery with an bracket expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "300C & (400A | 500G)"
 
         val result = underTest.map(variantQuery)
@@ -110,7 +169,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with a 'Maybe' expression the map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with a 'Maybe' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "MAYBE(300G)"
 
         val result = underTest.map(variantQuery)
@@ -120,22 +179,130 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with a 'Pangolineage' expression the map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with a 'Pangolineage' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "A.1.2.3"
 
         val result = underTest.map(variantQuery)
 
-        val expectedResult = PangoLineageEquals("A.1.2.3", false)
+        val expectedResult = PangoLineageEquals("pangoLineage", "A.1.2.3", false)
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
     }
 
     @Test
-    fun `given a variant variantQuery with a 'Pangolineage' expression including sublineages the map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with a 'Pangolineage' expression (including sublineages) then map should return the corresponding SiloQuery`() { // ktlint-disable max-line-length
         val variantQuery = "A.1.2.3*"
 
         val result = underTest.map(variantQuery)
 
-        val expectedResult = PangoLineageEquals("A.1.2.3", true)
+        val expectedResult = PangoLineageEquals("pangoLineage", "A.1.2.3", true)
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variantQuery with a 'Nof' expression then map should return the corresponding SiloQuery`() {
+        val variantQuery = "[3-of: 123A, 234T, 345G]"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = NOf(
+            3,
+            false,
+            listOf(
+                NucleotideSymbolEquals(123, "A"),
+                NucleotideSymbolEquals(234, "T"),
+                NucleotideSymbolEquals(345, "G"),
+            ),
+        )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variantQuery with a exact 'Nof' expression then map should return the corresponding SiloQuery`() {
+        val variantQuery = "[exactly-3-of: 123A, 234T, 345G]"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = NOf(
+            3,
+            true,
+            listOf(
+                NucleotideSymbolEquals(123, "A"),
+                NucleotideSymbolEquals(234, "T"),
+                NucleotideSymbolEquals(345, "G"),
+            ),
+        )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variantQuery with a 'Insertion' expression then map should throw an error`() {
+        val variantQuery = "ins_1234:GAG"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Nucleotide insertions are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a variant variantQuery with a 'AA mutation' expression then map should throw an error`() {
+        val variantQuery = "S:N501Y"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Amino acid mutations are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variantQuery with a 'AA insertion' expression then map should throw an error`() {
+        val variantQuery = "ins_S:501:EPE"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Amino acid insertions are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variantQuery with a 'nextclade pango lineage' expression then map should throw an error`() {
+        val variantQuery = "nextcladePangoLineage:BA.5*"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Nextclade pango lineages are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variantQuery with a 'Nextstrain clade lineage' expression then map should throw an error`() {
+        val variantQuery = "nextstrainClade:22B"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Nextstrain clade lineages are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variantQuery with a 'Gisaid clade lineage' expression then map should throw an error`() {
+        val variantQuery = "gisaid:AB"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Gisaid clade lineages are not supported yet."),
+        )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -1,6 +1,7 @@
 package org.genspectrum.lapis.model
 
 import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
@@ -57,6 +58,16 @@ class VariantQueryFacadeTest {
                 NucleotideSymbolEquals(500, "B"),
             ),
         )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with a not expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "!300G"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = Not(NucleotideSymbolEquals(300, "G"))
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -1,6 +1,7 @@
 package org.genspectrum.lapis.model
 
 import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.Maybe
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
@@ -28,7 +29,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with an and expression the map should return the corresponding SiloQuery`() {
+    fun `given a variant variantQuery with an 'And' expression the map should return the corresponding SiloQuery`() {
         val variantQuery = "300G & 400"
 
         val result = underTest.map(variantQuery)
@@ -43,7 +44,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with two and expression the map should return the corresponding SiloQuery`() {
+    fun `given a variant variantQuery with two 'And' expression the map should return the corresponding SiloQuery`() {
         val variantQuery = "300G & 400- & 500B"
 
         val result = underTest.map(variantQuery)
@@ -63,7 +64,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with a not expression the map should return the corresponding SiloQuery`() {
+    fun `given a variant variantQuery with a 'Not' expression the map should return the corresponding SiloQuery`() {
         val variantQuery = "!300G"
 
         val result = underTest.map(variantQuery)
@@ -73,7 +74,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with an Or expression the map should return the corresponding SiloQuery`() {
+    fun `given a variant variantQuery with an 'Or' expression the map should return the corresponding SiloQuery`() {
         val variantQuery = "300G | 400"
 
         val result = underTest.map(variantQuery)
@@ -84,6 +85,36 @@ class VariantQueryFacadeTest {
                 NucleotideSymbolEquals(400, "-"),
             ),
         )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with an bracket expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "300C & (400A | 500G)"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = And(
+            listOf(
+                NucleotideSymbolEquals(300, "C"),
+                Or(
+                    listOf(
+                        NucleotideSymbolEquals(400, "A"),
+                        NucleotideSymbolEquals(500, "G"),
+                    ),
+                ),
+            ),
+        )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with a 'Maybe' expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "MAYBE(300G)"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = Maybe(NucleotideSymbolEquals(300, "G"))
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -3,6 +3,7 @@ package org.genspectrum.lapis.model
 import org.genspectrum.lapis.silo.And
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
+import org.genspectrum.lapis.silo.Or
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
@@ -68,6 +69,21 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = Not(NucleotideSymbolEquals(300, "G"))
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with an Or expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "300G | 400"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = Or(
+            listOf(
+                NucleotideSymbolEquals(300, "G"),
+                NucleotideSymbolEquals(400, "-"),
+            ),
+        )
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -238,7 +238,7 @@ class VariantQueryFacadeTest {
     fun `given a variantQuery with a 'Insertion' expression then map should throw an error`() {
         val variantQuery = "ins_1234:GAG"
 
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+        val exception = assertThrows<SiloNotImplementedError> { underTest.map(variantQuery) }
 
         MatcherAssert.assertThat(
             exception.message,
@@ -250,7 +250,7 @@ class VariantQueryFacadeTest {
     fun `given a variant variantQuery with a 'AA mutation' expression then map should throw an error`() {
         val variantQuery = "S:N501Y"
 
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+        val exception = assertThrows<SiloNotImplementedError> { underTest.map(variantQuery) }
 
         MatcherAssert.assertThat(
             exception.message,
@@ -262,7 +262,7 @@ class VariantQueryFacadeTest {
     fun `given a valid variantQuery with a 'AA insertion' expression then map should throw an error`() {
         val variantQuery = "ins_S:501:EPE"
 
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+        val exception = assertThrows<SiloNotImplementedError> { underTest.map(variantQuery) }
 
         MatcherAssert.assertThat(
             exception.message,
@@ -274,7 +274,7 @@ class VariantQueryFacadeTest {
     fun `given a valid variantQuery with a 'nextclade pango lineage' expression then map should throw an error`() {
         val variantQuery = "nextcladePangoLineage:BA.5*"
 
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+        val exception = assertThrows<SiloNotImplementedError> { underTest.map(variantQuery) }
 
         MatcherAssert.assertThat(
             exception.message,
@@ -286,7 +286,7 @@ class VariantQueryFacadeTest {
     fun `given a valid variantQuery with a 'Nextstrain clade lineage' expression then map should throw an error`() {
         val variantQuery = "nextstrainClade:22B"
 
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+        val exception = assertThrows<SiloNotImplementedError> { underTest.map(variantQuery) }
 
         MatcherAssert.assertThat(
             exception.message,
@@ -298,7 +298,7 @@ class VariantQueryFacadeTest {
     fun `given a valid variantQuery with a 'Gisaid clade lineage' expression then map should throw an error`() {
         val variantQuery = "gisaid:AB"
 
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+        val exception = assertThrows<SiloNotImplementedError> { underTest.map(variantQuery) }
 
         MatcherAssert.assertThat(
             exception.message,

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -242,7 +242,7 @@ class VariantQueryFacadeTest {
 
     @Test
     fun `given a valid variantQuery with a 'AA insertion' expression the map should throw an error`() {
-        val variantQuery = "ins_S:N501EPE"
+        val variantQuery = "ins_S:501:EPE"
 
         val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
 

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -149,7 +149,7 @@ class VariantQueryFacadeTest {
     }
 
     @Test
-    fun `given a variant variantQuery with an bracket expression then map should return the corresponding SiloQuery`() {
+    fun `given a variantQuery with an bracket expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "300C & (400A | 500G)"
 
         val result = underTest.map(variantQuery)
@@ -214,78 +214,6 @@ class VariantQueryFacadeTest {
             ),
         )
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
-    }
-
-    @Test
-    fun `given a variantQuery with a 'Insertion' expression the map should throw an error`() {
-        val variantQuery = "ins_1234:GAG"
-
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
-
-        MatcherAssert.assertThat(
-            exception.message,
-            Matchers.equalTo("Nucleotide insertions are not supported yet."),
-        )
-    }
-
-    @Test
-    fun `given a variant variantQuery with a 'AA mutation' expression the map should throw an error`() {
-        val variantQuery = "S:N501Y"
-
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
-
-        MatcherAssert.assertThat(
-            exception.message,
-            Matchers.equalTo("Amino acid mutations are not supported yet."),
-        )
-    }
-
-    @Test
-    fun `given a valid variantQuery with a 'AA insertion' expression the map should throw an error`() {
-        val variantQuery = "ins_S:501:EPE"
-
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
-
-        MatcherAssert.assertThat(
-            exception.message,
-            Matchers.equalTo("Amino acid insertions are not supported yet."),
-        )
-    }
-
-    @Test
-    fun `given a valid variantQuery with a 'nextclade pango lineage' expression the map should throw an error`() {
-        val variantQuery = "nextcladePangoLineage:BA.5*"
-
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
-
-        MatcherAssert.assertThat(
-            exception.message,
-            Matchers.equalTo("Nextclade pango lineages are not supported yet."),
-        )
-    }
-
-    @Test
-    fun `given a valid variantQuery with a 'Nextstrain clade lineage' expression the map should throw an error`() {
-        val variantQuery = "nextstrainClade:22B"
-
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
-
-        MatcherAssert.assertThat(
-            exception.message,
-            Matchers.equalTo("Nextstrain clade lineages are not supported yet."),
-        )
-    }
-
-    @Test
-    fun `given a valid variantQuery with a 'Gisaid clade lineage' expression the map should throw an error`() {
-        val variantQuery = "gisaid:AB"
-
-        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
-
-        MatcherAssert.assertThat(
-            exception.message,
-            Matchers.equalTo("Gisaid clade lineages are not supported yet."),
-        )
     }
 
     @Test

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -5,6 +5,7 @@ import org.genspectrum.lapis.silo.Maybe
 import org.genspectrum.lapis.silo.Not
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
+import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
@@ -115,6 +116,26 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = Maybe(NucleotideSymbolEquals(300, "G"))
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with a 'Pangolineage' expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "A.1.2.3"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = PangoLineageEquals("A.1.2.3", false)
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with a 'Pangolineage' expression including sublineages the map should return the corresponding SiloQuery`() {
+        val variantQuery = "A.1.2.3*"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = PangoLineageEquals("A.1.2.3", true)
         MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -1,0 +1,62 @@
+package org.genspectrum.lapis.model
+
+import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.NucleotideSymbolEquals
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class VariantQueryFacadeTest {
+    private lateinit var underTest: VariantQueryFacade
+
+    @BeforeEach
+    fun setup() {
+        underTest = VariantQueryFacade()
+    }
+
+    @Test
+    fun `given a variant query with a single entry then map should return the corresponding SiloQuery`() {
+        val variantQuery = "300G"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = NucleotideSymbolEquals(300, "G")
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with an and expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "300G & 400"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = And(
+            listOf(
+                NucleotideSymbolEquals(300, "G"),
+                NucleotideSymbolEquals(400, "-"),
+            ),
+        )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+
+    @Test
+    fun `given a variant variantQuery with two and expression the map should return the corresponding SiloQuery`() {
+        val variantQuery = "300G & 400- & 500B"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = And(
+            listOf(
+                And(
+                    listOf(
+                        NucleotideSymbolEquals(300, "G"),
+                        NucleotideSymbolEquals(400, "-"),
+                    ),
+                ),
+                NucleotideSymbolEquals(500, "B"),
+            ),
+        )
+        MatcherAssert.assertThat(result, Matchers.equalTo(expectedResult))
+    }
+}

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -217,6 +217,78 @@ class VariantQueryFacadeTest {
     }
 
     @Test
+    fun `given a variant variantQuery with a 'Insertion' expression the map should throw an error`() {
+        val variantQuery = "ins_1234:GAG"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Nucleotide insertions are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variant variantQuery with a 'AA mutation' expression the map should throw an error`() {
+        val variantQuery = "S:N501Y"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Amino acid mutations are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variant variantQuery with a 'AA insertion' expression the map should throw an error`() {
+        val variantQuery = "ins_S:N501EPE"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Amino acid insertions are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variant variantQuery with a 'nextclade pango lineage' expression the map should throw an error`() {
+        val variantQuery = "nextcladePangoLineage:BA.5*"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Nextclade pango lineages are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variant variantQuery with a 'Nextstrain clade lineage' expression the map should throw an error`() {
+        val variantQuery = "nextstrainClade:22B"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Nextstrain clade lineages are not supported yet."),
+        )
+    }
+
+    @Test
+    fun `given a valid variant variantQuery with a 'Gisaid clade lineage' expression the map should throw an error`() {
+        val variantQuery = "gisaid:AB"
+
+        val exception = assertThrows<NotImplementedError> { underTest.map(variantQuery) }
+
+        MatcherAssert.assertThat(
+            exception.message,
+            Matchers.equalTo("Gisaid clade lineages are not supported yet."),
+        )
+    }
+
+    @Test
     fun `given a variantQuery with a exact 'Nof' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "[exactly-3-of: 123A, 234T, 345G]"
 

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -201,6 +201,26 @@ class SiloQueryTest {
                 }
                 """,
             ),
+            Arguments.of(
+                Or(listOf(StringEquals("theColumn", "theValue"), StringEquals("theOtherColumn", "theOtherValue"))),
+                """
+                {
+                    "type": "Or",
+                    "children": [
+                        {
+                        "type": "StringEquals",
+                        "column": "theColumn",
+                        "value": "theValue"
+                        },
+                        {
+                        "type": "StringEquals",
+                        "column": "theOtherColumn",
+                        "value": "theOtherValue"
+                        }
+                    ]
+                }
+                """,
+            ),
         )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -234,6 +234,35 @@ class SiloQueryTest {
                 }
                 """,
             ),
+            Arguments.of(
+                NOf(
+                    2,
+                    true,
+                    listOf(
+                        StringEquals("theColumn", "theValue"),
+                        StringEquals("theOtherColumn", "theOtherValue"),
+                    ),
+                ),
+                """
+                {
+                    "type": "NOf",
+                    "numberOfMatchers": 2,
+                    "matchExactly": true,
+                    "children": [
+                        {
+                        "type": "StringEquals",
+                        "column": "theColumn",
+                        "value": "theValue"
+                        },
+                        {
+                        "type": "StringEquals",
+                        "column": "theOtherColumn",
+                        "value": "theOtherValue"
+                        }
+                    ]
+                }
+                """,
+            ),
         )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -221,6 +221,19 @@ class SiloQueryTest {
                 }
                 """,
             ),
+            Arguments.of(
+                Maybe(StringEquals("theColumn", "theValue")),
+                """
+                {
+                    "type": "Maybe",
+                    "child": {
+                        "type": "StringEquals",
+                        "column": "theColumn",
+                        "value": "theValue"
+                    }
+                }
+                """,
+            ),
         )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -188,6 +188,19 @@ class SiloQueryTest {
                 }
                 """,
             ),
+            Arguments.of(
+                Not(StringEquals("theColumn", "theValue")),
+                """
+                {
+                    "type": "Not",
+                    "child": {
+                        "type": "StringEquals",
+                        "column": "theColumn",
+                        "value": "theValue"
+                    }
+                }
+                """,
+            ),
         )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -245,7 +245,7 @@ class SiloQueryTest {
                 ),
                 """
                 {
-                    "type": "NOf",
+                    "type": "N-Of",
                     "numberOfMatchers": 2,
                     "matchExactly": true,
                     "children": [

--- a/lapis2/src/test/resources/config/testDatabaseConfig.yaml
+++ b/lapis2/src/test/resources/config/testDatabaseConfig.yaml
@@ -12,5 +12,5 @@ schema:
     - name: pangoLineage
       type: pango_lineage
   features:
-    - feature: sarsCoV2VariantQuery
+    - name: sarsCoV2VariantQuery
   primaryKey: gisaid_epi_isl

--- a/lapis2/src/test/resources/config/testDatabaseConfig.yaml
+++ b/lapis2/src/test/resources/config/testDatabaseConfig.yaml
@@ -11,4 +11,6 @@ schema:
       type: string
     - name: pangoLineage
       type: pango_lineage
+  features:
+    - feature: sarsCoV2VariantQuery
   primaryKey: gisaid_epi_isl

--- a/lapis2/src/test/resources/config/testDatabaseConfigWithoutFeatures.yaml
+++ b/lapis2/src/test/resources/config/testDatabaseConfigWithoutFeatures.yaml
@@ -1,0 +1,14 @@
+schema:
+  instanceName: sars_cov-2_minimal_test_config
+  metadata:
+    - name: gisaid_epi_isl
+      type: string
+    - name: date
+      type: date
+    - name: region
+      type: string
+    - name: country
+      type: string
+    - name: pangoLineage
+      type: pango_lineage
+  primaryKey: gisaid_epi_isl

--- a/siloLapisTests/test/aggregatedQueries/complexVariantQuery.json
+++ b/siloLapisTests/test/aggregatedQueries/complexVariantQuery.json
@@ -1,0 +1,9 @@
+{
+  "testCaseName": "variant query",
+  "lapisRequest": {
+    "variantQuery": "300G & (400-|500B) & !600&MAYBE(700B|800-) & [3-of:123A,234T,345G] & A.1.2.3*"
+  },
+  "expected": {
+    "count": 0
+  }
+}

--- a/siloLapisTests/test/aggregatedQueries/variantQuery.json
+++ b/siloLapisTests/test/aggregatedQueries/variantQuery.json
@@ -1,0 +1,9 @@
+{
+  "testCaseName": "variant query",
+  "lapisRequest": {
+    "variantQuery": "B.1.1.7"
+  },
+  "expected": {
+    "count": 48
+  }
+}

--- a/siloLapisTests/testDatabaseConfig.yaml
+++ b/siloLapisTests/testDatabaseConfig.yaml
@@ -11,4 +11,6 @@ schema:
       type: string
     - name: pangoLineage
       type: pango_lineage
+  features:
+    - name: sarsCoV2VariantQuery
   primaryKey: gisaid_epi_isl


### PR DESCRIPTION
Resolves #193 

The generalization of the variant query will be part of #130. Right now the Silo filter columns are hardcoded.