### PR TITLE
feat: configure CORS - allow all origins

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
@@ -1,0 +1,16 @@
+package org.genspectrum.lapis
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class CorsConfiguration : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
+            .allowedMethods("GET", "POST", "OPTIONS")
+            .allowedHeaders("*")
+            .maxAge(3600)
+    }
+}


### PR DESCRIPTION
We should think about whether and how we want to make this configurable. #406 is an alternative, but I think we might not want to have it in the database config.