### PR TITLE
chore(root): disable body-max-line-length commit lint

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -18,7 +18,7 @@ const Configuration = {
                 "root", // used by dependabot to update the root package.json
             ]
         ],
-        "body-max-line-length": [RuleConfigSeverity.Error, "always", 200],
+        "body-max-line-length": [RuleConfigSeverity.Disabled],
     }
 };
 


### PR DESCRIPTION
dependabot sometimes creates very long lines in commit messages. Let's just ignore it.

See https://github.com/GenSpectrum/LAPIS/pull/753.

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
