### PR TITLE
feat(lapis): throw error when filtering by "equals" and "regex" for the same string field

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -168,6 +168,20 @@ class SiloFilterExpressionMapper(
                 )
             }
         }
+
+        val stringSearchFilters = allowedSequenceFiltersWithType.keys.filter { it.second == Filter.StringEquals }
+        for ((stringSearchColumnName) in stringSearchFilters) {
+            val stringEqualsFilterForSameColumn = allowedSequenceFiltersWithType[
+                Pair(stringSearchColumnName, Filter.StringSearch),
+            ]
+
+            if (stringEqualsFilterForSameColumn != null) {
+                throw BadRequestException(
+                    "Cannot filter for string regex '${stringEqualsFilterForSameColumn[0].originalKey}' " +
+                        "and string equals '$stringSearchColumnName' for the same field.",
+                )
+            }
+        }
     }
 
     private fun mapToStringEqualsFilters(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -499,6 +499,25 @@ class SiloFilterExpressionMapperTest {
         )
     }
 
+    @Test
+    fun `GIVEN value for string field and its corresponding regex field THEN throws error`() {
+        val filterParameter = getSequenceFilters(
+            mapOf(
+                "some_metadata" to "some value",
+                "some_metadata\$regex" to "some other value",
+            ),
+        )
+
+        val exception = assertThrows<BadRequestException> { underTest.map(filterParameter) }
+        assertThat(
+            exception.message,
+            containsString(
+                "Cannot filter for string regex 'some_metadata\$regex' " +
+                    "and string equals 'some_metadata' for the same field.",
+            ),
+        )
+    }
+
     companion object {
         @JvmStatic
         val filterParametersWithMultipleValues = listOf(


### PR DESCRIPTION
closes #899

## PR Checklist
- ~~[ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
