### PR TITLE
feat(lapis1): implement offset and make limit faster

### DIFF
--- a/server/src/main/java/ch/ethz/lapis/api/entity/req/OrderAndLimitConfig.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/req/OrderAndLimitConfig.java
@@ -17,4 +17,6 @@ public class OrderAndLimitConfig {
     private String orderBy;
 
     private Integer limit;
+
+    private Integer offset;
 }


### PR DESCRIPTION
This small PR for **LAPIS v1** adds a limited version of `offset` to the `/details` endpoint that only works if no sorting is specified, and it makes `limit` for details much faster.

(fyi @fengelniederhammer, @JonasKellerer)