### PR TITLE
feat: make it possible to return data from /details as CSV and TSV

### DIFF
--- a/lapis2/build.gradle
+++ b/lapis2/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging-jvm:3.0.5'
     antlr 'org.antlr:antlr4:4.13.0'
     implementation 'org.antlr:antlr4-runtime:4.13.0'
+    implementation 'org.apache.commons:commons-csv:1.10.0'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: "org.mockito"

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/OpenApiDocs.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/OpenApiDocs.kt
@@ -11,27 +11,28 @@ import org.genspectrum.lapis.config.SequenceFilterFields
 import org.genspectrum.lapis.controller.AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION
 import org.genspectrum.lapis.controller.AGGREGATED_REQUEST_SCHEMA
 import org.genspectrum.lapis.controller.AGGREGATED_RESPONSE_SCHEMA
+import org.genspectrum.lapis.controller.AMINO_ACID_MUTATIONS_PROPERTY
 import org.genspectrum.lapis.controller.AMINO_ACID_MUTATIONS_SCHEMA
 import org.genspectrum.lapis.controller.DETAILS_FIELDS_DESCRIPTION
 import org.genspectrum.lapis.controller.DETAILS_REQUEST_SCHEMA
 import org.genspectrum.lapis.controller.DETAILS_RESPONSE_SCHEMA
+import org.genspectrum.lapis.controller.FIELDS_PROPERTY
+import org.genspectrum.lapis.controller.FORMAT_PROPERTY
 import org.genspectrum.lapis.controller.LIMIT_DESCRIPTION
+import org.genspectrum.lapis.controller.LIMIT_PROPERTY
 import org.genspectrum.lapis.controller.LIMIT_SCHEMA
+import org.genspectrum.lapis.controller.MIN_PROPORTION_PROPERTY
+import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATIONS_PROPERTY
 import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATIONS_SCHEMA
 import org.genspectrum.lapis.controller.OFFSET_DESCRIPTION
+import org.genspectrum.lapis.controller.OFFSET_PROPERTY
 import org.genspectrum.lapis.controller.OFFSET_SCHEMA
 import org.genspectrum.lapis.controller.ORDER_BY_FIELDS_SCHEMA
+import org.genspectrum.lapis.controller.ORDER_BY_PROPERTY
 import org.genspectrum.lapis.controller.REQUEST_SCHEMA_WITH_MIN_PROPORTION
 import org.genspectrum.lapis.controller.SEQUENCE_FILTERS_SCHEMA
-import org.genspectrum.lapis.request.AMINO_ACID_MUTATIONS_PROPERTY
 import org.genspectrum.lapis.request.AminoAcidMutation
-import org.genspectrum.lapis.request.FIELDS_PROPERTY
-import org.genspectrum.lapis.request.LIMIT_PROPERTY
-import org.genspectrum.lapis.request.MIN_PROPORTION_PROPERTY
-import org.genspectrum.lapis.request.NUCLEOTIDE_MUTATIONS_PROPERTY
 import org.genspectrum.lapis.request.NucleotideMutation
-import org.genspectrum.lapis.request.OFFSET_PROPERTY
-import org.genspectrum.lapis.request.ORDER_BY_PROPERTY
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.response.COUNT_PROPERTY
 
@@ -48,7 +49,8 @@ fun buildOpenApiSchema(sequenceFilterFields: SequenceFilterFields, databaseConfi
         Pair(AMINO_ACID_MUTATIONS_PROPERTY, aminoAcidMutations()) +
         Pair(ORDER_BY_PROPERTY, orderByPostSchema()) +
         Pair(LIMIT_PROPERTY, limitSchema()) +
-        Pair(OFFSET_PROPERTY, offsetSchema())
+        Pair(OFFSET_PROPERTY, offsetSchema()) +
+        Pair(FORMAT_PROPERTY, formatSchema())
 
     return OpenAPI()
         .components(
@@ -225,3 +227,12 @@ private fun offsetSchema() = Schema<Int>()
 private fun fieldsSchema() = Schema<String>()
     .type("array")
     .items(Schema<String>().type("string"))
+
+private fun formatSchema() = Schema<String>()
+    .type("string")
+    .description(
+        "The data format of the response. " +
+            "Alternatively, the data format can be specified by setting the \"Accept\"-header.",
+    )
+    ._enum(listOf("csv", "tsv", "json"))
+    ._default("json")

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CsvWriter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CsvWriter.kt
@@ -13,11 +13,15 @@ interface CsvRecord {
 
 @Component
 class CsvWriter {
-    fun write(headers: Array<String>, data: List<CsvRecord>): String {
+    fun write(headers: Array<String>, data: List<CsvRecord>, delimiter: Delimiter): String {
         val stringWriter = StringWriter()
         CSVPrinter(
             stringWriter,
-            CSVFormat.DEFAULT.builder().setRecordSeparator("\n").setHeader(*headers).build(),
+            CSVFormat.DEFAULT.builder()
+                .setRecordSeparator("\n")
+                .setDelimiter(delimiter.value)
+                .setHeader(*headers)
+                .build(),
         ).use {
             for (datum in data) {
                 it.printRecord(*datum.asArray())
@@ -31,4 +35,9 @@ fun DetailsData.asCsvRecord() = JsonValuesCsvRecord(this.values)
 
 data class JsonValuesCsvRecord(val values: Collection<JsonNode>) : CsvRecord {
     override fun asArray() = values.map { it.asText() }.toTypedArray()
+}
+
+enum class Delimiter(val value: Char) {
+    COMMA(','),
+    TAB('\t'),
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CsvWriter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CsvWriter.kt
@@ -1,0 +1,34 @@
+package org.genspectrum.lapis.controller
+
+import com.fasterxml.jackson.databind.JsonNode
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+import org.genspectrum.lapis.silo.DetailsData
+import org.springframework.stereotype.Component
+import java.io.StringWriter
+
+interface CsvRecord {
+    fun asArray(): Array<String>
+}
+
+@Component
+class CsvWriter {
+    fun write(headers: Array<String>, data: List<CsvRecord>): String {
+        val stringWriter = StringWriter()
+        CSVPrinter(
+            stringWriter,
+            CSVFormat.DEFAULT.builder().setRecordSeparator("\n").setHeader(*headers).build(),
+        ).use {
+            for (datum in data) {
+                it.printRecord(*datum.asArray())
+            }
+        }
+        return stringWriter.toString().trim()
+    }
+}
+
+fun DetailsData.asCsvRecord() = JsonValuesCsvRecord(this.values)
+
+data class JsonValuesCsvRecord(val values: Collection<JsonNode>) : CsvRecord {
+    override fun asArray() = values.map { it.asText() }.toTypedArray()
+}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DataFormatParameterFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DataFormatParameterFilter.kt
@@ -1,0 +1,64 @@
+package org.genspectrum.lapis.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.genspectrum.lapis.util.CachedBodyHttpServletRequest
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.Collections
+import java.util.Enumeration
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class DataFormatParameterFilter(val objectMapper: ObjectMapper) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val reReadableRequest = CachedBodyHttpServletRequest(request, objectMapper)
+
+        filterChain.doFilter(AcceptHeaderModifyingRequestWrapper(reReadableRequest), response)
+    }
+}
+
+class AcceptHeaderModifyingRequestWrapper(
+    private val reReadableRequest: CachedBodyHttpServletRequest,
+) : HttpServletRequestWrapper(reReadableRequest) {
+
+    override fun getHeader(name: String): String? {
+        if (name.equals("Accept", ignoreCase = true)) {
+            when (reReadableRequest.getRequestFields()[FORMAT_PROPERTY]?.textValue()?.uppercase()) {
+                "CSV" -> {
+                    log.debug { "Overwriting Accept header to text/csv due to format property" }
+                    return "text/csv"
+                }
+
+                else -> {}
+            }
+        }
+
+        return super.getHeader(name)
+    }
+
+    override fun getHeaders(name: String): Enumeration<String>? {
+        if (name.equals("Accept", ignoreCase = true)) {
+            when (reReadableRequest.getRequestFields()[FORMAT_PROPERTY]?.textValue()?.uppercase()) {
+                "CSV" -> {
+                    log.debug { "Overwriting Accept header to text/csv due to format property" }
+                    return Collections.enumeration(listOf("text/csv"))
+                }
+
+                else -> {}
+            }
+        }
+
+        return super.getHeaders(name)
+    }
+}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DataFormatParameterFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DataFormatParameterFilter.kt
@@ -7,12 +7,16 @@ import jakarta.servlet.http.HttpServletRequestWrapper
 import jakarta.servlet.http.HttpServletResponse
 import mu.KotlinLogging
 import org.genspectrum.lapis.util.CachedBodyHttpServletRequest
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.util.Collections
 import java.util.Enumeration
 
 private val log = KotlinLogging.logger {}
+
+const val TEXT_CSV_HEADER = "text/csv"
+const val TEXT_TSV_HEADER = "text/tab-separated-values"
 
 @Component
 class DataFormatParameterFilter(val objectMapper: ObjectMapper) : OncePerRequestFilter() {
@@ -36,8 +40,20 @@ class AcceptHeaderModifyingRequestWrapper(
         if (name.equals("Accept", ignoreCase = true)) {
             when (reReadableRequest.getRequestFields()[FORMAT_PROPERTY]?.textValue()?.uppercase()) {
                 "CSV" -> {
-                    log.debug { "Overwriting Accept header to text/csv due to format property" }
-                    return "text/csv"
+                    log.debug { "Overwriting Accept header to $TEXT_CSV_HEADER due to format property" }
+                    return TEXT_CSV_HEADER
+                }
+
+                "TSV" -> {
+                    log.debug { "Overwriting Accept header to $TEXT_TSV_HEADER due to format property" }
+                    return TEXT_TSV_HEADER
+                }
+
+                "JSON" -> {
+                    log.debug {
+                        "Overwriting Accept header to ${MediaType.APPLICATION_JSON_VALUE} due to format property"
+                    }
+                    return MediaType.APPLICATION_JSON_VALUE
                 }
 
                 else -> {}
@@ -51,8 +67,20 @@ class AcceptHeaderModifyingRequestWrapper(
         if (name.equals("Accept", ignoreCase = true)) {
             when (reReadableRequest.getRequestFields()[FORMAT_PROPERTY]?.textValue()?.uppercase()) {
                 "CSV" -> {
-                    log.debug { "Overwriting Accept header to text/csv due to format property" }
-                    return Collections.enumeration(listOf("text/csv"))
+                    log.debug { "Overwriting Accept header to $TEXT_CSV_HEADER due to format property" }
+                    return Collections.enumeration(listOf(TEXT_CSV_HEADER))
+                }
+
+                "TSV" -> {
+                    log.debug { "Overwriting Accept header to $TEXT_TSV_HEADER due to format property" }
+                    return Collections.enumeration(listOf(TEXT_TSV_HEADER))
+                }
+
+                "JSON" -> {
+                    log.debug {
+                        "Overwriting Accept header to ${MediaType.APPLICATION_JSON_VALUE} due to format property"
+                    }
+                    return Collections.enumeration(listOf(MediaType.APPLICATION_JSON_VALUE))
                 }
 
                 else -> {}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -8,25 +8,18 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import org.genspectrum.lapis.auth.ACCESS_KEY_PROPERTY
 import org.genspectrum.lapis.logging.RequestContext
 import org.genspectrum.lapis.model.SiloQueryModel
-import org.genspectrum.lapis.request.AMINO_ACID_MUTATIONS_PROPERTY
 import org.genspectrum.lapis.request.AminoAcidMutation
 import org.genspectrum.lapis.request.DEFAULT_MIN_PROPORTION
-import org.genspectrum.lapis.request.FIELDS_PROPERTY
-import org.genspectrum.lapis.request.LIMIT_PROPERTY
-import org.genspectrum.lapis.request.MIN_PROPORTION_PROPERTY
 import org.genspectrum.lapis.request.MutationProportionsRequest
-import org.genspectrum.lapis.request.NUCLEOTIDE_MUTATIONS_PROPERTY
 import org.genspectrum.lapis.request.NucleotideMutation
-import org.genspectrum.lapis.request.OFFSET_PROPERTY
-import org.genspectrum.lapis.request.ORDER_BY_PROPERTY
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.SequenceFiltersRequestWithFields
 import org.genspectrum.lapis.response.AggregationData
 import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.silo.DetailsData
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -46,6 +39,7 @@ const val ORDER_BY_FIELDS_SCHEMA = "OrderByFields"
 const val LIMIT_SCHEMA = "Limit"
 const val OFFSET_SCHEMA = "Offset"
 
+const val DETAILS_ENDPOINT_DESCRIPTION = "Returns the specified metadata fields of sequences matching the filter."
 const val AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION =
     "The fields to stratify by. If empty, only the overall count is returned"
 const val DETAILS_FIELDS_DESCRIPTION =
@@ -55,21 +49,11 @@ const val OFFSET_DESCRIPTION = "The offset of the first entry to return in the r
     "This is useful for pagination in combination with \"limit\"."
 
 @RestController
-class LapisController(private val siloQueryModel: SiloQueryModel, private val requestContext: RequestContext) {
-    companion object {
-        private val nonSequenceFilterFields =
-            listOf(
-                MIN_PROPORTION_PROPERTY,
-                ACCESS_KEY_PROPERTY,
-                FIELDS_PROPERTY,
-                NUCLEOTIDE_MUTATIONS_PROPERTY,
-                AMINO_ACID_MUTATIONS_PROPERTY,
-                ORDER_BY_PROPERTY,
-                LIMIT_PROPERTY,
-                OFFSET_PROPERTY,
-            )
-    }
-
+class LapisController(
+    private val siloQueryModel: SiloQueryModel,
+    private val requestContext: RequestContext,
+    private val csvWriter: CsvWriter,
+) {
     @GetMapping("/aggregated")
     @LapisAggregatedResponse
     fun aggregated(
@@ -109,7 +93,7 @@ class LapisController(private val siloQueryModel: SiloQueryModel, private val re
         offset: Int? = null,
     ): List<AggregationData> {
         val request = SequenceFiltersRequestWithFields(
-            sequenceFilters?.filter { !nonSequenceFilterFields.contains(it.key) } ?: emptyMap(),
+            sequenceFilters?.filter { !SPECIAL_REQUEST_PROPERTIES.contains(it.key) } ?: emptyMap(),
             nucleotideMutations ?: emptyList(),
             aminoAcidMutations ?: emptyList(),
             fields ?: emptyList(),
@@ -173,7 +157,7 @@ class LapisController(private val siloQueryModel: SiloQueryModel, private val re
         offset: Int? = null,
     ): List<MutationData> {
         val request = MutationProportionsRequest(
-            sequenceFilters?.filter { !nonSequenceFilterFields.contains(it.key) } ?: emptyMap(),
+            sequenceFilters?.filter { !SPECIAL_REQUEST_PROPERTIES.contains(it.key) } ?: emptyMap(),
             nucleotideMutations ?: emptyList(),
             aminoAcidMutations ?: emptyList(),
             minProportion,
@@ -199,9 +183,13 @@ class LapisController(private val siloQueryModel: SiloQueryModel, private val re
         return siloQueryModel.computeMutationProportions(request)
     }
 
-    @GetMapping("/details")
+    @GetMapping("/details", produces = [MediaType.APPLICATION_JSON_VALUE])
     @LapisDetailsResponse
-    fun details(
+    @Operation(
+        description = DETAILS_ENDPOINT_DESCRIPTION,
+        operationId = "getDetails",
+    )
+    fun getDetailsAsJson(
         @SequenceFilters
         @RequestParam
         sequenceFilters: Map<String, String>?,
@@ -235,7 +223,7 @@ class LapisController(private val siloQueryModel: SiloQueryModel, private val re
         offset: Int? = null,
     ): List<DetailsData> {
         val request = SequenceFiltersRequestWithFields(
-            sequenceFilters?.filter { !nonSequenceFilterFields.contains(it.key) } ?: emptyMap(),
+            sequenceFilters?.filter { !SPECIAL_REQUEST_PROPERTIES.contains(it.key) } ?: emptyMap(),
             nucleotideMutations ?: emptyList(),
             aminoAcidMutations ?: emptyList(),
             fields ?: emptyList(),
@@ -249,9 +237,64 @@ class LapisController(private val siloQueryModel: SiloQueryModel, private val re
         return siloQueryModel.getDetails(request)
     }
 
-    @PostMapping("/details")
+    @GetMapping("/details", produces = ["text/csv"])
+    @Operation(
+        description = DETAILS_ENDPOINT_DESCRIPTION,
+        operationId = "getDetailsAsCsv",
+    )
+    fun getDetailsAsCsv(
+        @SequenceFilters
+        @RequestParam
+        sequenceFilters: Map<String, String>?,
+        @Parameter(description = DETAILS_FIELDS_DESCRIPTION)
+        @RequestParam
+        fields: List<String>?,
+        @Parameter(
+            schema = Schema(ref = "#/components/schemas/$ORDER_BY_FIELDS_SCHEMA"),
+            description = "The fields of the response to order by." +
+                " Fields specified here must also be present in \"fields\".",
+        )
+        @RequestParam
+        orderBy: List<OrderByField>?,
+        @Parameter(schema = Schema(ref = "#/components/schemas/$NUCLEOTIDE_MUTATIONS_SCHEMA"))
+        @RequestParam
+        nucleotideMutations: List<NucleotideMutation>?,
+        @Parameter(schema = Schema(ref = "#/components/schemas/$AMINO_ACID_MUTATIONS_SCHEMA"))
+        @RequestParam
+        aminoAcidMutations: List<AminoAcidMutation>?,
+        @Parameter(
+            schema = Schema(ref = "#/components/schemas/$LIMIT_SCHEMA"),
+            description = LIMIT_DESCRIPTION,
+        )
+        @RequestParam
+        limit: Int? = null,
+        @Parameter(
+            schema = Schema(ref = "#/components/schemas/$OFFSET_SCHEMA"),
+            description = OFFSET_DESCRIPTION,
+        )
+        @RequestParam
+        offset: Int? = null,
+    ): String {
+        val request = SequenceFiltersRequestWithFields(
+            sequenceFilters?.filter { !SPECIAL_REQUEST_PROPERTIES.contains(it.key) } ?: emptyMap(),
+            nucleotideMutations ?: emptyList(),
+            aminoAcidMutations ?: emptyList(),
+            fields ?: emptyList(),
+            orderBy ?: emptyList(),
+            limit,
+            offset,
+        )
+
+        return getDetailsAsCsv(request)
+    }
+
+    @PostMapping("/details", produces = [MediaType.APPLICATION_JSON_VALUE])
     @LapisDetailsResponse
-    fun postDetails(
+    @Operation(
+        description = DETAILS_ENDPOINT_DESCRIPTION,
+        operationId = "postDetails",
+    )
+    fun postDetailsAsJson(
         @Parameter(schema = Schema(ref = "#/components/schemas/$DETAILS_REQUEST_SCHEMA"))
         @RequestBody
         request: SequenceFiltersRequestWithFields,
@@ -260,38 +303,45 @@ class LapisController(private val siloQueryModel: SiloQueryModel, private val re
 
         return siloQueryModel.getDetails(request)
     }
+
+    @PostMapping("/details", produces = ["text/csv"])
+    @Operation(
+        description = DETAILS_ENDPOINT_DESCRIPTION,
+        operationId = "postDetailsAsCsv",
+    )
+    fun postDetailsAsCsv(
+        @Parameter(schema = Schema(ref = "#/components/schemas/$DETAILS_REQUEST_SCHEMA"))
+        @RequestBody
+        request: SequenceFiltersRequestWithFields,
+    ): String {
+        return getDetailsAsCsv(request)
+    }
+
+    private fun getDetailsAsCsv(request: SequenceFiltersRequestWithFields): String {
+        requestContext.filter = request
+
+        val data = siloQueryModel.getDetails(request)
+
+        if (data.isEmpty()) {
+            return ""
+        }
+
+        val headers = data[0].keys.toTypedArray<String>()
+        return csvWriter.write(headers, data.map { it.asCsvRecord() })
+    }
 }
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-@Operation(
-    description = "Returns the number of sequences matching the specified sequence filters",
-    responses = [
-        ApiResponse(
-            responseCode = "200",
-            description = "OK",
-            content = [
-                Content(
-                    array = ArraySchema(
-                        schema = Schema(ref = "#/components/schemas/$AGGREGATED_RESPONSE_SCHEMA"),
-                    ),
-                ),
-            ],
-        ),
-        ApiResponse(
-            responseCode = "400",
-            description = "Bad Request",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-        ApiResponse(
-            responseCode = "403",
-            description = "Forbidden",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-        ApiResponse(
-            responseCode = "500",
-            description = "Internal Server Error",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
+@Operation(description = "Returns the number of sequences matching the specified sequence filters")
+@ApiResponse(
+    responseCode = "200",
+    description = "OK",
+    content = [
+        Content(
+            array = ArraySchema(
+                schema = Schema(ref = "#/components/schemas/$AGGREGATED_RESPONSE_SCHEMA"),
+            ),
         ),
     ],
 )
@@ -302,61 +352,24 @@ private annotation class LapisAggregatedResponse
 @Operation(
     description = "Returns a list of mutations along with properties whose proportions are greater than or equal to " +
         "the specified minProportion. Only sequences matching the specified sequence filters are considered.",
-    responses = [
-        ApiResponse(
-            responseCode = "200",
-            description = "OK",
-            content = [Content(array = ArraySchema(schema = Schema(implementation = MutationData::class)))],
-        ),
-        ApiResponse(
-            responseCode = "400",
-            description = "Bad Request",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-        ApiResponse(
-            responseCode = "403",
-            description = "Forbidden",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-        ApiResponse(
-            responseCode = "500",
-            description = "Internal Server Error",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-    ],
+)
+@ApiResponse(
+    responseCode = "200",
+    description = "OK",
+    content = [Content(array = ArraySchema(schema = Schema(implementation = MutationData::class)))],
 )
 private annotation class LapisNucleotideMutationsResponse
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-@Operation(
-    description = "Returns the specified metadata fields of sequences matching the filter.",
-    responses = [
-        ApiResponse(
-            responseCode = "200",
-            description = "OK",
-            content = [
-                Content(
-                    array = ArraySchema(
-                        schema = Schema(ref = "#/components/schemas/$DETAILS_RESPONSE_SCHEMA"),
-                    ),
-                ),
-            ],
-        ),
-        ApiResponse(
-            responseCode = "400",
-            description = "Bad Request",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-        ApiResponse(
-            responseCode = "403",
-            description = "Forbidden",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
-        ),
-        ApiResponse(
-            responseCode = "500",
-            description = "Internal Server Error",
-            content = [Content(schema = Schema(implementation = LapisHttpErrorResponse::class))],
+@ApiResponse(
+    responseCode = "200",
+    description = "OK",
+    content = [
+        Content(
+            array = ArraySchema(
+                schema = Schema(ref = "#/components/schemas/$DETAILS_RESPONSE_SCHEMA"),
+            ),
         ),
     ],
 )

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/OperationsSorter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/OperationsSorter.kt
@@ -1,0 +1,28 @@
+package org.genspectrum.lapis.controller
+
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Content
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+
+@Component
+class OperationsSorter : OperationCustomizer {
+    override fun customize(operation: Operation, handlerMethod: HandlerMethod): Operation {
+        operation.responses.forEach { _, response ->
+            val applicationJsonFirstContents =
+                response.content.toSortedMap(
+                    compareByDescending<String> { it.contains(MediaType.APPLICATION_JSON_VALUE) }.thenBy { it },
+                )
+
+            response.content = Content().apply {
+                for ((mediaTypeName, mediaType) in applicationJsonFirstContents) {
+                    addMediaType(mediaTypeName, mediaType)
+                }
+            }
+        }
+
+        return operation
+    }
+}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/SpecialProperties.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/SpecialProperties.kt
@@ -1,0 +1,23 @@
+package org.genspectrum.lapis.controller
+
+const val FORMAT_PROPERTY = "dataFormat"
+const val ACCESS_KEY_PROPERTY = "accessKey"
+const val MIN_PROPORTION_PROPERTY = "minProportion"
+const val FIELDS_PROPERTY = "fields"
+const val NUCLEOTIDE_MUTATIONS_PROPERTY = "nucleotideMutations"
+const val AMINO_ACID_MUTATIONS_PROPERTY = "aminoAcidMutations"
+const val ORDER_BY_PROPERTY = "orderBy"
+const val LIMIT_PROPERTY = "limit"
+const val OFFSET_PROPERTY = "offset"
+
+val SPECIAL_REQUEST_PROPERTIES = listOf(
+    MIN_PROPORTION_PROPERTY,
+    ACCESS_KEY_PROPERTY,
+    FIELDS_PROPERTY,
+    NUCLEOTIDE_MUTATIONS_PROPERTY,
+    AMINO_ACID_MUTATIONS_PROPERTY,
+    ORDER_BY_PROPERTY,
+    LIMIT_PROPERTY,
+    OFFSET_PROPERTY,
+    FORMAT_PROPERTY,
+)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
@@ -4,19 +4,12 @@ import com.fasterxml.jackson.core.ObjectCodec
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.JsonNodeType
-import org.genspectrum.lapis.auth.ACCESS_KEY_PROPERTY
-
-const val NUCLEOTIDE_MUTATIONS_PROPERTY = "nucleotideMutations"
-const val AMINO_ACID_MUTATIONS_PROPERTY = "aminoAcidMutations"
-const val ORDER_BY_PROPERTY = "orderBy"
-const val LIMIT_PROPERTY = "limit"
-const val OFFSET_PROPERTY = "offset"
-
-private val nonSequenceFilterPrimitiveFields = listOf(
-    LIMIT_PROPERTY,
-    OFFSET_PROPERTY,
-    ACCESS_KEY_PROPERTY,
-)
+import org.genspectrum.lapis.controller.AMINO_ACID_MUTATIONS_PROPERTY
+import org.genspectrum.lapis.controller.LIMIT_PROPERTY
+import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATIONS_PROPERTY
+import org.genspectrum.lapis.controller.OFFSET_PROPERTY
+import org.genspectrum.lapis.controller.ORDER_BY_PROPERTY
+import org.genspectrum.lapis.controller.SPECIAL_REQUEST_PROPERTIES
 
 interface CommonSequenceFilters {
     val sequenceFilters: Map<String, String>
@@ -71,7 +64,7 @@ fun parseCommonFields(node: JsonNode, codec: ObjectCodec): ParsedCommonFields {
     val sequenceFilters = node.fields()
         .asSequence()
         .filter { isStringOrNumber(it.value) }
-        .filter { !nonSequenceFilterPrimitiveFields.contains(it.key) }
+        .filter { !SPECIAL_REQUEST_PROPERTIES.contains(it.key) }
         .associate { it.key to it.value.asText() }
     return ParsedCommonFields(nucleotideMutations, aminoAcidMutations, sequenceFilters, orderByFields, limit, offset)
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
@@ -4,10 +4,11 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeType
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.NumericNode
+import org.genspectrum.lapis.controller.MIN_PROPORTION_PROPERTY
 import org.springframework.boot.jackson.JsonComponent
 
-const val MIN_PROPORTION_PROPERTY = "minProportion"
 const val DEFAULT_MIN_PROPORTION = 0.05
 
 data class MutationProportionsRequest(
@@ -26,31 +27,17 @@ class MutationProportionsRequestDeserializer : JsonDeserializer<MutationProporti
         val node = jsonParser.readValueAsTree<JsonNode>()
         val codec = jsonParser.codec
 
-        when (node.get(MIN_PROPORTION_PROPERTY)?.nodeType) {
-            null,
-            JsonNodeType.MISSING,
-            JsonNodeType.NULL,
-            JsonNodeType.NUMBER,
-            -> {
-            }
+        val minProportion = when (val minProportionNode = node.get(MIN_PROPORTION_PROPERTY)) {
+            null, is NullNode -> DEFAULT_MIN_PROPORTION
+            is NumericNode -> minProportionNode.doubleValue()
 
             else -> throw IllegalArgumentException("minProportion must be a number")
         }
 
         val parsedCommonFields = parseCommonFields(node, codec)
 
-        val (minProportions, actualSequenceFilters) = parsedCommonFields.sequenceFilters.entries.partition {
-            it.key == MIN_PROPORTION_PROPERTY
-        }
-
-        val minProportion = if (minProportions.isEmpty()) {
-            DEFAULT_MIN_PROPORTION
-        } else {
-            minProportions.single().value.toDouble()
-        }
-
         return MutationProportionsRequest(
-            actualSequenceFilters.associate { it.key to it.value },
+            parsedCommonFields.sequenceFilters,
             parsedCommonFields.nucleotideMutations,
             parsedCommonFields.aminoAcidMutations,
             minProportion,

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
+import org.genspectrum.lapis.controller.FIELDS_PROPERTY
 import org.springframework.boot.jackson.JsonComponent
-
-const val FIELDS_PROPERTY = "fields"
 
 data class SequenceFiltersRequestWithFields(
     override val sequenceFilters: Map<String, String>,

--- a/lapis2/src/main/resources/public/error/404.html
+++ b/lapis2/src/main/resources/public/error/404.html
@@ -5,7 +5,8 @@
     <title>Error 404</title>
 </head>
 <body>
-<h1>Page not found!</h1>
-<a href="/swagger-ui/index.html">Visit our swagger-ui</a>
+    <h1>LAPIS</h1>
+    <h3>Page not found!</h3>
+    <a href="/swagger-ui/index.html">Visit our swagger-ui</a>
 </body>
 </html>

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCsvTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCsvTest.kt
@@ -1,0 +1,147 @@
+package org.genspectrum.lapis.controller
+
+import com.fasterxml.jackson.databind.node.DoubleNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.genspectrum.lapis.model.SiloQueryModel
+import org.genspectrum.lapis.request.SequenceFiltersRequestWithFields
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LapisControllerCsvTest(@Autowired val mockMvc: MockMvc) {
+    @MockkBean
+    lateinit var siloQueryModelMock: SiloQueryModel
+
+    @Test
+    fun `GET empty details return empty CSV`() {
+        every {
+            siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
+        } returns emptyList()
+
+        mockMvc.perform(get("/details?country=Switzerland").header("Accept", "text/csv"))
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+            .andExpect(content().string(""))
+    }
+
+    @Test
+    fun `GET details as CSV with accept header`() {
+        every {
+            siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
+        } returns listOf(
+            mapOf("country" to TextNode("Switzerland"), "age" to IntNode(42), "floatValue" to DoubleNode(3.14)),
+            mapOf("country" to TextNode("Switzerland"), "age" to IntNode(43), "floatValue" to NullNode.instance),
+        )
+
+        mockMvc.perform(get("/details?country=Switzerland").header("Accept", "text/csv"))
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+            .andExpect(
+                content().string(
+                    """
+                       country,age,floatValue
+                       Switzerland,42,3.14
+                       Switzerland,43,null
+                    """.trimIndent(),
+                ),
+            )
+    }
+
+    @Test
+    fun `GET details as CSV with request parameter`() {
+        every {
+            siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
+        } returns listOf(
+            mapOf("country" to TextNode("Switzerland"), "age" to IntNode(42)),
+            mapOf("country" to TextNode("Switzerland"), "age" to IntNode(43)),
+        )
+
+        mockMvc.perform(get("/details?country=Switzerland&dataFormat=csv"))
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+            .andExpect(
+                content().string(
+                    """
+                        country,age
+                        Switzerland,42
+                        Switzerland,43
+                    """.trimIndent(),
+                ),
+            )
+    }
+
+    @Test
+    fun `POST details returns empty CSV`() {
+        every {
+            siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
+        } returns emptyList()
+
+        val request = post("/details")
+            .content("""{"country": "Switzerland"}""")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept("text/csv")
+
+        mockMvc.perform(request)
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+            .andExpect(content().string(""))
+    }
+
+    @Test
+    fun `POST details as CSV with accept header`() {
+        every {
+            siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
+        } returns emptyList()
+
+        val request = post("/details")
+            .content("""{"country": "Switzerland"}""")
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept("text/csv")
+
+        mockMvc.perform(request)
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+            .andExpect(content().string(""))
+    }
+
+    @Test
+    fun `POST details as CSV with request parameter`() {
+        every {
+            siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
+        } returns emptyList()
+
+        val request = post("/details")
+            .content("""{"country": "Switzerland", "dataFormat": "csv"}""")
+            .contentType(MediaType.APPLICATION_JSON)
+
+        mockMvc.perform(request)
+            .andExpect(status().isOk)
+            .andExpect(header().string("Content-Type", "text/csv;charset=UTF-8"))
+            .andExpect(content().string(""))
+    }
+
+    private fun sequenceFiltersRequestWithFields(
+        sequenceFilters: Map<String, String>,
+        fields: List<String> = emptyList(),
+    ) = SequenceFiltersRequestWithFields(
+        sequenceFilters,
+        emptyList(),
+        emptyList(),
+        fields,
+        emptyList(),
+    )
+}

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/OperationsSorterTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/OperationsSorterTest.kt
@@ -1,0 +1,48 @@
+package org.genspectrum.lapis.controller
+
+import io.mockk.mockk
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.responses.ApiResponse
+import io.swagger.v3.oas.models.responses.ApiResponses
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+import org.springframework.web.method.HandlerMethod
+
+class OperationsSorterTest {
+    @Test
+    fun `given content with multiple media types then sorts application json to the top`() {
+        val underTest = OperationsSorter()
+
+        val input = Operation().apply {
+            responses = ApiResponses()
+            responses["jsonFirst"] = ApiResponse().apply {
+                content = Content()
+                content["application/json"] = null
+                content["text/csv"] = null
+                content["text/tab-separated-values"] = null
+            }
+            responses["csvFirst"] = ApiResponse().apply {
+                content = Content()
+                content["text/csv"] = null
+                content["application/json"] = null
+                content["text/tab-separated-values"] = null
+            }
+        }
+
+        val inputCsvFirstKeys = input.responses["csvFirst"]?.content?.keys
+        assertThat(inputCsvFirstKeys?.first(), `is`("text/csv"))
+
+        val result = underTest.customize(input, mockk<HandlerMethod>())
+
+        val jsonFirstKeys = result.responses["jsonFirst"]?.content?.keys
+        assertThat(jsonFirstKeys?.first(), `is`("application/json"))
+        assertThat(jsonFirstKeys, hasSize(3))
+
+        val csvFirstKeys = result.responses["csvFirst"]?.content?.keys
+        assertThat(csvFirstKeys?.first(), `is`("application/json"))
+        assertThat(jsonFirstKeys, hasSize(3))
+    }
+}

--- a/siloLapisTests/.gitignore
+++ b/siloLapisTests/.gitignore
@@ -1,2 +1,5 @@
 build/
 node_modules/
+
+**/output/
+**/logs/

--- a/siloLapisTests/test/details.spec.ts
+++ b/siloLapisTests/test/details.spec.ts
@@ -109,4 +109,24 @@ Solothurn,EPI_ISL_1002052,B.1
     `.trim()
     );
   });
+
+  it('should return the data as TSV', async () => {
+    const urlParams = new URLSearchParams({
+      fields: 'gisaid_epi_isl,pango_lineage,division',
+      orderBy: 'gisaid_epi_isl',
+      limit: '3',
+      dataFormat: 'tsv',
+    });
+
+    const result = await fetch(basePath + '/details?' + urlParams.toString());
+
+    expect(await result.text()).to.be.equal(
+      String.raw`
+division	gisaid_epi_isl	pango_lineage
+Vaud	EPI_ISL_1001493	B.1.177.44
+Bern	EPI_ISL_1001920	B.1.177
+Solothurn	EPI_ISL_1002052	B.1
+    `.trim()
+    );
+  });
 });


### PR DESCRIPTION
resolves #284 
resolves #129 

I implemented the idiomatic version via the accept header and mapped the `dataFormat` field to produce a different header.