### PR TITLE
chore(github-actions): google-github-actions/release-please-action is deprecated

### DIFF
--- a/.github/workflows/release-lapis2.yml
+++ b/.github/workflows/release-lapis2.yml
@@ -20,7 +20,7 @@ jobs:
       checks: read
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'GenSpectrum/LAPIS' }}
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           path: .


### PR DESCRIPTION
Apparently https://github.com/google-github-actions/release-please-action is deprecated, they move it to https://github.com/googleapis/release-please-action.

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- ~~[ ] The implemented feature is covered by an appropriate test.~~
