### PR TITLE
feat: make headers accessible to browser despite CORS

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
@@ -1,6 +1,9 @@
 package org.genspectrum.lapis
 
+import org.genspectrum.lapis.openApi.REQUEST_ID_HEADER
+import org.genspectrum.lapis.request.LAPIS_DATA_VERSION_HEADER
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders.RETRY_AFTER
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
@@ -11,6 +14,7 @@ class CorsConfiguration : WebMvcConfigurer {
             .allowedOrigins("*")
             .allowedMethods("GET", "POST", "OPTIONS")
             .allowedHeaders("*")
+            .exposedHeaders(LAPIS_DATA_VERSION_HEADER, REQUEST_ID_HEADER, RETRY_AFTER)
             .maxAge(3600)
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -5,6 +5,7 @@ import org.genspectrum.lapis.model.SiloNotImplementedError
 import org.genspectrum.lapis.silo.SiloException
 import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.core.annotation.Order
+import org.springframework.http.HttpHeaders.RETRY_AFTER
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
@@ -85,7 +86,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleSiloUnavailableException(e: SiloUnavailableException): ErrorResponse {
         log.warn(e) { "Caught SiloUnavailableException: ${e.message}" }
 
-        return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message) { header("Retry-After", e.retryAfter) }
+        return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message) { header(RETRY_AFTER, e.retryAfter) }
     }
 
     private fun responseEntity(


### PR DESCRIPTION
## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~

See https://javascript.info/fetch-crossorigin#response-headers.
> To grant JavaScript access to any other response header, the server must send the Access-Control-Expose-Headers header.