### PR TITLE
feat(lapis2): Use entrypoint.sh as entrypoint in dockerfile to allow passing JVM_OPTS

### DIFF
--- a/lapis2/.dockerignore
+++ b/lapis2/.dockerignore
@@ -4,3 +4,4 @@
 !gradlew
 !build.gradle
 !settings.gradle
+!entrypoint.sh

--- a/lapis2/Dockerfile
+++ b/lapis2/Dockerfile
@@ -12,15 +12,12 @@ WORKDIR /workspace
 
 COPY --from=build /workspace/build/libs/*.jar app.jar
 
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
 EXPOSE 8080
 
-ENTRYPOINT [ \
-    "java", \
-    "-jar", \
-    "app.jar", \
-    "--referenceGenomeFilename=./reference_genomes.json", \
-    "--spring.profiles.active=docker" \
-    ]
+ENTRYPOINT ["./entrypoint.sh"]
 
-LABEL org.opencontainers.image.source="https://github.com/GenSpectrum/LAPIS"
+LABEL org.opencontainers.image.source="https://github.com/GenSpectrum/LAPIS/lapis2"
 LABEL org.opencontainers.image.description="Lightweight API for Sequences: An API, a query engine, and a database schema for genomic sequences"

--- a/lapis2/Dockerfile
+++ b/lapis2/Dockerfile
@@ -6,7 +6,7 @@ COPY . ./
 
 RUN ./gradlew bootJar
 
-FROM openjdk:21-slim
+FROM eclipse-temurin:21-alpine
 
 WORKDIR /workspace
 
@@ -20,7 +20,7 @@ ENTRYPOINT [ \
     "app.jar", \
     "--referenceGenomeFilename=./reference_genomes.json", \
     "--spring.profiles.active=docker" \
-]
+    ]
 
 LABEL org.opencontainers.image.source="https://github.com/GenSpectrum/LAPIS"
 LABEL org.opencontainers.image.description="Lightweight API for Sequences: An API, a query engine, and a database schema for genomic sequences"

--- a/lapis2/entrypoint.sh
+++ b/lapis2/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Takes JVM_OPTS as environment variable and passes it to the JVM
+JVM_OPTS=${JVM_OPTS:-}
+ARGS="${*}"
+
+GENERAL_OPTS="-jar app.jar \
+    --spring.profiles.active=docker \
+    --referenceGenomeFilename=./reference_genomes.json \
+    $ARGS"
+
+if [ -n "$JVM_OPTS" ]; then
+    CMD="java $JVM_OPTS $GENERAL_OPTS"
+else
+    CMD="java $GENERAL_OPTS"
+fi
+echo Running application with command:
+echo "$CMD"
+$CMD


### PR DESCRIPTION
- **chore(lapis2): use eclipse-temurin instead of deprecated openjdk image**
- **feat(lapis2): use entrypoint.sh to allow passing JVM_OPTS through env variable**

resolves #821 