### PR TITLE
fix: details does no longer return insertions

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -139,7 +139,9 @@ fun buildOpenApiSchema(
                                     "The key 'count' is always present.",
                             )
                             .required(listOf(COUNT_PROPERTY))
-                            .properties(getAggregatedResponseProperties(metadataFieldSchemas(databaseConfig))),
+                            .properties(
+                                getAggregatedResponseProperties(aggregatedMetadataFieldSchemas(databaseConfig)),
+                            ),
                     ),
                 )
                 .addSchemas(
@@ -150,7 +152,7 @@ fun buildOpenApiSchema(
                             .description(
                                 "The response contains the metadata of every sequence matching the sequence filters.",
                             )
-                            .properties(metadataFieldSchemas(databaseConfig)),
+                            .properties(detailsMetadataFieldSchemas(databaseConfig)),
                     ),
                 )
                 .addSchemas(
@@ -299,8 +301,14 @@ private fun infoResponseSchema() =
         )
         .required(listOf("dataVersion"))
 
-private fun metadataFieldSchemas(databaseConfig: DatabaseConfig) =
+private fun aggregatedMetadataFieldSchemas(databaseConfig: DatabaseConfig) =
     databaseConfig.schema.metadata.associate { it.name to Schema<String>().type(mapToOpenApiType(it.type)) }
+
+private fun detailsMetadataFieldSchemas(databaseConfig: DatabaseConfig) =
+    databaseConfig.schema.metadata.filter {
+        it.type != MetadataType.AMINO_ACID_INSERTION && it.type != MetadataType.NUCLEOTIDE_INSERTION
+    }
+        .associate { it.name to Schema<String>().type(mapToOpenApiType(it.type)) }
 
 private fun mapToOpenApiType(type: MetadataType): String =
     when (type) {

--- a/siloLapisTests/test/details.spec.ts
+++ b/siloLapisTests/test/details.spec.ts
@@ -12,8 +12,6 @@ describe('The /details endpoint', () => {
 
     expect(result.data).to.have.length(2);
     expect(result.data[0]).to.be.deep.equal({
-      aaInsertions: undefined,
-      insertions: undefined,
       age: undefined,
       country: undefined,
       date: undefined,
@@ -34,8 +32,6 @@ describe('The /details endpoint', () => {
 
     expect(result.data).to.have.length(2);
     expect(result.data[0]).to.be.deep.equal({
-      aaInsertions: undefined,
-      insertions: '25701:CCC',
       age: 54,
       country: 'Switzerland',
       date: '2021-07-19',
@@ -136,13 +132,11 @@ Solothurn	B.1	key_1002052
 
   it('should correctly handle nucleotide insertion requests', async () => {
     const expectedResultWithNucleotideInsertion = {
-      aaInsertions: undefined,
       age: 57,
       country: 'Switzerland',
       date: '2021-05-12',
       division: 'Zürich',
       primaryKey: 'key_3578231',
-      insertions: '25701:CCC,5959:TAT',
       pangoLineage: 'P.1',
       qcValue: 0.93,
       region: 'Europe',
@@ -160,8 +154,6 @@ Solothurn	B.1	key_1002052
 
   it('should correctly handle amino acid insertion requests', async () => {
     const expectedResultWithAminoAcidInsertion = {
-      aaInsertions: 'S:143:T,ORF1a:3602:FEP',
-      insertions: undefined,
       age: 52,
       country: 'Switzerland',
       date: '2021-07-04',


### PR DESCRIPTION
In https://github.com/GenSpectrum/LAPIS-SILO/pull/354 SILO no longer returns insertions on the details endpoint. This is now also in LAPIS

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
