### PR TITLE
feat: allow that `fields` only contains the primary key in protected mode

### DIFF
--- a/.idea/runConfigurations/LapisV2Protected.xml
+++ b/.idea/runConfigurations/LapisV2Protected.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="LapisV2Protected" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="lapis-v2.main" />
-    <option name="PROGRAM_PARAMETERS" value="--silo.url=http://localhost:8081 --lapis.databaseConfig.path=siloLapisTests/testData/testDatabaseConfig.yaml --lapis.accessKeys.path=lapis2/src/test/resources/config/testAccessKeys.yaml --referenceGenomeFilename=siloLapisTests/testData/reference_genomes.json" />
+    <option name="PROGRAM_PARAMETERS" value="--silo.url=http://localhost:8081 --lapis.databaseConfig.path=siloLapisTests/testData/protectedTestDatabaseConfig.yaml --lapis.accessKeys.path=lapis2/src/test/resources/config/testAccessKeys.yaml --referenceGenomeFilename=siloLapisTests/testData/reference_genomes.json" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.genspectrum.lapis.LapisApplicationKt" />
     <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
     <method v="2">

--- a/siloLapisTests/testData/protectedTestDatabaseConfig.yaml
+++ b/siloLapisTests/testData/protectedTestDatabaseConfig.yaml
@@ -1,0 +1,32 @@
+schema:
+  instanceName: sars_cov-2_minimal_test_config
+  opennessLevel: PROTECTED
+  metadata:
+    - name: primaryKey
+      type: string
+    - name: date
+      type: date
+    - name: region
+      type: string
+      generateIndex: true
+    - name: country
+      type: string
+      generateIndex: true
+    - name: pangoLineage
+      type: pango_lineage
+    - name: division
+      type: string
+      generateIndex: true
+    - name: age
+      type: int
+    - name: qc_value
+      type: float
+    - name: insertions
+      type: insertion
+    - name: aaInsertions
+      type: aaInsertion
+  features:
+    - name: sarsCoV2VariantQuery
+  primaryKey: primaryKey
+  dateToSortBy: date
+  partitionBy: pangoLineage


### PR DESCRIPTION
The result will not be of much use, since you only get all primary keys, but no additional information. This is required for the UShER integration of cov-spectrum.

resolves #623

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
