### PR TITLE
Update config

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
@@ -1,7 +1,10 @@
 package org.genspectrum.lapis.config
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
 data class DatabaseConfig(val schema: DatabaseSchema)
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class DatabaseSchema(
     val instanceName: String,
     val opennessLevel: OpennessLevel,
@@ -10,6 +13,7 @@ data class DatabaseSchema(
     val features: List<DatabaseFeature> = emptyList(),
 )
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class DatabaseMetadata(val name: String, val type: String, val valuesAreUnique: Boolean = false)
 
 data class DatabaseFeature(val name: String)

--- a/lapis2/src/main/resources/application.properties
+++ b/lapis2/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 springdoc.default-produces-media-type=application/json
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.operationsSorter=alpha
+server.forward-headers-strategy=framework

--- a/siloLapisTests/testDatabaseConfig.yaml
+++ b/siloLapisTests/testDatabaseConfig.yaml
@@ -8,10 +8,17 @@ schema:
       type: date
     - name: region
       type: string
+      generateIndex: true
     - name: country
       type: string
+      generateIndex: true
     - name: pango_lineage
       type: pango_lineage
+    - name: division
+      type: string
+      generateIndex: true
   features:
     - name: sarsCoV2VariantQuery
   primaryKey: gisaid_epi_isl
+  dateToSortBy: date
+  partitionBy: pango_lineage


### PR DESCRIPTION
Use an updated config from SILO. Also ignore fields in the database config that LAPIS doesn't need.

`server.forward-headers-strategy=framework` should generate a HTTPS URL in the swagger UI. On my local VBox, this worked.
https://github.com/springdoc/springdoc-openapi/issues/171#issuecomment-556573535