### PR TITLE
fix: don't set Transfer-Encoding twice

### DIFF
--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCompressionTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCompressionTest.kt
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpHeaders.ACCEPT_ENCODING
 import org.springframework.http.HttpHeaders.CONTENT_ENCODING
+import org.springframework.http.HttpHeaders.CONTENT_LENGTH
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.web.servlet.MockMvc
@@ -46,6 +47,7 @@ class LapisControllerCompressionTest(
         val content = mockMvc.perform(requestsScenario.request)
             .andExpect(status().isOk)
             .andExpect(content().contentType(requestsScenario.expectedContentType))
+            .andExpect(header().doesNotExist(CONTENT_LENGTH))
             .andExpect(header().string(CONTENT_ENCODING, requestsScenario.compressionFormat))
             .andReturn()
             .response


### PR DESCRIPTION
Some proxies such as Traefik will throw an error when the Transfer-Encoding header is present twice. We shouldn't set the header ourselves, but leave that to Tomcat (which also makes sure that the chunking is done correctly). Instead, prevent setting a content length when the response is compressed.

related: #600 

resolves #

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate end-to-end test.
