### PR TITLE
download compression is too slow

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -75,7 +75,6 @@ class LapisSpringConfig {
         filter.setIncludePayload(true)
         filter.setMaxPayloadLength(10000)
         filter.setIncludeHeaders(false)
-        filter.setAfterMessagePrefix("REQUEST DATA: ")
         return filter
     }
 

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CompressionFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CompressionFilter.kt
@@ -222,6 +222,18 @@ class CompressingServletOutputStream(
         compressingStream.write(byte)
     }
 
+    override fun write(bytes: ByteArray) {
+        compressingStream.write(bytes)
+    }
+
+    override fun write(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+    ) {
+        compressingStream.write(bytes, offset, length)
+    }
+
     override fun isReady() = outputStream.isReady
 
     override fun setWriteListener(listener: WriteListener?) = outputStream.setWriteListener(listener)

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/logging/RequestContext.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/logging/RequestContext.kt
@@ -20,6 +20,7 @@ class RequestContext {
     var endpoint: String? = null
     var filter: CommonSequenceFilters? = null
     var responseCode: Int? = null
+    var cached: Boolean? = null
 }
 
 private val log = KotlinLogging.logger {}


### PR DESCRIPTION
resolves #717

Tests on a medium-sized data set (3552 sequences):
I measured request times of /sample/unalignedNucleotideSequences:
- uncompressed: 1300 ms, 65 MB
- gzip compressed: 3100 ms (before: 14 s), 8 MB
- zstd compressed: 970 ms (before: 7.4 s), 342 kB

I tested this using the Ebola dataset from Loculus. I pushed it to a branch: https://github.com/GenSpectrum/LAPIS/tree/ebolaTestData

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
