### PR TITLE
make maybe mutation queries case insensitive

### DIFF
--- a/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
+++ b/lapis2/src/main/antlr/org/genspectrum/lapis/model/variantqueryparser/VariantQuery.g4
@@ -9,7 +9,7 @@ expr:
   | expr '&' expr    # And
   | expr '|' expr    # Or
   | '(' expr ')'     # Parenthesis
-  | 'MAYBE(' expr ')' # Maybe
+  | M A Y B E '(' expr ')' # Maybe
   ;
 
 single:

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryFacade.kt
@@ -2,10 +2,14 @@ package org.genspectrum.lapis.model
 
 import VariantQueryLexer
 import VariantQueryParser
+import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
 import org.antlr.v4.runtime.tree.ParseTreeWalker
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.springframework.stereotype.Component
 
@@ -15,11 +19,27 @@ class VariantQueryFacade(val referenceGenomeSchema: ReferenceGenomeSchema) {
         val lexer = VariantQueryLexer(CharStreams.fromString(variantQuery))
         val tokens = CommonTokenStream(lexer)
         val parser = VariantQueryParser(tokens)
+        parser.removeErrorListeners()
+        parser.addErrorListener(ThrowingErrorListener())
+
         val listener = VariantQueryCustomListener(referenceGenomeSchema)
 
         val walker = ParseTreeWalker()
         walker.walk(listener, parser.start())
 
         return listener.getVariantQueryExpression()
+    }
+}
+
+class ThrowingErrorListener : BaseErrorListener() {
+    override fun syntaxError(
+        recognizer: Recognizer<*, *>?,
+        offendingSymbol: Any?,
+        line: Int,
+        charPositionInLine: Int,
+        message: String?,
+        exception: RecognitionException?,
+    ) {
+        throw BadRequestException("Failed to parse variant query (line $line:$charPositionInLine): $message.")
     }
 }

--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/request/MaybeMutationWrapper.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/request/MaybeMutationWrapper.kt
@@ -6,7 +6,7 @@ interface MaybeMutation<Self : MaybeMutation<Self>> {
     fun asMaybe(): Self
 }
 
-val MAYBE_REGEX = Regex("""^MAYBE\((?<mutationCandidate>.+)\)$""")
+val MAYBE_REGEX = Regex("""^MAYBE\((?<mutationCandidate>.+)\)$""", RegexOption.IGNORE_CASE)
 
 inline fun <reified T : MaybeMutation<T>> wrapWithMaybeMutationParser(
     mutationCandidate: String,

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -168,6 +168,16 @@ class VariantQueryFacadeTest {
     }
 
     @Test
+    fun `GIVEN a variantQuery with a mixed-case 'Maybe' expression THEN map should return 'Maybe' SiloQuery`() {
+        val variantQuery = "maYbE(T12C)"
+
+        val result = underTest.map(variantQuery)
+
+        val expectedResult = Maybe(NucleotideSymbolEquals(null, 12, "C"))
+        assertThat(result, equalTo(expectedResult))
+    }
+
+    @Test
     fun `given a variantQuery with a 'Pangolineage' expression then map should return the corresponding SiloQuery`() {
         val variantQuery = "A.1.2.3"
 

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -2,6 +2,7 @@ package org.genspectrum.lapis.model
 
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.config.ReferenceSequenceSchema
+import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.silo.AminoAcidInsertionContains
 import org.genspectrum.lapis.silo.AminoAcidSymbolEquals
 import org.genspectrum.lapis.silo.And
@@ -17,7 +18,9 @@ import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.StringEquals
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class VariantQueryFacadeTest {
     private val dummyReferenceGenomeSchema = ReferenceGenomeSchema(
@@ -485,6 +488,18 @@ class VariantQueryFacadeTest {
         assertThat(
             result,
             equalTo(PangoLineageEquals(NEXTCLADE_PANGO_LINEAGE_COLUMN, "jn.1", true)),
+        )
+    }
+
+    @Test
+    fun `GIVEN an invalid variant query THEN throw bad request exception`() {
+        val variantQuery = "nextcladePangoLineage:jn.1* thisIsInvalid"
+
+        val exception = assertThrows<BadRequestException> { underTest.map(variantQuery) }
+
+        assertThat(
+            exception.message,
+            `is`("Failed to parse variant query (line 1:28): mismatched input 't' expecting {<EOF>, '&', '|'}."),
         )
     }
 }

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidMutationTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidMutationTest.kt
@@ -89,6 +89,14 @@ class AminoAcidMutationTest {
                     AminoAcidMutation("gene1", 123, "A", maybe = true),
                 ),
                 Arguments.of(
+                    "\"maybe(gene1:G123A)\"",
+                    AminoAcidMutation("gene1", 123, "A", maybe = true),
+                ),
+                Arguments.of(
+                    "\"MayBe(gene1:G123A)\"",
+                    AminoAcidMutation("gene1", 123, "A", maybe = true),
+                ),
+                Arguments.of(
                     "\"gene1:*123A\"",
                     AminoAcidMutation("gene1", 123, "A", maybe = false),
                 ),

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/request/NucleotideMutationTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/request/NucleotideMutationTest.kt
@@ -92,6 +92,14 @@ class NucleotideMutationTest {
                     "\"MAYBE(123X)\"",
                     NucleotideMutation(null, 123, "X", maybe = true),
                 ),
+                Arguments.of(
+                    "\"maybe(123X)\"",
+                    NucleotideMutation(null, 123, "X", maybe = true),
+                ),
+                Arguments.of(
+                    "\"maYbE(123X)\"",
+                    NucleotideMutation(null, 123, "X", maybe = true),
+                ),
             )
 
         @JvmStatic

--- a/siloLapisTests/test/aggregated.spec.ts
+++ b/siloLapisTests/test/aggregated.spec.ts
@@ -116,6 +116,18 @@ describe('The /aggregated endpoint', () => {
     expect(resultJson.error.detail).to.include('Unknown field: notAField, known values are [primaryKey,');
   });
 
+  it('should return bad request for invalid variant query', async () => {
+    const urlParams = new URLSearchParams({
+      variantQuery: 'not a valid variant query',
+    });
+
+    const result = await getAggregated(urlParams);
+
+    expect(result.status).equals(400);
+    const resultJson = await result.json();
+    expect(resultJson.error.detail).to.include('Failed to parse variant query');
+  });
+
   it('should apply limit and offset', async () => {
     const resultWithLimit = await lapisClient.postAggregated1({
       aggregatedPostRequest: {


### PR DESCRIPTION
resolves #797

* Breaking change: throw "bad request" when there is unmatched variant query parser input
  * Stop logging unmatched parser input to stdout.
* make "maybe" case-insensitive in both, variant queries and normal mutation filters

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
