### PR TITLE
fix(lapis2): only accept a single variant query in a request

### DIFF
--- a/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis2/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -69,7 +69,7 @@ class SiloFilterExpressionMapper(
                 Filter.StringEquals -> mapToStringEqualsFilters(siloColumnName, values)
                 Filter.PangoLineage -> mapToPangoLineageFilter(siloColumnName, values)
                 Filter.DateBetween -> mapToDateBetweenFilter(siloColumnName, values)
-                Filter.VariantQuery -> mapToVariantQueryFilter(values[0].values[0])
+                Filter.VariantQuery -> mapToVariantQueryFilter(values)
                 Filter.IntEquals -> mapToIntEqualsFilter(siloColumnName, values)
                 Filter.IntBetween -> mapToIntBetweenFilter(siloColumnName, values)
                 Filter.FloatEquals -> mapToFloatEqualsFilter(siloColumnName, values)
@@ -189,9 +189,17 @@ class SiloFilterExpressionMapper(
         },
     )
 
-    private fun mapToVariantQueryFilter(variantQuery: String?): SiloFilterExpression {
+    private fun mapToVariantQueryFilter(values: List<SequenceFilterValue>): SiloFilterExpression {
+        if (values[0].values.size != 1) {
+            throw BadRequestException(
+                "variantQuery must have exactly one value, found ${values[0].values.size} values.",
+            )
+        }
+
+        val variantQuery = values[0].values.single()
+
         if (variantQuery.isNullOrBlank()) {
-            throw BadRequestException("variantQuery must not be empty")
+            throw BadRequestException("variantQuery must not be empty, got '$variantQuery'")
         }
 
         return variantQueryFacade.map(variantQuery)

--- a/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis2/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -400,6 +400,26 @@ class SiloFilterExpressionMapperTest {
     }
 
     @Test
+    fun `GIVEN a query with empty variantQueries array THEN it should throw a bad request error`() {
+        val filterParameter = DummySequenceFilters(
+            mapOf("variantQuery" to emptyList()),
+        )
+
+        val exception = assertThrows<BadRequestException> { underTest.map(filterParameter) }
+        assertThat(exception.message, containsString("variantQuery must have exactly one value, found 0 values."))
+    }
+
+    @Test
+    fun `GIVEN a query with multiple variantQueries THEN it should throw a bad request error`() {
+        val filterParameter = DummySequenceFilters(
+            mapOf("variantQuery" to listOf("A123T", "C123T")),
+        )
+
+        val exception = assertThrows<BadRequestException> { underTest.map(filterParameter) }
+        assertThat(exception.message, containsString("variantQuery must have exactly one value, found 2 values."))
+    }
+
+    @Test
     fun `given a query with a variantQuery alongside nucleotide mutations then it should throw an error`() {
         val filterParameter = DummySequenceFilters(
             mapOf("variantQuery" to listOf("A123T")),

--- a/siloLapisTests/test/aggregated.spec.ts
+++ b/siloLapisTests/test/aggregated.spec.ts
@@ -128,6 +128,18 @@ describe('The /aggregated endpoint', () => {
     expect(resultJson.error.detail).to.include('Failed to parse variant query');
   });
 
+  it('should return bad request when sending multiple values for variant query', async () => {
+    const urlParams = new URLSearchParams();
+    urlParams.append('variantQuery', '123A');
+    urlParams.append('variantQuery', '123G');
+
+    const result = await getAggregated(urlParams);
+
+    expect(result.status).equals(400);
+    const resultJson = await result.json();
+    expect(resultJson.error.detail).to.include('variantQuery must have exactly one value');
+  });
+
   it('should apply limit and offset', async () => {
     const resultWithLimit = await lapisClient.postAggregated1({
       aggregatedPostRequest: {


### PR DESCRIPTION
Together with #797 this should fix the reported issue.

resolves #798

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
