### PR TITLE
[DO NOT MERGE] feature branch regex

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -27,7 +27,7 @@ import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
-import org.genspectrum.lapis.silo.StringEquals
+import org.genspectrum.lapis.silo.StringSearch
 import org.genspectrum.lapis.silo.True
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -66,7 +66,7 @@ class SiloFilterExpressionMapper(
         val filterExpressions = allowedSequenceFiltersWithType.map { (key, values) ->
             val (siloColumnName, filter) = key
             when (filter) {
-                Filter.StringEquals -> mapToStringEqualsFilters(siloColumnName, values)
+                Filter.StringSearch -> mapToStringSearchFilters(siloColumnName, values)
                 Filter.PangoLineage -> mapToPangoLineageFilter(siloColumnName, values)
                 Filter.DateBetween -> mapToDateBetweenFilter(siloColumnName, values)
                 Filter.VariantQuery -> mapToVariantQueryFilter(values)
@@ -103,7 +103,7 @@ class SiloFilterExpressionMapper(
             is SequenceFilterFieldType.DateTo -> Pair(type.associatedField, Filter.DateBetween)
             SequenceFilterFieldType.Date -> Pair(field.name, Filter.DateBetween)
             SequenceFilterFieldType.PangoLineage -> Pair(field.name, Filter.PangoLineage)
-            SequenceFilterFieldType.String -> Pair(field.name, Filter.StringEquals)
+            SequenceFilterFieldType.String -> Pair(field.name, Filter.StringSearch)
             SequenceFilterFieldType.VariantQuery -> Pair(field.name, Filter.VariantQuery)
             SequenceFilterFieldType.Int -> Pair(field.name, Filter.IntEquals)
             is SequenceFilterFieldType.IntFrom -> Pair(type.associatedField, Filter.IntBetween)
@@ -167,10 +167,10 @@ class SiloFilterExpressionMapper(
         }
     }
 
-    private fun mapToStringEqualsFilters(
+    private fun mapToStringSearchFilters(
         siloColumnName: SequenceFilterFieldName,
         values: List<SequenceFilterValue>,
-    ) = Or(values[0].values.map { StringEquals(siloColumnName, it) })
+    ) = Or(values[0].values.map { StringSearch(siloColumnName, it) })
 
     private fun mapToBooleanEqualsFilters(
         siloColumnName: SequenceFilterFieldName,
@@ -425,7 +425,7 @@ class SiloFilterExpressionMapper(
     }
 
     private enum class Filter {
-        StringEquals,
+        StringSearch,
         PangoLineage,
         DateBetween,
         VariantQuery,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -34,7 +34,7 @@ import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
-import org.genspectrum.lapis.silo.StringEquals
+import org.genspectrum.lapis.silo.StringSearch
 
 private val log = KotlinLogging.logger { }
 
@@ -173,11 +173,11 @@ class VariantQueryCustomListener(val referenceGenomeSchema: ReferenceGenomeSchem
             NEXTSTRAIN_CLADE_RECOMBINANT -> ctx.text.lowercase()
             else -> ctx.text.uppercase()
         }
-        expressionStack.addLast(StringEquals(NEXTSTRAIN_CLADE_COLUMN, value))
+        expressionStack.addLast(StringSearch(NEXTSTRAIN_CLADE_COLUMN, value))
     }
 
     override fun enterGisaidCladeNomenclature(ctx: GisaidCladeNomenclatureContext) {
-        expressionStack.addLast(StringEquals(GISAID_CLADE_COLUMN, ctx.text.uppercase()))
+        expressionStack.addLast(StringSearch(GISAID_CLADE_COLUMN, ctx.text.uppercase()))
     }
 
     private fun addPangoLineage(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -214,7 +214,7 @@ sealed class SiloAction<ResponseType>(
 
 sealed class SiloFilterExpression(val type: String)
 
-data class StringEquals(val column: String, val value: String?) : SiloFilterExpression("StringEquals")
+data class StringSearch(val column: String, val searchExpression: String) : SiloFilterExpression("StringSearch")
 
 data class BooleanEquals(val column: String, val value: Boolean?) : SiloFilterExpression("BooleanEquals")
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -29,7 +29,7 @@ import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
-import org.genspectrum.lapis.silo.StringEquals
+import org.genspectrum.lapis.silo.StringSearch
 import org.genspectrum.lapis.silo.True
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
@@ -548,8 +548,8 @@ class SiloFilterExpressionMapperTest {
                         "other_metadata" to listOf("def"),
                     ),
                     And(
-                        Or(StringEquals("some_metadata", "ABC")),
-                        Or(StringEquals("other_metadata", "def")),
+                        Or(StringSearch("some_metadata", "ABC")),
+                        Or(StringSearch("other_metadata", "def")),
                     ),
                 ),
                 Arguments.of(
@@ -557,7 +557,7 @@ class SiloFilterExpressionMapperTest {
                         "some_metadata" to listOf(null),
                     ),
                     And(
-                        Or(StringEquals("some_metadata", null)),
+                        Or(StringSearch("some_metadata", null)),
                     ),
                 ),
                 Arguments.of(
@@ -589,8 +589,8 @@ class SiloFilterExpressionMapperTest {
                     And(
                         listOf(
                             Or(PangoLineageEquals("pangoLineage", "A.1.2.3", includeSublineages = false)),
-                            Or(StringEquals("some_metadata", "ABC")),
-                            Or(StringEquals("other_metadata", "DEF")),
+                            Or(StringSearch("some_metadata", "ABC")),
+                            Or(StringSearch("other_metadata", "DEF")),
                         ),
                     ),
                 ),
@@ -638,7 +638,7 @@ class SiloFilterExpressionMapperTest {
                     ),
                     And(
                         DateBetween("date", from = null, to = LocalDate.of(2021, 6, 3)),
-                        Or(StringEquals("some_metadata", "ABC")),
+                        Or(StringSearch("some_metadata", "ABC")),
                     ),
                 ),
                 Arguments.of(
@@ -659,7 +659,7 @@ class SiloFilterExpressionMapperTest {
                     ),
                     And(
                         NucleotideSymbolEquals(null, 300, "G"),
-                        Or(StringEquals("some_metadata", "ABC")),
+                        Or(StringSearch("some_metadata", "ABC")),
                     ),
                 ),
                 Arguments.of(
@@ -770,8 +770,8 @@ class SiloFilterExpressionMapperTest {
                     ),
                     And(
                         Or(
-                            StringEquals("some_metadata", "value1"),
-                            StringEquals("some_metadata", "value2"),
+                            StringSearch("some_metadata", "value1"),
+                            StringSearch("some_metadata", "value2"),
                         ),
                     ),
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -15,7 +15,7 @@ import org.genspectrum.lapis.silo.NucleotideInsertionContains
 import org.genspectrum.lapis.silo.NucleotideSymbolEquals
 import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.PangoLineageEquals
-import org.genspectrum.lapis.silo.StringEquals
+import org.genspectrum.lapis.silo.StringSearch
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
@@ -437,7 +437,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(NEXTSTRAIN_CLADE_COLUMN, "22B")))
+        assertThat(result, equalTo(StringSearch(NEXTSTRAIN_CLADE_COLUMN, "22B")))
     }
 
     @Test
@@ -447,7 +447,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(NEXTSTRAIN_CLADE_COLUMN, "22B")))
+        assertThat(result, equalTo(StringSearch(NEXTSTRAIN_CLADE_COLUMN, "22B")))
     }
 
     @Test
@@ -456,7 +456,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(NEXTSTRAIN_CLADE_COLUMN, "recombinant")))
+        assertThat(result, equalTo(StringSearch(NEXTSTRAIN_CLADE_COLUMN, "recombinant")))
     }
 
     @Test
@@ -466,7 +466,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(NEXTSTRAIN_CLADE_COLUMN, "recombinant")))
+        assertThat(result, equalTo(StringSearch(NEXTSTRAIN_CLADE_COLUMN, "recombinant")))
     }
 
     @Test
@@ -475,7 +475,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(GISAID_CLADE_COLUMN, "X")))
+        assertThat(result, equalTo(StringSearch(GISAID_CLADE_COLUMN, "X")))
     }
 
     @Test
@@ -485,7 +485,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(GISAID_CLADE_COLUMN, "X")))
+        assertThat(result, equalTo(StringSearch(GISAID_CLADE_COLUMN, "X")))
     }
 
     @Test
@@ -494,7 +494,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(StringEquals(GISAID_CLADE_COLUMN, "AB")))
+        assertThat(result, equalTo(StringSearch(GISAID_CLADE_COLUMN, "AB")))
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -60,7 +60,7 @@ class SiloClientTest(
 
         someQuery = SiloQuery(
             SiloAction.aggregated(),
-            StringEquals("theColumn", "a value that is difference for each test method: $counter"),
+            StringSearch("theColumn", "a value that is different for each test method: $counter"),
         )
         counter++
     }
@@ -83,7 +83,7 @@ class SiloClientTest(
                 ),
         )
 
-        val query = SiloQuery(SiloAction.aggregated(), StringEquals("theColumn", "theValue"))
+        val query = SiloQuery(SiloAction.aggregated(), StringSearch("theColumn", "theValue"))
         val result = underTest.sendQuery(query).toList()
 
         assertThat(
@@ -111,7 +111,7 @@ class SiloClientTest(
                 ),
         )
 
-        val query = SiloQuery(action, StringEquals("theColumn", "theValue"))
+        val query = SiloQuery(action, StringSearch("theColumn", "theValue"))
         val result = underTest.sendQuery(query).toList()
 
         assertThat(result, hasSize(2))
@@ -155,7 +155,7 @@ class SiloClientTest(
 
         val query = SiloQuery(
             SiloAction.genomicSequence(SequenceType.ALIGNED, "someSequenceName"),
-            StringEquals("theColumn", "theValue"),
+            StringSearch("theColumn", "theValue"),
         )
         val result = underTest.sendQuery(query).toList()
 
@@ -182,7 +182,7 @@ class SiloClientTest(
                 ),
         )
 
-        val query = SiloQuery(SiloAction.details(), StringEquals("theColumn", "theValue"))
+        val query = SiloQuery(SiloAction.details(), StringSearch("theColumn", "theValue"))
         val result = underTest.sendQuery(query).toList()
 
         assertThat(result, hasSize(2))

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -20,7 +20,7 @@ class SiloQueryTest {
 
     @Test
     fun `Query is correctly serialized to JSON`() {
-        val underTest = SiloQuery(SiloAction.aggregated(), StringEquals("theColumn", "theValue"))
+        val underTest = SiloQuery(SiloAction.aggregated(), StringSearch("theColumn", "theValue"))
 
         val result = objectMapper.writeValueAsString(underTest)
 
@@ -31,9 +31,9 @@ class SiloQueryTest {
                     "randomize": false
                 },
                 "filterExpression": {
-                    "type": "StringEquals",
+                    "type": "StringSearch",
                     "column": "theColumn",
-                    "value": "theValue"
+                    "searchExpression": "theValue"
                 }
             }
         """
@@ -352,22 +352,22 @@ class SiloQueryTest {
                     """,
                 ),
                 Arguments.of(
-                    StringEquals("theColumn", "theValue"),
+                    StringSearch("theColumn", "theValue"),
                     """
                         {
-                            "type": "StringEquals",
+                            "type": "StringSearch",
                             "column": "theColumn",
-                            "value": "theValue"
+                            "searchExpression": "theValue"
                         }
                     """,
                 ),
                 Arguments.of(
-                    StringEquals("theColumn", null),
+                    StringSearch("theColumn", null),
                     """
                         {
-                            "type": "StringEquals",
+                            "type": "StringSearch",
                             "column": "theColumn",
-                            "value": null
+                            "searchExpression": null
                         }
                     """,
                 ),
@@ -405,20 +405,20 @@ class SiloQueryTest {
                     """,
                 ),
                 Arguments.of(
-                    And(listOf(StringEquals("theColumn", "theValue"), StringEquals("theOtherColumn", "theOtherValue"))),
+                    And(listOf(StringSearch("theColumn", "theValue"), StringSearch("theOtherColumn", "theOtherValue"))),
                     """
                         {
                             "type": "And",
                             "children": [
                                 {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theColumn",
-                                "value": "theValue"
+                                "searchExpression": "theValue"
                                 },
                                 {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theOtherColumn",
-                                "value": "theOtherValue"
+                                "searchExpression": "theOtherValue"
                                 }
                             ]
                         }
@@ -551,47 +551,47 @@ class SiloQueryTest {
                     """,
                 ),
                 Arguments.of(
-                    Not(StringEquals("theColumn", "theValue")),
+                    Not(StringSearch("theColumn", "theValue")),
                     """
                         {
                             "type": "Not",
                             "child": {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theColumn",
-                                "value": "theValue"
+                                "searchExpression": "theValue"
                             }
                         }
                     """,
                 ),
                 Arguments.of(
-                    Or(listOf(StringEquals("theColumn", "theValue"), StringEquals("theOtherColumn", "theOtherValue"))),
+                    Or(listOf(StringSearch("theColumn", "theValue"), StringSearch("theOtherColumn", "theOtherValue"))),
                     """
                         {
                             "type": "Or",
                             "children": [
                                 {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theColumn",
-                                "value": "theValue"
+                                "searchExpression": "theValue"
                                 },
                                 {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theOtherColumn",
-                                "value": "theOtherValue"
+                                "searchExpression": "theOtherValue"
                                 }
                             ]
                         }
                     """,
                 ),
                 Arguments.of(
-                    Maybe(StringEquals("theColumn", "theValue")),
+                    Maybe(StringSearch("theColumn", "theValue")),
                     """
                         {
                             "type": "Maybe",
                             "child": {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theColumn",
-                                "value": "theValue"
+                                "searchExpression": "theValue"
                             }
                         }
                     """,
@@ -601,8 +601,8 @@ class SiloQueryTest {
                         2,
                         true,
                         listOf(
-                            StringEquals("theColumn", "theValue"),
-                            StringEquals("theOtherColumn", "theOtherValue"),
+                            StringSearch("theColumn", "theValue"),
+                            StringSearch("theOtherColumn", "theOtherValue"),
                         ),
                     ),
                     """
@@ -612,14 +612,14 @@ class SiloQueryTest {
                             "matchExactly": true,
                             "children": [
                                 {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theColumn",
-                                "value": "theValue"
+                                "searchExpression": "theValue"
                                 },
                                 {
-                                "type": "StringEquals",
+                                "type": "StringSearch",
                                 "column": "theOtherColumn",
-                                "value": "theOtherValue"
+                                "searchExpression": "theOtherValue"
                                 }
                             ]
                         }


### PR DESCRIPTION
resolves #750

This feature branch maps string fields from the API to SILO's StringSearch instead of StringEquals expressions

This is a breaking change as any search for a string field will now also assume the value to be a regex string, whereas before it was just a string that was compared against the column values with equality.

The problem with a permanent solution is that the [current api](https://lapis.cov-spectrum.org/gisaid/v2/swagger-ui/index.html#/lapis-controller/postDetails_1) just expects a pair of `"column": "value"`, where not specification of whether the filtering should be done with equality or regex matching is possible.

Possible solutions:
- Upon short consideration, it is expected that string columns are going to need not both types, but only one type of the filter expressions. E.g. author lists will generally be filtered with regexes, the primary key with equality. This could therefore be configured in the column declarations (i.e. in the database_config)
- Make LAPIS parse the `"value"`. If it is of the form `"regex({})"` / `"LIKE {}"`, we will regex-match it, if `"= {}"` we will compare with equality.
- Make LAPIS parse the `"column"`. If it is of the form `"{column}Match"`, we will regex-match, otherwise we will compare with equality.
- Change the API to take objects instead of one `"value"`

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
