### PR TITLE
feat: implement a request cache for mutation and insertion queries

### DIFF
--- a/lapis2/build.gradle
+++ b/lapis2/build.gradle
@@ -29,6 +29,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
@@ -39,6 +41,7 @@ dependencies {
     implementation 'org.antlr:antlr4-runtime:4.13.1'
     implementation 'org.apache.commons:commons-csv:1.10.0'
     implementation 'com.github.luben:zstd-jni:1.5.5-11'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: "org.mockito"

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -20,12 +20,16 @@ import org.genspectrum.lapis.openApi.buildOpenApiSchema
 import org.genspectrum.lapis.util.TimeFactory
 import org.genspectrum.lapis.util.YamlObjectMapper
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.filter.CommonsRequestLoggingFilter
 import java.io.File
 
 @Configuration
+@EnableScheduling
+@EnableCaching
 class LapisSpringConfig {
     @Bean
     fun openAPI(

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
@@ -111,6 +111,7 @@ private class ProtectedDataAuthorizationFilter(
         private val WHITELISTED_PATH_PREFIXES = listOf(
             "/swagger-ui",
             "/api-docs",
+            "/actuator",
             "/sample$DATABASE_CONFIG_ROUTE",
             "/sample$REFERENCE_GENOME_ROUTE",
         )

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
@@ -1,0 +1,43 @@
+package org.genspectrum.lapis.scheduler
+
+import mu.KotlinLogging
+import org.genspectrum.lapis.silo.CachedSiloClient
+import org.genspectrum.lapis.silo.SILO_QUERY_CACHE_NAME
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class DataVersionCacheInvalidator(
+    private val cachedSiloClient: CachedSiloClient,
+    private val cacheClearer: CacheClearer,
+) {
+    private var currentlyCachedDataVersion = "uninitialized"
+
+    @Scheduled(fixedRate = 1, timeUnit = TimeUnit.SECONDS)
+    @Synchronized
+    fun invalidateSiloCache() {
+        log.debug { "checking for data version change" }
+
+        val info = cachedSiloClient.callInfo()
+        if (info.dataVersion != currentlyCachedDataVersion) {
+            log.info {
+                "Invalidating cache, old data version: $currentlyCachedDataVersion, " +
+                    "new data version: ${info.dataVersion}"
+            }
+            cacheClearer.clearCache()
+            currentlyCachedDataVersion = info.dataVersion
+        }
+    }
+}
+
+@Component
+class CacheClearer {
+    @CacheEvict(SILO_QUERY_CACHE_NAME, allEntries = true)
+    fun clearCache() {
+        log.info { "Clearing cache $SILO_QUERY_CACHE_NAME" }
+    }
+}

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -34,6 +34,7 @@ interface CommonActionFields {
 
 sealed class SiloAction<ResponseType>(
     @JsonIgnore val typeReference: TypeReference<SiloQueryResponse<ResponseType>>,
+    @JsonIgnore val cacheable: Boolean,
 ) : CommonActionFields {
     companion object {
         fun aggregated(
@@ -104,7 +105,7 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val type: String = "Aggregated",
-    ) : SiloAction<List<AggregationData>>(AggregationDataTypeReference())
+    ) : SiloAction<List<AggregationData>>(AggregationDataTypeReference(), cacheable = false)
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class MutationsAction(
@@ -113,7 +114,7 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val type: String = "Mutations",
-    ) : SiloAction<List<MutationData>>(MutationDataTypeReference())
+    ) : SiloAction<List<MutationData>>(MutationDataTypeReference(), cacheable = true)
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class AminoAcidMutationsAction(
@@ -122,7 +123,7 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val type: String = "AminoAcidMutations",
-    ) : SiloAction<List<MutationData>>(AminoAcidMutationDataTypeReference())
+    ) : SiloAction<List<MutationData>>(AminoAcidMutationDataTypeReference(), cacheable = true)
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class DetailsAction(
@@ -131,7 +132,7 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val type: String = "Details",
-    ) : SiloAction<List<DetailsData>>(DetailsDataTypeReference())
+    ) : SiloAction<List<DetailsData>>(DetailsDataTypeReference(), cacheable = false)
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class NucleotideInsertionsAction(
@@ -139,7 +140,7 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val type: String = "Insertions",
-    ) : SiloAction<List<InsertionData>>(InsertionDataTypeReference())
+    ) : SiloAction<List<InsertionData>>(InsertionDataTypeReference(), cacheable = true)
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class AminoAcidInsertionsAction(
@@ -147,7 +148,7 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val type: String = "AminoAcidInsertions",
-    ) : SiloAction<List<InsertionData>>(InsertionDataTypeReference())
+    ) : SiloAction<List<InsertionData>>(InsertionDataTypeReference(), cacheable = true)
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private data class SequenceAction(
@@ -156,7 +157,7 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val type: SequenceType,
         val sequenceName: String,
-    ) : SiloAction<List<SequenceData>>(SequenceDataTypeReference())
+    ) : SiloAction<List<SequenceData>>(SequenceDataTypeReference(), cacheable = false)
 }
 
 sealed class SiloFilterExpression(val type: String)

--- a/lapis2/src/main/resources/application.properties
+++ b/lapis2/src/main/resources/application.properties
@@ -2,3 +2,12 @@ springdoc.default-produces-media-type=application/json
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.operationsSorter=alpha
 server.forward-headers-strategy=framework
+
+spring.cache.cache-names=siloQueryCache
+spring.cache.caffeine.spec=maximumSize=50000
+
+management.endpoints.enabled-by-default=false
+management.endpoint.health.enabled=true
+management.endpoint.caches.enabled=true
+management.endpoint.metrics.enabled=true
+management.endpoints.web.exposure.include=health,caches,metrics

--- a/lapis2/src/test/resources/logback-test.xml
+++ b/lapis2/src/test/resources/logback-test.xml
@@ -9,6 +9,10 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
+    <logger name="org.springframework.cache" level="trace">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
     <logger name="org.genspectrum" level="debug" />
     <logger name="ch.qos.logback" level="warn" />
 </configuration>


### PR DESCRIPTION
Also make sure to invalidate the cache when SILO has a new data version

resolves #137

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
