### PR TITLE
docs(root): improve README, try to focus more on potential users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,57 @@
 # Lightweight API for Sequences (LAPIS)
 
-This is a generalized Lightweight API for Sequences. It uses [SILO](https://github.com/GenSpectrum/LAPIS-SILO) as
-database for storing and querying the sequence data.
+**LAPIS** (**L**ightweight **API** for **S**equences) is a webservice for querying genomic sequences.
+It is designed for pathogen data to answer genomic epidemiological questions.
+Main features include:
 
-You can find the code for LAPIS in the `lapis` directory, the documentation for LAPIS in the `lapis-docs` directory, and
-the end-to-end tests in the `lapis-e2e` directory.
+* **Data retrieval**: You can download sequences, metadata, alignments, translations, and annotation data.
+* **Data aggregation**: You can flexibly group and aggregate sequences
+  (e.g., to find out the number of sequences per country over time)
+* **Powerful filters**: You can filter by metadata and combinations of mutations.
+  It is possible to specify complex filter conditions using Boolean logic.
+* **Easy to use**: It is a simple HTTP/REST API (application programming interface).
+  For most cases, you can query it just by typing a URL into your browser.
+  It can also be called from any programming language.
+* **Many output formats**: You can download the metadata and aggregated data as JSON, CSV, or TSV.
+  Sequences are provided as FASTA.
+* **Very fast**: LAPIS was originally developed to query SARS-CoV-2 sequences
+  and, therefore, capable to process millions of sequences efficiently.
+  It uses [SILO](https://github.com/GenSpectrum/LAPIS-SILO) as its data query engine.
+
+### Hosting LAPIS yourself
+
+LAPIS is designed to be configurable to make analysis of genomic data available to a wide range of users.
+It is possible to host your own instance of LAPIS and to configure it to your needs.
+We want to make it as easy as possible to set up your own instance of LAPIS.
+If you have any trouble, feel free to reach out to us.
+We are happy to help!
 
 ## OpenAPI documentation
 
-The openApi documentation is generated per LAPIS instance from the provided config.
-
 The swagger ui is available at `url.to.lapis:<port>/swagger-ui.html`.
+It will help you to explore the LAPIS API and to test it interactively.
+
+The openApi documentation is generated per LAPIS instance from the provided config.
 
 The OpenAPI specification is available at `url.to.lapis:<port>/api-docs` (in JSON format) or at
 `url.to.lapis:<port>/api-docs.yaml` (in YAML format).
+
+## SILO Compatibility
+
+This table shows which LAPIS version is required for which SILO version.
+Higher versions will also work if they are not specified in the table.
+
+| LAPIS | SILO  |
+|-------|-------|
+| 0.2.1 | 0.2.0 |
+| 0.1   | 0.1.0 |
+
+## Repository Structure
+
+* `lapis`: The code for [LAPIS](lapis/README.md).
+* `lapis-docs`: The [documentation website](lapis-docs/README.md) for LAPIS.
+* `lapis-e2e`: The end-to-end tests for LAPIS.
+  Check the tests if you are looking for example queries, e.g. [here](lapis-e2e/test/aggregatedQueries).
 
 ## Creating A Release
 
@@ -29,12 +67,3 @@ Creating a release means:
 The changelog and the version number are determined by the commit messages.
 Therefore, commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
 Also refer to the Release Please documentation for more information on how to write commit messages.
-
-## SILO Compatibility
-
-This table shows which LAPIS version is required for which SILO version:
-
-| LAPIS | SILO  |
-|-------|-------|
-| 0.2.1 | 0.2.0 |
-| 0.1   | 0.1.0 |

--- a/lapis-docs/README.md
+++ b/lapis-docs/README.md
@@ -1,9 +1,30 @@
 # LAPIS Documentation
 
-This documentation is a website built with
-[Starlight](https://starlight.astro.build/) and [Astro](https://docs.astro.build).
+A documentation website tailored to your LAPIS instance.
+
+## Features
+
+* **Customizable**: The documentation will generate content based on your LAPIS configuration.
+* **Request Generator**: An interactive wizard to help users getting started using your LAPIS instance.
+* **User documentation**: Detailed information on how to use the LAPIS API, explaining concepts and providing examples.
+* **Maintainer documentation**: Information on how to deploy and maintain your own LAPIS instance.
+  If you want to get started setting up your own LAPIS instance,
+  we recommend setting up this documentation first and iterating from there.
+* **Config Generator**: An interactive wizard to help you generate and modify the configuration of your LAPIS instance.
+* **Architecture Overview**: An overview of the LAPIS architecture and how it interacts with SILO.
+
+## Quickstart
+
+```shell
+IMAGE=ghcr.io/genspectrum/lapis-docs docker compose -f test-docker-compose.yml up
+```
+
+Visit http://localhost:4321/docs/ in your browser.
 
 ## Commands
+
+This documentation is a website built with
+[Starlight](https://starlight.astro.build/) and [Astro](https://docs.astro.build).
 
 | Command                   | Action                                           |
 |:--------------------------|:-------------------------------------------------|
@@ -29,11 +50,13 @@ Thus, the documentation can only be built at deployment time (i.e. when the conf
 We provide Docker images that can be used to build the documentation, and then serve it.
 
 See [the Docker compose file](./test-docker-compose.yml) for an example of how to use the Docker image:
+
 * The database config must be mounted to `/config/database_config.yaml`.
-* The environment variable `LAPIS_URL` must be set to the URL of the backing LAPIS instance. 
-This is used to generate links to that instance.
-* Astro recommends to set the [`site` config option](https://docs.astro.build/en/reference/configuration-reference/#site).
-This can be done via the environment variable `ASTRO_SITE`.
+* The environment variable `LAPIS_URL` must be set to the URL of the backing LAPIS instance.
+  This is used to generate links to that instance.
+* Astro recommends to set
+  the [`site` config option](https://docs.astro.build/en/reference/configuration-reference/#site).
+  This can be done via the environment variable `ASTRO_SITE`.
 
 ```shell
 IMAGE=ghcr.io/genspectrum/lapis-docs docker compose -f test-docker-compose.yml up

--- a/lapis-docs/test-docker-compose.yml
+++ b/lapis-docs/test-docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   lapis-docs:
     image: ${IMAGE}

--- a/lapis/README.md
+++ b/lapis/README.md
@@ -1,26 +1,7 @@
-## Local Setup
+# LAPIS
 
-Run tests:
-
-```bash
-./gradlew test
-```
-
-When running LAPIS, you need to pass the following arguments:
-
-* the SILO url `--silo.url=http://<url>:<port>`,
-* the path to the database config `--lapis.databaseConfig.path=<path/to/config>`,
-* the path to the reference genome `--referenceGenomeFilename=<path/to/referenceGenome>`
-  
-e.g. when running via gradle:
-
-```bash
-./gradlew bootRun --args='--silo.url=http://<url>:<port> --lapis.databaseConfig.path=<path/to/config> --referenceGenomeFilename=<path/to/referenceGenome>
-```
-
-Optionally, you can pass:
-* `lapis.docs.url` to make the "Documentation" link on the landing page (`/`) point to your self-hosted [lapis docs](../lapis-docs/README.md).
-  If `lapis.docs.url` is not set or empty, then the "Documentation" link will not be shown.
+This directory contains the LAPIS code.
+LAPIS is a REST API written in Kotlin using Spring Boot.
 
 ## Running the Docker image
 
@@ -31,6 +12,20 @@ Use Docker Compose to run SILO and LAPIS:
 ```bash
 LAPIS_TAG=latest SILO_TAG=latest DATABASE_CONFIG=path/to/config docker compose up
 ```
+
+## Configuration
+
+When running LAPIS, you need to pass the following arguments:
+
+* the SILO url `--silo.url=http://<url>:<port>`
+* the path to the database config `--lapis.databaseConfig.path=<path/to/config>`,
+ in the Docker image this is already set to `/workspace/database_config.yaml`.
+* the path to the reference genome `--referenceGenomeFilename=<path/to/referenceGenome>`
+  in the Docker image this is already set to `/workspace/reference_genomes.yaml`.
+
+Optionally, you can pass:
+* `lapis.docs.url` to make the "Documentation" link on the landing page (`/`) point to your self-hosted [lapis docs](../lapis-docs/README.md).
+  If `lapis.docs.url` is not set or empty, then the "Documentation" link will not be shown.
 
 ### Operating LAPIS behind a proxy
 
@@ -76,4 +71,18 @@ spring.cache.type=none
 or by providing the command line argument:
 ```bash
 --spring.cache.type=none
+```
+
+## Local Setup
+
+Run tests:
+
+```bash
+./gradlew test
+```
+
+e.g. when running via gradle:
+
+```bash
+./gradlew bootRun --args='--silo.url=http://<url>:<port> --lapis.databaseConfig.path=<path/to/config> --referenceGenomeFilename=<path/to/referenceGenome>
 ```


### PR DESCRIPTION
I tried to improve the READMEs with regard to the release, focussing more on users that should understand what LAPIS is and how to use it.