### PR TITLE
fix: allow access in authorized mode when `fields` is specified non-fine-grained

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
@@ -123,9 +123,7 @@ private class ProtectedDataAuthorizationFilter(
             return AuthorizationResult.success()
         }
 
-        val requestFields = request.getRequestFields()
-
-        val accessKey = requestFields[ACCESS_KEY_PROPERTY]?.textValue()
+        val accessKey = request.getStringField(ACCESS_KEY_PROPERTY)
             ?: return AuthorizationResult.failure("An access key is required to access $path.")
 
         if (accessKeys.fullAccessKey == accessKey) {
@@ -133,8 +131,9 @@ private class ProtectedDataAuthorizationFilter(
         }
 
         val endpointServesAggregatedData = ENDPOINTS_THAT_SERVE_AGGREGATED_DATA.contains(path) &&
-            fieldsThatServeNonAggregatedData.intersect(requestFields.keys).isEmpty() &&
-            requestFields[FIELDS_PROPERTY]?.intersect(fieldsThatServeNonAggregatedData.toSet())?.isNotEmpty() != false
+            fieldsThatServeNonAggregatedData.intersect(request.getRequestFieldNames()).isEmpty() &&
+            request.getStringArrayField(FIELDS_PROPERTY).intersect(fieldsThatServeNonAggregatedData.toSet())
+                .isEmpty()
 
         if (endpointServesAggregatedData && accessKeys.aggregatedDataAccessKey == accessKey) {
             return AuthorizationResult.success()

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DataFormatParameterFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DataFormatParameterFilter.kt
@@ -40,7 +40,7 @@ class AcceptHeaderModifyingRequestWrapper(
 ) : HttpServletRequestWrapper(reReadableRequest) {
     override fun getHeader(name: String): String? {
         if (name.equals("Accept", ignoreCase = true)) {
-            when (reReadableRequest.getRequestFields()[FORMAT_PROPERTY]?.textValue()?.uppercase()) {
+            when (reReadableRequest.getStringField(FORMAT_PROPERTY)?.uppercase()) {
                 "CSV" -> {
                     log.debug { "Overwriting Accept header to $TEXT_CSV_HEADER due to format property" }
                     return TEXT_CSV_HEADER
@@ -67,7 +67,7 @@ class AcceptHeaderModifyingRequestWrapper(
 
     override fun getHeaders(name: String): Enumeration<String>? {
         if (name.equals("Accept", ignoreCase = true)) {
-            when (reReadableRequest.getRequestFields()[FORMAT_PROPERTY]?.textValue()?.uppercase()) {
+            when (reReadableRequest.getStringField(FORMAT_PROPERTY)?.uppercase()) {
                 "CSV" -> {
                     log.debug { "Overwriting Accept header to $TEXT_CSV_HEADER due to format property" }
                     return Collections.enumeration(listOf(TEXT_CSV_HEADER))

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DownloadAsFileFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/DownloadAsFileFilter.kt
@@ -20,8 +20,8 @@ class DownloadAsFileFilter(private val objectMapper: ObjectMapper) : OncePerRequ
     ) {
         val reReadableRequest = CachedBodyHttpServletRequest(request, objectMapper)
 
-        val downloadAsFile = reReadableRequest.getRequestFields()[DOWNLOAD_AS_FILE_PROPERTY]?.asBoolean()
-        if (downloadAsFile == true) {
+        val downloadAsFile = reReadableRequest.getBooleanField(DOWNLOAD_AS_FILE_PROPERTY) ?: false
+        if (downloadAsFile) {
             val filename = getFilename(reReadableRequest)
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=$filename")
         }


### PR DESCRIPTION
Before, `intersect` was called on a JsonNode, which did not work as expected.

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate end-to-end test.~~
