### PR TITLE
chore(github-actions): replace deprecated grad-build-action

### DIFF
--- a/.github/workflows/lapis2.yml
+++ b/.github/workflows/lapis2.yml
@@ -16,12 +16,12 @@ jobs:
           java-version: '21'
           distribution: 'adopt'
       - name: Execute Tests
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: test
           build-root-directory: lapis2
       - name: Check Format And Lint
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: ktlintCheck
           build-root-directory: lapis2
@@ -80,13 +80,13 @@ jobs:
           node-version: lts/*
 
       - name: Build OpenAPI Spec
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: generateOpenApiDocs
           build-root-directory: lapis2
 
       - name: Build OpenAPI Spec Protected
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: generateOpenApiDocs -PopennessLevel=protected
           build-root-directory: lapis2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Execute tests
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: test
           build-root-directory: server


### PR DESCRIPTION
The tests show a notice:

> Deprecation warnings
> This job uses deprecated functionality from the gradle/gradle-build-action action. Follow the links for upgrade details.
> 
>     [The action `gradle/gradle-build-action` has been replaced by `gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)
>     [Using the action to execute Gradle via the `arguments` parameter is deprecated](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated)

I followed:
https://github.com/gradle/actions/blob/90f1de055606f0041bed57fdbee974a43650e639/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
