### PR TITLE
fix: exact n of query with more elements than n

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -97,9 +97,10 @@ class VariantQueryCustomListener(val referenceGenomeSchema: ReferenceGenomeSchem
 
         val n = ctx.nOfNumberOfMatchers().text.toInt()
         val matchExactly = ctx.nOfMatchExactly() != null
+        val nOfExprs = ctx.nOfExprs().expr().size
 
         val children = mutableListOf<SiloFilterExpression>()
-        for (i in 1..n) {
+        for (i in 1..nOfExprs) {
             children += expressionStack.removeLast()
         }
 

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -221,7 +221,7 @@ class VariantQueryFacadeTest {
 
     @Test
     fun `given a variantQuery with a 'Nof' expression then map should return the corresponding SiloQuery`() {
-        val variantQuery = "[3-of: 123A, 234T, 345G]"
+        val variantQuery = "[3-of: 123A, 234T, 345G, 456A]"
 
         val result = underTest.map(variantQuery)
 
@@ -232,6 +232,7 @@ class VariantQueryFacadeTest {
                 NucleotideSymbolEquals(null, 123, "A"),
                 NucleotideSymbolEquals(null, 234, "T"),
                 NucleotideSymbolEquals(null, 345, "G"),
+                NucleotideSymbolEquals(null, 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -239,7 +240,7 @@ class VariantQueryFacadeTest {
 
     @Test
     fun `given a variantQuery with a exact 'Nof' expression then map should return the corresponding SiloQuery`() {
-        val variantQuery = "[exactly-3-of: 123A, 234T, 345G]"
+        val variantQuery = "[exactly-3-of: 123A, 234T, 345G, 456A]"
 
         val result = underTest.map(variantQuery)
 
@@ -250,6 +251,27 @@ class VariantQueryFacadeTest {
                 NucleotideSymbolEquals(null, 123, "A"),
                 NucleotideSymbolEquals(null, 234, "T"),
                 NucleotideSymbolEquals(null, 345, "G"),
+                NucleotideSymbolEquals(null, 456, "A"),
+            ),
+        )
+        assertThat(result, equalTo(expectedResult))
+    }
+
+    @Test
+    @Suppress("ktlint:standard:max-line-length")
+    fun `given a variantQuery with a nested exact 'Nof' expression then map should return the corresponding SiloQuery`() {
+        val variantQuery = "[exactly-3-of: 123A, !234G, 345G, 456A]"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = NOf(
+            3,
+            true,
+            listOf(
+                NucleotideSymbolEquals(null, 123, "A"),
+                Not(NucleotideSymbolEquals(null, 234, "G")),
+                NucleotideSymbolEquals(null, 345, "G"),
+                NucleotideSymbolEquals(null, 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))


### PR DESCRIPTION
This resolves the issue mentioned in https://github.com/GenSpectrum/cov-spectrum-website/pull/895
Here the query contained more elements in the n-of query than the size of n.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
