### PR TITLE
fix: update e2e tests: deletions are also mutations (from SILO)

### DIFF
--- a/lapis2-docs/.gitignore
+++ b/lapis2-docs/.gitignore
@@ -23,3 +23,5 @@ pnpm-debug.log*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+.idea

--- a/siloLapisTests/test/aminoAcidMutations.spec.ts
+++ b/siloLapisTests/test/aminoAcidMutations.spec.ts
@@ -10,7 +10,7 @@ describe('The /aminoAcidMutations endpoint', () => {
       sequenceFiltersWithMinProportion: { country: 'Switzerland' },
     });
 
-    expect(result.data).to.have.length(107);
+    expect(result.data).to.have.length(132);
 
     const rareMutationProportion = result.data.find(
       mutationData => mutationData.mutation === mutationWithLessThan10PercentProportion
@@ -94,7 +94,7 @@ describe('The /aminoAcidMutations endpoint', () => {
       },
     });
 
-    expect(result.data).to.have.length(55);
+    expect(result.data).to.have.length(68);
     expect(result.data[0]).to.deep.equal(expectedFirstResultWithNucleotideInsertion);
   });
 
@@ -111,7 +111,7 @@ describe('The /aminoAcidMutations endpoint', () => {
       },
     });
 
-    expect(result.data).to.have.length(25);
+    expect(result.data).to.have.length(32);
     expect(result.data[0]).to.deep.equal(expectedFirstResultWithAminoAcidInsertion);
   });
 


### PR DESCRIPTION
SILO now correctly shows deletions as mutations https://github.com/GenSpectrum/LAPIS-SILO/pull/236. This changes our e2e tests. This PR should fix them.