### PR TITLE
refactor: flatten mapped variant queries

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -71,8 +71,17 @@ class VariantQueryCustomListener(val referenceGenomeSchema: ReferenceGenomeSchem
     }
 
     override fun exitAnd(ctx: AndContext?) {
-        val children = listOf(expressionStack.removeLast(), expressionStack.removeLast()).reversed()
-        expressionStack.addLast(And(children))
+        val lastChildren = when (val last = expressionStack.removeLast()) {
+            is And -> last.children
+            else -> listOf(last)
+        }
+
+        val secondLastChildren = when (val secondLast = expressionStack.removeLast()) {
+            is And -> secondLast.children
+            else -> listOf(secondLast)
+        }
+
+        expressionStack.addLast(And(lastChildren + secondLastChildren))
     }
 
     override fun exitNot(ctx: NotContext?) {
@@ -81,8 +90,17 @@ class VariantQueryCustomListener(val referenceGenomeSchema: ReferenceGenomeSchem
     }
 
     override fun exitOr(ctx: OrContext?) {
-        val children = listOf(expressionStack.removeLast(), expressionStack.removeLast()).reversed()
-        expressionStack.addLast(Or(children))
+        val lastChildren = when (val last = expressionStack.removeLast()) {
+            is Or -> last.children
+            else -> listOf(last)
+        }
+
+        val secondLastChildren = when (val secondLast = expressionStack.removeLast()) {
+            is Or -> secondLast.children
+            else -> listOf(secondLast)
+        }
+
+        expressionStack.addLast(Or(lastChildren + secondLastChildren))
     }
 
     override fun exitMaybe(ctx: MaybeContext?) {

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -583,8 +583,8 @@ class SiloFilterExpressionMapperTest {
                     ),
                     And(
                         And(
-                            NucleotideSymbolEquals(null, 300, "G"),
                             NucleotideSymbolEquals(null, 400, "A"),
+                            NucleotideSymbolEquals(null, 300, "G"),
                         ),
                     ),
                 ),

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -41,39 +41,29 @@ class VariantQueryFacadeTest {
 
         val expectedResult =
             And(
-                And(
-                    And(
-                        And(
-                            And(
-                                And(
-                                    NucleotideSymbolEquals(null, 300, "G"),
-                                    Or(
-                                        NucleotideSymbolEquals(null, 400, "-"),
-                                        NucleotideSymbolEquals(null, 500, "B"),
-                                    ),
-                                ),
-                                Not(HasNucleotideMutation(null, 600)),
-                            ),
-                            Maybe(
-                                Or(
-                                    NucleotideSymbolEquals(null, 700, "B"),
-                                    NucleotideSymbolEquals(null, 800, "-"),
-                                ),
-                            ),
-                        ),
-                        NOf(
-                            3,
-                            matchExactly = false,
-                            listOf(
-                                NucleotideSymbolEquals(null, 123, "A"),
-                                NucleotideSymbolEquals(null, 234, "T"),
-                                NucleotideSymbolEquals(null, 345, "G"),
-                            ),
-                        ),
-                    ),
-                    PangoLineageEquals(NEXTCLADE_PANGO_LINEAGE_COLUMN, "jn.1", true),
-                ),
                 PangoLineageEquals(PANGO_LINEAGE_COLUMN, "A.1.2.3", true),
+                PangoLineageEquals(NEXTCLADE_PANGO_LINEAGE_COLUMN, "jn.1", true),
+                NOf(
+                    3,
+                    matchExactly = false,
+                    listOf(
+                        NucleotideSymbolEquals(null, 123, "A"),
+                        NucleotideSymbolEquals(null, 234, "T"),
+                        NucleotideSymbolEquals(null, 345, "G"),
+                    ),
+                ),
+                Maybe(
+                    Or(
+                        NucleotideSymbolEquals(null, 800, "-"),
+                        NucleotideSymbolEquals(null, 700, "B"),
+                    ),
+                ),
+                Not(HasNucleotideMutation(null, 600)),
+                Or(
+                    NucleotideSymbolEquals(null, 500, "B"),
+                    NucleotideSymbolEquals(null, 400, "-"),
+                ),
+                NucleotideSymbolEquals(null, 300, "G"),
             )
 
         assertThat(result, equalTo(expectedResult))
@@ -105,8 +95,8 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = And(
-            NucleotideSymbolEquals(null, 300, "G"),
             NucleotideSymbolEquals(null, 400, "-"),
+            NucleotideSymbolEquals(null, 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -118,11 +108,9 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = And(
-            And(
-                NucleotideSymbolEquals(null, 300, "G"),
-                NucleotideSymbolEquals(null, 400, "-"),
-            ),
             NucleotideSymbolEquals(null, 500, "B"),
+            NucleotideSymbolEquals(null, 400, "-"),
+            NucleotideSymbolEquals(null, 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -144,8 +132,8 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = Or(
-            NucleotideSymbolEquals(null, 300, "G"),
             NucleotideSymbolEquals(null, 400, "-"),
+            NucleotideSymbolEquals(null, 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -157,11 +145,11 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = And(
-            NucleotideSymbolEquals(null, 300, "C"),
             Or(
-                NucleotideSymbolEquals(null, 400, "A"),
                 NucleotideSymbolEquals(null, 500, "G"),
+                NucleotideSymbolEquals(null, 400, "A"),
             ),
+            NucleotideSymbolEquals(null, 300, "C"),
         )
         assertThat(result, equalTo(expectedResult))
     }


### PR DESCRIPTION
people sometimes send very long variant queries that resulted in very deeply nested expressions

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate end-to-end test.~~
