### PR TITLE
fix(lapis2-docs): relative links must not end with a `/`

### DIFF
--- a/lapis2-docs/src/components/FiltersTable/FiltersTable.astro
+++ b/lapis2-docs/src/components/FiltersTable/FiltersTable.astro
@@ -32,7 +32,7 @@ const multiSegmented = isMultiSegmented(referenceGenomes);
                         {filter.type === 'pango_lineage' ? (
                             <>
                                 See
-                                <BaseAwareLink href='/concepts/pango-lineage-query/'>Pango lineage query</BaseAwareLink>
+                                <BaseAwareLink href='/concepts/pango-lineage-query'>Pango lineage query</BaseAwareLink>
                             </>
                         ) : (
                             filter.description
@@ -46,7 +46,7 @@ const multiSegmented = isMultiSegmented(referenceGenomes);
             <td>list of strings</td>
             <td>
                 See
-                <BaseAwareLink href='/concepts/mutation-filters/'>mutation filters</BaseAwareLink>
+                <BaseAwareLink href='/concepts/mutation-filters'>mutation filters</BaseAwareLink>
             </td>
         </tr>
         <tr>
@@ -54,7 +54,7 @@ const multiSegmented = isMultiSegmented(referenceGenomes);
             <td>list of strings</td>
             <td>
                 See
-                <BaseAwareLink href='/concepts/mutation-filters/'>mutation filters</BaseAwareLink>
+                <BaseAwareLink href='/concepts/mutation-filters'>mutation filters</BaseAwareLink>
             </td>
         </tr>
         <tr>

--- a/lapis2-docs/src/content/docs/concepts/pango-lineage-query.mdx
+++ b/lapis2-docs/src/content/docs/concepts/pango-lineage-query.mdx
@@ -12,7 +12,7 @@ Pango lineage names inherit the hierarchical nature of genetic lineages. For exa
 More information about the pango nomenclature can be found on the website of the
 [Pango network](https://www.pango.network/).
 
-With the pangoLineage filter<OnlyIf condition={hasFeature('sarsCoV2VariantQuery')}> and in [variant queries](../concepts/variant-query/)</OnlyIf>,
+With the pangoLineage filter<OnlyIf condition={hasFeature('sarsCoV2VariantQuery')}> and in [variant queries](../concepts/variant-query)</OnlyIf>,
 it is possible to not only filter for a very specific lineage but also to include its sub-lineages.
 To include sub-lineages, add a `*` at the end.
 For example, writing B.1.351 will only give samples of B.1.351.

--- a/lapis2-docs/src/content/docs/concepts/request-methods.mdx
+++ b/lapis2-docs/src/content/docs/concepts/request-methods.mdx
@@ -56,7 +56,7 @@ example code for doing it with curl and from R and Python:
 
 :::note
 This is a general example and will only work on instances that have the fields `region`, `country`, and `date`.
-Check out the [fields](../references/fields/) and [filters](../references/filters/) page to see information about this instance.
+Check out the [fields](../references/fields) and [filters](../references/filters) page to see information about this instance.
 :::
 
 ## URL Encoded Form Data

--- a/lapis2-docs/src/content/docs/concepts/response-format.mdx
+++ b/lapis2-docs/src/content/docs/concepts/response-format.mdx
@@ -4,7 +4,7 @@ description: Response format
 ---
 
 The response format is tailored to each specific endpoint.
-To view the response format for a particular endpoint, please visit our [Swagger UI](../references/open-api-definition/).
+To view the response format for a particular endpoint, please visit our [Swagger UI](../references/open-api-definition).
 Once there, select the endpoint of interest and scroll down to the "Responses" section.
 A '200' response code indicates a successful request, while any other code signifies an error.
 
@@ -30,5 +30,5 @@ Fields marked with an asterisk (\*) are always included in the response; unmarke
 
 :::note
 Every response, regardless of format, includes the data version as it is crucial information. For more details, visit the
-[data versions page](../concepts/data-versions/).
+[data versions page](../concepts/data-versions).
 :::

--- a/lapis2-docs/src/content/docs/concepts/variant-query.mdx
+++ b/lapis2-docs/src/content/docs/concepts/variant-query.mdx
@@ -48,14 +48,14 @@ Get the sequences that fulfill exactly 2 out of 4 conditions:
 [exactly-2-of: 123A & 234T, !234T, S:345- | S:346-, [2-of: 222T, 333G, 444A, 555C]]
 ```
 
-For SARS-CoV-2, it is also possible to use [Pango lineage queries](../concepts/pango-lineage-query/) (either called by pangolin
+For SARS-CoV-2, it is also possible to use [Pango lineage queries](../concepts/pango-lineage-query) (either called by pangolin
 or by Nextclade) and filter by Nextstrain clades:
 
 ```
 BA.5* | nextcladePangoLineage:BA.5* | nextstrainClade:22B
 ```
 
-LAPIS supports a ternary logic to query [ambiguous nucleotide symbols](../concepts/ambiguous-symbols/).
+LAPIS supports a ternary logic to query [ambiguous nucleotide symbols](../concepts/ambiguous-symbols).
 
 ```
 MAYBE(123W)

--- a/lapis2-docs/src/content/docs/getting-started/introduction.mdx
+++ b/lapis2-docs/src/content/docs/getting-started/introduction.mdx
@@ -20,7 +20,7 @@ to answer genomic epidemiological questions. Main features include:
     engine.
 
 :::tip
-To get started, you can use our [**interactive wizard**](./generate-your-request/) to generate your query.
+To get started, you can use our [**interactive wizard**](./generate-your-request) to generate your query.
 We provide code examples for Python and R.
 :::
 
@@ -43,5 +43,5 @@ If you have any trouble, feel free to reach out to us.
 
 :::note
 This documentation also includes a section about how to set up your own instance of LAPIS.
-Refer to [this tutorial](../maintainer-docs/tutorials/start-lapis-and-silo/) for a quick start guide.
+Refer to [this tutorial](../maintainer-docs/tutorials/start-lapis-and-silo) for a quick start guide.
 :::

--- a/lapis2-docs/src/content/docs/references/additional-request-properties.mdx
+++ b/lapis2-docs/src/content/docs/references/additional-request-properties.mdx
@@ -6,7 +6,7 @@ description: Request properties that are not sequence filters
 Most of the request properties are sequence filters.
 However, there are some properties that influence the response data in other ways.
 
-Check the [Swagger UI](../references/open-api-definition/) for the full specification.
+Check the [Swagger UI](../references/open-api-definition) for the full specification.
 
 ## Ordering The Results
 

--- a/lapis2-docs/src/content/docs/references/introduction.mdx
+++ b/lapis2-docs/src/content/docs/references/introduction.mdx
@@ -12,7 +12,7 @@ For instance, the `GET /sample/aggregated` endpoint returns the count of sequenc
 Every endpoint accepts [`GET` and `POST`](../concepts/request-methods) requests.
 Both methods yield identical data; however, the manner of providing the filter criteria differs.
 
-The various endpoints are listed in the [Open API / Swagger](../references/open-api-definition/) documentation,
+The various endpoints are listed in the [Open API / Swagger](../references/open-api-definition) documentation,
 which also offers a convenient testing interface via Swagger-UI.
 
 ## Filters
@@ -20,12 +20,12 @@ which also offers a convenient testing interface via Swagger-UI.
 The output from each endpoint can be refined using various parameters.
 For instance, to determine the number of sequences originating from Germany,
 you would use `GET /sample/aggregated?country=Germany`.
-The available filters are detailed in [Filters](../references/filters/),
-and you can experiment with them at [Open API / Swagger](../references/open-api-definition/).
+The available filters are detailed in [Filters](../references/filters),
+and you can experiment with them at [Open API / Swagger](../references/open-api-definition).
 
 ## Fields
 
 Fields allow you to dictate the grouping of the returned data.
 For example, to find out the number of sequences from each country,you would use `GET /sample/aggregated?fields=country`.
-The available fields are documented in [Fields](../references/fields/),
-and you can test them at [Open API / Swagger](../references/open-api-definition/).
+The available fields are documented in [Fields](../references/fields),
+and you can test them at [Open API / Swagger](../references/open-api-definition).

--- a/lapis2-docs/tests/docs.spec.ts
+++ b/lapis2-docs/tests/docs.spec.ts
@@ -154,6 +154,8 @@ async function clickOnNextButton(page: Page, indexOfCurrentPage: number) {
     }
 }
 
+const doesNotEndWithSlashRegex = /[^\/]$/;
+
 async function clickOnAllRelativeLinksInMainBody(page: Page) {
     const currentPageUrl = page.url();
 
@@ -162,6 +164,7 @@ async function clickOnAllRelativeLinksInMainBody(page: Page) {
         .locator('a[href]:not([href^="http://"]):not([href^="https://"])')
         .all();
     for (const relativeLink of relativeLinks) {
+        await expect(relativeLink).toHaveAttribute('href', doesNotEndWithSlashRegex);
         await relativeLink.click();
 
         const errorMessage = `Went to ${page.url()} from ${currentPageUrl}, but did not find target page.`;


### PR DESCRIPTION
Otherwise the following happens:
- Be on page, e.g. /references/filters
- Click on link that ends with slash, e.g. `../concepts/pango-lineage-query/`
- now you are on /concepts/pango-lineage-query/
- clicking another relative link, e.g. ``../concepts/variant-query` will result in wrong target, in this case /concepts/concepts/variant-query

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
