### PR TITLE
chore(docs): we don't need internationalization #376

### DIFF
--- a/lapis2-docs/src/content/config.ts
+++ b/lapis2-docs/src/content/config.ts
@@ -1,7 +1,6 @@
 import { defineCollection } from 'astro:content';
-import { docsSchema, i18nSchema } from '@astrojs/starlight/schema';
+import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
     docs: defineCollection({ schema: docsSchema() }),
-    i18n: defineCollection({ type: 'data', schema: i18nSchema() }),
 };


### PR DESCRIPTION
@chaoran-chen was there a specific reason why you added this collection? Currently Astro shows the warning:
"11:08:36 [WARN] [content] The i18n collection is defined but no content/i18n folder exists in the content directory. Create a new folder for the collection, or check your content configuration file for typos."