### PR TITLE
fix(lapis2): prefer zstd over gzip

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CompressionFilter.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/controller/CompressionFilter.kt
@@ -65,8 +65,8 @@ enum class Compression(
                 .map { it.trim() }
 
             return when {
-                headersList.contains(GZIP.value) -> GZIP
                 headersList.contains(ZSTD.value) -> ZSTD
+                headersList.contains(GZIP.value) -> GZIP
                 else -> null
             }
         }


### PR DESCRIPTION
resolves #738

Chrome now supports zstd compression, so it will set `Accept-Encoding: gzip, deflate, br, zstd`. In that case, we should prefer zstd, because it's usually faster and has better compression ratios.

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
