### PR TITLE
fix: end to end tests failing due to timeout and new pango lineage alias in return

### DIFF
--- a/lapis2-docs/playwright.config.ts
+++ b/lapis2-docs/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     forbidOnly: !!process.env.CI,
     retries: 1,
     workers: process.env.CI ? 1 : undefined,
-    timeout: 60000,
+    timeout: 90000,
     reporter: 'html',
     use: {
         trace: 'retain-on-failure',

--- a/siloLapisTests/test/details.spec.ts
+++ b/siloLapisTests/test/details.spec.ts
@@ -145,7 +145,7 @@ Solothurn	B.1	key_1002052
       division: 'Zürich',
       primaryKey: 'key_3578231',
       insertions: '25701:CCC,5959:TAT',
-      pangoLineage: 'B.1.1.28.1',
+      pangoLineage: 'P.1',
       qcValue: 0.93,
       region: 'Europe',
     };
@@ -169,7 +169,7 @@ Solothurn	B.1	key_1002052
       date: '2021-07-04',
       division: 'Vaud',
       primaryKey: 'key_3259931',
-      pangoLineage: 'B.1.617.2.43',
+      pangoLineage: 'AY.43',
       qcValue: 0.98,
       region: 'Europe',
     };


### PR DESCRIPTION
There is a ticket to fix the time the e2e tests take: #603 

