### PR TITLE
chore(lapis2): add commit tags to images

### DIFF
--- a/.github/workflows/lapis2.yml
+++ b/.github/workflows/lapis2.yml
@@ -121,6 +121,7 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=commit-
 
       - name: Get LAPIS Branch Tag
         id: lapisBranchTag


### PR DESCRIPTION
resolves #678

This should add commit-hash-based tags to images 