### PR TITLE
feat(lapis2): clear cache when SILO is restarting

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
@@ -1,8 +1,10 @@
 package org.genspectrum.lapis.scheduler
 
 import mu.KotlinLogging
+import org.genspectrum.lapis.response.InfoData
 import org.genspectrum.lapis.silo.CachedSiloClient
 import org.genspectrum.lapis.silo.SILO_QUERY_CACHE_NAME
+import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -24,6 +26,11 @@ class DataVersionCacheInvalidator(
 
         val info = try {
             cachedSiloClient.callInfo()
+        } catch (e: SiloUnavailableException) {
+            log.debug { "Caught ${SiloUnavailableException::class.java} $e" }
+            InfoData(
+                dataVersion = "currently unavailable",
+            )
         } catch (e: Exception) {
             log.debug { "Failed to call info: $e" }
             return


### PR DESCRIPTION
Currently, LAPIS might still return cached data.

This was an accidental discovery while working on CoV Spectrum while SILO crashed.

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
