### PR TITLE
fix building with gradlew bootBuildImage

### DIFF
--- a/lapis2/build.gradle
+++ b/lapis2/build.gradle
@@ -51,6 +51,7 @@ tasks.named('test') {
 }
 
 tasks.named('bootBuildImage') {
+    environment = ["BP_JVM_VERSION": "20"]
     imageName = "ghcr.io/genspectrum/${project.name}"
 }
 


### PR DESCRIPTION
Fixes bug, which was introduced by BellSoft Liberica 10.1.0, which does no longer support jvm 19. Thus the docker file could no longer be created.

The jvm for `compileKotlin` is still at version 19, because the current version (1.8.20) of `org.jetbrains.kotlin.jvm` does not support jvm 20 yet