### PR TITLE
feat(lapis): regex filtering for string columns #898

### DIFF
--- a/lapis-e2e/test/aggregated.spec.ts
+++ b/lapis-e2e/test/aggregated.spec.ts
@@ -151,6 +151,17 @@ describe('The /aggregated endpoint', () => {
     expect(resultJson.error.detail).to.include('variantQuery must have exactly one value');
   });
 
+  it('should return bad request when sending regex filter for field that does not allow it', async () => {
+    const urlParams = new URLSearchParams();
+    urlParams.append('region$regex', 'Euro');
+
+    const result = await getAggregated(urlParams);
+
+    expect(result.status).equals(400);
+    const resultJson = await result.json();
+    expect(resultJson.error.detail).to.include("'region$regex' is not a valid sequence filter");
+  });
+
   it('should apply limit and offset', async () => {
     const resultWithLimit = await lapisClient.postAggregated1({
       aggregatedPostRequest: {

--- a/lapis-e2e/test/aggregatedQueries/basicStringSearch.json
+++ b/lapis-e2e/test/aggregatedQueries/basicStringSearch.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "basic string search",
+  "lapisRequest": {
+    "division$regex": "Basel-(Land|Stadt)"
+  },
+  "expected": [
+    {
+      "count": 20
+    }
+  ]
+}

--- a/lapis-e2e/testData/multiSegmented/testDatabaseConfig.yaml
+++ b/lapis-e2e/testData/multiSegmented/testDatabaseConfig.yaml
@@ -4,10 +4,12 @@ schema:
   metadata:
     - name: primaryKey
       type: string
+      lapisAllowsRegexSearch: true
     - name: date
       type: date
     - name: country
       type: string
+      lapisAllowsRegexSearch: true
       generateIndex: true
   primaryKey: primaryKey
   dateToSortBy: date

--- a/lapis-e2e/testData/singleSegmented/protectedTestDatabaseConfig.yaml
+++ b/lapis-e2e/testData/singleSegmented/protectedTestDatabaseConfig.yaml
@@ -4,6 +4,7 @@ schema:
   metadata:
     - name: primaryKey
       type: string
+      lapisAllowsRegexSearch: true
     - name: date
       type: date
     - name: region
@@ -11,11 +12,13 @@ schema:
       generateIndex: true
     - name: country
       type: string
+      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: pangoLineage
       type: pango_lineage
     - name: division
       type: string
+      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: age
       type: int

--- a/lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml
+++ b/lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml
@@ -4,6 +4,7 @@ schema:
   metadata:
     - name: primaryKey
       type: string
+      lapisAllowsRegexSearch: true
     - name: date
       type: date
     - name: region
@@ -11,11 +12,13 @@ schema:
       generateIndex: true
     - name: country
       type: string
+      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: pangoLineage
       type: pango_lineage
     - name: division
       type: string
+      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: age
       type: int

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
@@ -15,7 +15,12 @@ data class DatabaseSchema(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class DatabaseMetadata(val name: String, val type: MetadataType, val valuesAreUnique: Boolean = false)
+data class DatabaseMetadata(
+    val name: String,
+    val type: MetadataType,
+    val valuesAreUnique: Boolean = false,
+    val lapisAllowsRegexSearch: Boolean = false,
+)
 
 enum class MetadataType {
     @JsonProperty("string")

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -43,6 +43,10 @@ private fun mapToSequenceFilterField(databaseMetadata: DatabaseMetadata) =
                 name = databaseMetadata.name,
                 type = SequenceFilterFieldType.String,
             ),
+            SequenceFilterField(
+                name = "${databaseMetadata.name}\$regex",
+                type = SequenceFilterFieldType.StringSearch(databaseMetadata.name),
+            ),
         )
 
         MetadataType.PANGO_LINEAGE -> listOf(
@@ -136,4 +140,6 @@ sealed class SequenceFilterFieldType(val openApiType: kotlin.String) {
     data class FloatFrom(val associatedField: SequenceFilterFieldName) : SequenceFilterFieldType("number")
 
     data class FloatTo(val associatedField: SequenceFilterFieldName) : SequenceFilterFieldType("number")
+
+    data class StringSearch(val associatedField: SequenceFilterFieldName) : SequenceFilterFieldType("string")
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -43,11 +43,16 @@ private fun mapToSequenceFilterField(databaseMetadata: DatabaseMetadata) =
                 name = databaseMetadata.name,
                 type = SequenceFilterFieldType.String,
             ),
-            SequenceFilterField(
-                name = "${databaseMetadata.name}\$regex",
-                type = SequenceFilterFieldType.StringSearch(databaseMetadata.name),
-            ),
-        )
+        ).let {
+            when (databaseMetadata.lapisAllowsRegexSearch) {
+                true -> it + SequenceFilterField(
+                    name = "${databaseMetadata.name}\$regex",
+                    type = SequenceFilterFieldType.StringSearch(databaseMetadata.name),
+                )
+
+                false -> it
+            }
+        }
 
         MetadataType.PANGO_LINEAGE -> listOf(
             SequenceFilterField(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -28,6 +28,7 @@ import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.genspectrum.lapis.silo.StringEquals
+import org.genspectrum.lapis.silo.StringSearch
 import org.genspectrum.lapis.silo.True
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -75,6 +76,7 @@ class SiloFilterExpressionMapper(
                 Filter.FloatEquals -> mapToFloatEqualsFilter(siloColumnName, values)
                 Filter.FloatBetween -> mapToFloatBetweenFilter(siloColumnName, values)
                 Filter.BooleanEquals -> mapToBooleanEqualsFilters(siloColumnName, values)
+                Filter.StringSearch -> mapToStringSearchFilters(siloColumnName, values)
             }
         }
 
@@ -103,6 +105,7 @@ class SiloFilterExpressionMapper(
             is SequenceFilterFieldType.DateTo -> Pair(type.associatedField, Filter.DateBetween)
             SequenceFilterFieldType.Date -> Pair(field.name, Filter.DateBetween)
             SequenceFilterFieldType.PangoLineage -> Pair(field.name, Filter.PangoLineage)
+            is SequenceFilterFieldType.StringSearch -> Pair(type.associatedField, Filter.StringSearch)
             SequenceFilterFieldType.String -> Pair(field.name, Filter.StringEquals)
             SequenceFilterFieldType.VariantQuery -> Pair(field.name, Filter.VariantQuery)
             SequenceFilterFieldType.Int -> Pair(field.name, Filter.IntEquals)
@@ -354,6 +357,11 @@ class SiloFilterExpressionMapper(
         )
     }
 
+    private fun mapToStringSearchFilters(
+        siloColumnName: SequenceFilterFieldName,
+        values: List<SequenceFilterValue>,
+    ) = Or(values[0].values.map { StringSearch(siloColumnName, it) })
+
     private inline fun <reified T : SequenceFilterFieldType> findFloatOfFilterType(
         dateRangeFilters: List<SequenceFilterValue>,
     ): Double? {
@@ -434,6 +442,7 @@ class SiloFilterExpressionMapper(
         FloatEquals,
         FloatBetween,
         BooleanEquals,
+        StringSearch,
     }
 
     private val variantQueryTypes = listOf(Filter.PangoLineage)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -272,6 +272,8 @@ data class FloatEquals(val column: String, val value: Double?) : SiloFilterExpre
 
 data class FloatBetween(val column: String, val from: Double?, val to: Double?) : SiloFilterExpression("FloatBetween")
 
+data class StringSearch(val column: String, val searchExpression: String?) : SiloFilterExpression("StringSearch")
+
 enum class SequenceType {
     @JsonProperty("Fasta")
     UNALIGNED,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/DummySequenceFilterFields.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/DummySequenceFilterFields.kt
@@ -23,6 +23,7 @@ val dummySequenceFilterFields = SequenceFilterFields(
         "dateFrom" to SequenceFilterFieldType.DateFrom(DATE_FIELD),
         PANGO_LINEAGE_FIELD to SequenceFilterFieldType.PangoLineage,
         "some_metadata" to SequenceFilterFieldType.String,
+        "some_metadata\$regex" to SequenceFilterFieldType.StringSearch("some_metadata"),
         "other_metadata" to SequenceFilterFieldType.String,
         "variantQuery" to SequenceFilterFieldType.VariantQuery,
         "intField" to SequenceFilterFieldType.Int,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
@@ -16,15 +16,22 @@ class SequenceFilterFieldsTest {
     }
 
     @Test
-    fun `given database config with a string field then contains a string field`() {
+    fun `given database config with a string field then contains a string field and string search field`() {
         val input = databaseConfigWithFields(listOf(DatabaseMetadata("fieldName", MetadataType.STRING)))
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
-        assertThat(underTest.fields, aMapWithSize(1))
+        assertThat(underTest.fields, aMapWithSize(2))
         assertThat(
             underTest.fields,
             hasEntry("fieldname", SequenceFilterField("fieldName", SequenceFilterFieldType.String)),
+        )
+        assertThat(
+            underTest.fields,
+            hasEntry(
+                "fieldname\$regex",
+                SequenceFilterField("fieldName\$regex", SequenceFilterFieldType.StringSearch("fieldName")),
+            ),
         )
     }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
@@ -16,8 +16,16 @@ class SequenceFilterFieldsTest {
     }
 
     @Test
-    fun `given database config with a string field then contains a string field and string search field`() {
-        val input = databaseConfigWithFields(listOf(DatabaseMetadata("fieldName", MetadataType.STRING)))
+    fun `given database config with a string field allowing regex then contains a string and string search field`() {
+        val input = databaseConfigWithFields(
+            listOf(
+                DatabaseMetadata(
+                    name = "fieldName",
+                    type = MetadataType.STRING,
+                    lapisAllowsRegexSearch = true,
+                ),
+            ),
+        )
 
         val underTest = SequenceFilterFields.fromDatabaseConfig(input)
 
@@ -32,6 +40,19 @@ class SequenceFilterFieldsTest {
                 "fieldname\$regex",
                 SequenceFilterField("fieldName\$regex", SequenceFilterFieldType.StringSearch("fieldName")),
             ),
+        )
+    }
+
+    @Test
+    fun `given database config with a string field forbidding regex then only contains a string field`() {
+        val input = databaseConfigWithFields(listOf(DatabaseMetadata("fieldName", MetadataType.STRING)))
+
+        val underTest = SequenceFilterFields.fromDatabaseConfig(input)
+
+        assertThat(underTest.fields, aMapWithSize(1))
+        assertThat(
+            underTest.fields,
+            hasEntry("fieldname", SequenceFilterField("fieldName", SequenceFilterFieldType.String)),
         )
     }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -30,6 +30,7 @@ import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.PangoLineageEquals
 import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.genspectrum.lapis.silo.StringEquals
+import org.genspectrum.lapis.silo.StringSearch
 import org.genspectrum.lapis.silo.True
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
@@ -795,6 +796,18 @@ class SiloFilterExpressionMapperTest {
                             BooleanEquals("test_boolean_column", true),
                             BooleanEquals("test_boolean_column", false),
                             BooleanEquals("test_boolean_column", null),
+                        ),
+                    ),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "some_metadata\$regex" to listOf("someRegex", null, "otherRegex"),
+                    ),
+                    And(
+                        Or(
+                            StringSearch("some_metadata", searchExpression = "someRegex"),
+                            StringSearch("some_metadata", searchExpression = null),
+                            StringSearch("some_metadata", searchExpression = "otherRegex"),
                         ),
                     ),
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -703,6 +703,16 @@ class SiloQueryTest {
                         }
                     """,
                 ),
+                Arguments.of(
+                    StringSearch("theColumn", "theValue"),
+                    """
+                        {
+                            "type": "StringSearch",
+                            "column": "theColumn",
+                            "searchExpression": "theValue"
+                        }
+                    """,
+                ),
             )
     }
 }


### PR DESCRIPTION
resolves #898
resolves #901 

Users can now filter for all string columns using regular expressions. Users can decide between a string equals filter using the current notation `"myMetadata": "searchedValue"`. When users want to search using regex, they need to append `$regex` to the metadata field name eg. `"myMetadata$regex": "someRegex"`.

The string columns which support regex search can be configured using the option `lapisAllowsRegexSearch`. Per default it is turned off.

## PR Checklist
- [ ] All necessary documentation has been adapted.
   - This will be done in #900 
   - The swagger already has the correct values for the example. Only the schema could be refined to include information about the search, see #903
- [x] The implemented feature is covered by an appropriate test.
