### PR TITLE
692 put logs into file again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ playground/
 
 docker-compose.override.yml
 
-log
+log/
+logs/

--- a/lapis2/.gitignore
+++ b/lapis2/.gitignore
@@ -5,4 +5,5 @@ build/
 !**/src/test/**/build/
 /lapis-v2-openapi.json
 /lapis-v2-openapi-protected.json
-log
+log/
+logs/

--- a/lapis2/README.md
+++ b/lapis2/README.md
@@ -57,3 +57,8 @@ How to execute the tests
 * Install NPM dependencies: `npm install`
 * Generate a Typescript client for LAPIS: `npm run generateLapisClient`
 * Execute the tests: `npm run test`
+
+## Logs
+
+LAPIS logs to rotating files in `./logs` and to stdout.
+In the Docker container, log files are stored in `/workspace/logs`

--- a/lapis2/build.gradle
+++ b/lapis2/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.apache.commons:commons-csv:1.10.0'
     implementation 'com.github.luben:zstd-jni:1.5.6-1'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.5.0"
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: "org.mockito"

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -71,9 +71,6 @@ class LapisSpringConfig {
     @Bean
     fun logFilter(): CommonsRequestLoggingFilter {
         val filter = CommonsRequestLoggingFilter()
-        filter.setIncludeQueryString(true)
-        filter.setIncludePayload(true)
-        filter.setMaxPayloadLength(10000)
         filter.setIncludeHeaders(false)
         return filter
     }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/request/LapisInfo.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/request/LapisInfo.kt
@@ -1,6 +1,10 @@
 package org.genspectrum.lapis.request
 
 import io.swagger.v3.oas.annotations.media.Schema
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.controller.LapisErrorResponse
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisResponse
@@ -19,20 +23,36 @@ import org.springframework.http.server.ServerHttpResponse
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
 
+private const val REPORT_TO =
+    "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues. " +
+        "Please include the request ID and the requestInfo in your report."
+
 @Schema(description = LAPIS_INFO_DESCRIPTION)
 data class LapisInfo(
     @Schema(
         description = LAPIS_DATA_VERSION_RESPONSE_DESCRIPTION,
         example = LAPIS_DATA_VERSION_EXAMPLE,
-    ) var dataVersion: String? = null,
-    @Schema(description = REQUEST_ID_HEADER_DESCRIPTION)
+    )
+    var dataVersion: String? = null,
+    @Schema(
+        description = REQUEST_ID_HEADER_DESCRIPTION,
+        example = "dfb342ea-3607-4caf-b35e-9aba75d06f81",
+    )
     var requestId: String? = null,
+    @Schema(
+        description = "Some information about the request in human readable form. Intended for debugging.",
+        example = "my_instance on my.server.com at 2024-01-01T12:00:00.0000",
+    )
+    var requestInfo: String? = null,
+    @Schema(example = REPORT_TO)
+    val reportTo: String = REPORT_TO,
 )
 
 @ControllerAdvice
 class ResponseBodyAdviceDataVersion(
     private val dataVersion: DataVersion,
     private val requestIdContext: RequestIdContext,
+    private val databaseConfig: DatabaseConfig,
 ) : ResponseBodyAdvice<Any> {
     override fun beforeBodyWrite(
         body: Any?,
@@ -46,15 +66,26 @@ class ResponseBodyAdviceDataVersion(
 
         val isDownload = response.headers.getFirst(HttpHeaders.CONTENT_DISPOSITION)?.startsWith("attachment") ?: false
 
+        request.uri.host
+
         return when {
             body is LapisResponse<*> && isDownload -> body.data
-            body is LapisResponse<*> -> LapisResponse(body.data, getLapisInfo())
-            body is LapisErrorResponse -> LapisErrorResponse(body.error, getLapisInfo())
+            body is LapisResponse<*> -> LapisResponse(body.data, getLapisInfo(request))
+            body is LapisErrorResponse -> LapisErrorResponse(body.error, getLapisInfo(request))
             else -> body
         }
     }
 
-    private fun getLapisInfo() = LapisInfo(dataVersion.dataVersion, requestIdContext.requestId)
+    private fun getLapisInfo(request: ServerHttpRequest) =
+        LapisInfo(
+            dataVersion = dataVersion.dataVersion,
+            requestId = requestIdContext.requestId,
+            requestInfo = "${databaseConfig.schema.instanceName} on ${request.uri.host} at ${now()}",
+        )
+
+    private fun now(): String {
+        return Clock.System.now().toLocalDateTime(TimeZone.UTC).toString()
+    }
 
     override fun supports(
         returnType: MethodParameter,

--- a/lapis2/src/main/resources/logback.xml
+++ b/lapis2/src/main/resources/logback.xml
@@ -1,6 +1,35 @@
 <configuration>
 
-    <property name="PATTERN" value="%date %level [%thread] [%X{RequestId}] %class: %message%n"/>
+    <property name="LOG_FILE" value="LAPIS"/>
+    <property name="STATISTICS_LOG_FILE" value="statistics"/>
+    <property name="LOG_DIR" value="logs"/>
+    <property name="PATTERN" value="%date %level [%thread] %class: %message%n"/>
+
+    <appender name="RollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${LOG_FILE}.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>${PATTERN}</Pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/archived/${LOG_FILE}-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>10GB</maxFileSize>
+            <maxHistory>0</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="StatisticsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${STATISTICS_LOG_FILE}.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%message%n</Pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/archived/${STATISTICS_LOG_FILE}-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>10GB</maxFileSize>
+            <maxHistory>0</maxHistory>
+        </rollingPolicy>
+    </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
@@ -10,17 +39,17 @@
 
     <root level="info">
         <appender-ref ref="RollingFile"/>
+        <appender-ref ref="STDOUT"/>
     </root>
 
     <logger name="org.springframework.web.filter.CommonsRequestLoggingFilter" level="debug" additivity="false">
         <appender-ref ref="RollingFile"/>
+        <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="info">
-        <appender-ref ref="STDOUT"/>
-    </root>
-
     <logger name="StatisticsLogger" level="info" additivity="false">
+        <appender-ref ref="RollingFile"/>
+        <appender-ref ref="StatisticsRollingFile"/>
         <appender-ref ref="STDOUT"/>
     </logger>
 


### PR DESCRIPTION
resolves #692

I also included a link to GitHub issues in the LAPIS responses and some info that should help us look for the correct log files. The info is included in all responses, but will be most helpful in analysing error messages. Responses will look like this: 
```json
{
    "error": {
        "type": "about:blank",
        "title": "Internal Server Error",
        "status": 500,
        "detail": "Could not connect to silo: class java.net.ConnectException null"
    },
    "info": {
        "dataVersion": null,
        "requestId": "dfb342ea-3607-4caf-b35e-9aba75d06f81",
        "requestInfo": "sars_cov-2_minimal_test_config on localhost at 2024-04-04T12:14:49.420620237",
        "reportTo": "Please report to https://github.com/GenSpectrum/LAPIS/issues in case you encounter any unexpected issues.Please include the request ID and the requestInfo in your report."
    }
}
``` 

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
