### PR TITLE
fix: e2e tests with new silo ordering of insertions and mutations

### DIFF
--- a/siloLapisTests/test/alignedNucleotideSequence.spec.ts
+++ b/siloLapisTests/test/alignedNucleotideSequence.spec.ts
@@ -11,7 +11,7 @@ describe('The /alignedNucleotideSequence endpoint', () => {
 
     expect(primaryKeys).to.have.length(100);
     expect(sequences).to.have.length(100);
-    expect(primaryKeys[0]).to.equal('>EPI_ISL_3247294');
+    expect(primaryKeys[0]).to.equal('>EPI_ISL_3259931');
     expect(sequences[0]).to.have.length(29903);
   });
 

--- a/siloLapisTests/test/aminoAcidInsertions.spec.ts
+++ b/siloLapisTests/test/aminoAcidInsertions.spec.ts
@@ -22,7 +22,7 @@ describe('The /aminoAcidInsertions endpoint', () => {
       },
     });
 
-    expect(ascendingOrderedResult.data[0]).to.have.property('insertion', 'ins_ORF1a:3602:FEP');
+    expect(ascendingOrderedResult.data[0]).to.have.property('insertion', 'ins_ORF1a:3602:F');
 
     const descendingOrderedResult = await lapisClient.postAminoAcidInsertions1({
       insertionsRequest: {
@@ -42,7 +42,7 @@ describe('The /aminoAcidInsertions endpoint', () => {
     });
 
     expect(resultWithLimit.data).to.have.length(2);
-    expect(resultWithLimit.data[1]).to.have.property('insertion', 'ins_ORF1a:3602:F');
+    expect(resultWithLimit.data[1]).to.have.property('insertion', 'ins_ORF1a:3602:FEP');
 
     const resultWithLimitAndOffset = await lapisClient.postAminoAcidInsertions1({
       insertionsRequest: {
@@ -100,9 +100,11 @@ insertion,count
     expect(resultText).to.contain(
       String.raw`
 ins_ORF1a:3602:F,1
-ins_S:143:T,1
+ins_ORF1a:3602:FEP,1
 ins_S:210:IV,1
 ins_S:247:SGE,1
+ins_S:214:EPE,5
+ins_S:143:T,1
 `.trim()
     );
   });
@@ -125,9 +127,11 @@ insertion	count
     expect(resultText).to.contain(
       String.raw`
 ins_ORF1a:3602:F	1
-ins_S:143:T	1
+ins_ORF1a:3602:FEP	1
 ins_S:210:IV	1
 ins_S:247:SGE	1
+ins_S:214:EPE	5
+ins_S:143:T	1
     `.trim()
     );
   });

--- a/siloLapisTests/test/aminoAcidSequence.spec.ts
+++ b/siloLapisTests/test/aminoAcidSequence.spec.ts
@@ -12,7 +12,7 @@ describe('The /alignedAminoAcidSequence endpoint', () => {
 
     expect(primaryKeys).to.have.length(100);
     expect(sequences).to.have.length(100);
-    expect(primaryKeys[0]).to.equal('>EPI_ISL_3247294');
+    expect(primaryKeys[0]).to.equal('>EPI_ISL_3259931');
     expect(sequences[0]).to.have.length(1274);
   });
 

--- a/siloLapisTests/test/details.spec.ts
+++ b/siloLapisTests/test/details.spec.ts
@@ -19,7 +19,7 @@ describe('The /details endpoint', () => {
       age: undefined,
       country: undefined,
       date: undefined,
-      division: 'Aargau',
+      division: 'Zürich',
       gisaidEpiIsl: undefined,
       pangoLineage: 'B.1.617.2',
       qcValue: undefined,
@@ -37,14 +37,14 @@ describe('The /details endpoint', () => {
     expect(result.data).to.have.length(2);
     expect(result.data[0]).to.be.deep.equal({
       aaInsertions: undefined,
-      insertions: undefined,
-      age: 50,
+      insertions: '25701:CCC',
+      age: 54,
       country: 'Switzerland',
       date: '2021-07-19',
-      division: 'Aargau',
-      gisaidEpiIsl: 'EPI_ISL_3128811',
+      division: 'Zürich',
+      gisaidEpiIsl: 'EPI_ISL_3128796',
       pangoLineage: 'B.1.617.2',
-      qcValue: 0.9,
+      qcValue: 0.96,
       region: 'Europe',
     });
   });

--- a/siloLapisTests/test/nucleotideInsertions.spec.ts
+++ b/siloLapisTests/test/nucleotideInsertions.spec.ts
@@ -101,8 +101,8 @@ insertion,count
 
     expect(resultText).to.contain(
       String.raw`
-ins_22339:GCTGGT,1
 ins_5959:TAT,2
+ins_22339:GCTGGT,1
 ins_22204:CAGAA,1
 ins_25701:CCC,17
 `.trim()
@@ -126,8 +126,8 @@ insertion	count
 
     expect(resultText).to.contain(
       String.raw`
-ins_22339:GCTGGT	1
 ins_5959:TAT	2
+ins_22339:GCTGGT	1
 ins_22204:CAGAA	1
 ins_25701:CCC	17
     `.trim()


### PR DESCRIPTION
Due to https://github.com/GenSpectrum/LAPIS-SILO/pull/215