### PR TITLE
feat(lapis): use dot symbol as regex separator #908

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -2,6 +2,11 @@ name: Changelog Preview
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   previewChangelog:

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,11 @@ name: Commitlint
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   commitlint:

--- a/lapis-docs/src/components/FiltersTable/getFilters.tsx
+++ b/lapis-docs/src/components/FiltersTable/getFilters.tsx
@@ -41,7 +41,7 @@ export function getFilters(config: Config) {
 
             if (metadata.lapisAllowsRegexSearch) {
                 const allowRegexSearchDescription = {
-                    name: `${metadata.name}$regex`,
+                    name: `${metadata.name}.regex`,
                     type: metadata.type,
                     description: `Filters the "${metadata.name}" column using a regular expression,`,
                     link: {

--- a/lapis-docs/src/components/QueryGenerator/FiltersSelection.tsx
+++ b/lapis-docs/src/components/QueryGenerator/FiltersSelection.tsx
@@ -32,8 +32,8 @@ export const FiltersSelection = (props: Props) => {
                             <>
                                 <FilterField key={metadata.name} name={metadata.name} {...props} />
                                 <FilterField
-                                    key={metadata.name + '$regex'}
-                                    name={metadata.name + '$regex'}
+                                    key={metadata.name + '.regex'}
+                                    name={metadata.name + '.regex'}
                                     {...props}
                                 />
                             </>

--- a/lapis-docs/src/content/docs/concepts/string-search.mdx
+++ b/lapis-docs/src/content/docs/concepts/string-search.mdx
@@ -17,11 +17,11 @@ Under the hood, we use the [RE2](https://github.com/google/re2) library to evalu
 Get the number of sequences with the `division` field containing the string `Basel`:
 
 ```
-GET /sample/aggregated?division$regex=Basel
+GET /sample/aggregated?division.regex=Basel
 ```
 
 Get the number of sequences with the `division` field starting with the string `Basel`:
 
 ```
-GET /sample/aggregated?division$regex=^Basel
+GET /sample/aggregated?division.regex=^Basel
 ```

--- a/lapis-e2e/test/aggregated.spec.ts
+++ b/lapis-e2e/test/aggregated.spec.ts
@@ -46,7 +46,7 @@ describe('The /aggregated endpoint', () => {
       })
     );
 
-  it('should correcty handle aggregated request with multiple segments', async () => {
+  it('should correctly handle aggregated request with multiple segments', async () => {
     const result = await lapisClientMultiSegmented.postAggregated1({
       aggregatedPostRequest: {
         nucleotideMutations: ['L:T1A', 'M:T1C'],
@@ -153,13 +153,13 @@ describe('The /aggregated endpoint', () => {
 
   it('should return bad request when sending regex filter for field that does not allow it', async () => {
     const urlParams = new URLSearchParams();
-    urlParams.append('region$regex', 'Euro');
+    urlParams.append('region.regex', 'Euro');
 
     const result = await getAggregated(urlParams);
 
     expect(result.status).equals(400);
     const resultJson = await result.json();
-    expect(resultJson.error.detail).to.include("'region$regex' is not a valid sequence filter");
+    expect(resultJson.error.detail).to.include("'region.regex' is not a valid sequence filter");
   });
 
   it('should apply limit and offset', async () => {
@@ -305,5 +305,17 @@ age	country	count
     expect(result.status).equals(200);
     const resultJson = await result.json();
     expect(resultJson.data[0]).to.have.property('count', 1);
+  });
+
+  it('should correctly handle string search filters in GET requests', async () => {
+    const urlParams = new URLSearchParams({
+      'division.regex': 'Basel-(Land|Stadt)',
+    });
+
+    const result = await getAggregated(urlParams);
+
+    expect(result.status).equals(200);
+    const resultJson = await result.json();
+    expect(resultJson.data[0]).to.have.property('count', 20);
   });
 });

--- a/lapis-e2e/test/aggregatedQueries/basicStringSearch.json
+++ b/lapis-e2e/test/aggregatedQueries/basicStringSearch.json
@@ -1,7 +1,7 @@
 {
   "testCaseName": "basic string search",
   "lapisRequest": {
-    "division$regex": "Basel-(Land|Stadt)"
+    "divisionRegex": "Basel-(Land|Stadt)"
   },
   "expected": [
     {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -46,7 +46,7 @@ private fun mapToSequenceFilterField(databaseMetadata: DatabaseMetadata) =
         ).let {
             when (databaseMetadata.lapisAllowsRegexSearch) {
                 true -> it + SequenceFilterField(
-                    name = "${databaseMetadata.name}\$regex",
+                    name = "${databaseMetadata.name}.regex",
                     type = SequenceFilterFieldType.StringSearch(databaseMetadata.name),
                 )
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/DummySequenceFilterFields.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/DummySequenceFilterFields.kt
@@ -23,7 +23,7 @@ val dummySequenceFilterFields = SequenceFilterFields(
         "dateFrom" to SequenceFilterFieldType.DateFrom(DATE_FIELD),
         PANGO_LINEAGE_FIELD to SequenceFilterFieldType.PangoLineage,
         "some_metadata" to SequenceFilterFieldType.String,
-        "some_metadata\$regex" to SequenceFilterFieldType.StringSearch("some_metadata"),
+        "some_metadata.regex" to SequenceFilterFieldType.StringSearch("some_metadata"),
         "other_metadata" to SequenceFilterFieldType.String,
         "variantQuery" to SequenceFilterFieldType.VariantQuery,
         "intField" to SequenceFilterFieldType.Int,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
@@ -37,8 +37,8 @@ class SequenceFilterFieldsTest {
         assertThat(
             underTest.fields,
             hasEntry(
-                "fieldname\$regex",
-                SequenceFilterField("fieldName\$regex", SequenceFilterFieldType.StringSearch("fieldName")),
+                "fieldname.regex",
+                SequenceFilterField("fieldName.regex", SequenceFilterFieldType.StringSearch("fieldName")),
             ),
         )
     }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -504,7 +504,7 @@ class SiloFilterExpressionMapperTest {
         val filterParameter = getSequenceFilters(
             mapOf(
                 "some_metadata" to "some value",
-                "some_metadata\$regex" to "some other value",
+                "some_metadata.regex" to "some other value",
             ),
         )
 
@@ -512,7 +512,7 @@ class SiloFilterExpressionMapperTest {
         assertThat(
             exception.message,
             containsString(
-                "Cannot filter for string regex 'some_metadata\$regex' " +
+                "Cannot filter for string regex 'some_metadata.regex' " +
                     "and string equals 'some_metadata' for the same field.",
             ),
         )
@@ -820,7 +820,7 @@ class SiloFilterExpressionMapperTest {
                 ),
                 Arguments.of(
                     mapOf(
-                        "some_metadata\$regex" to listOf("someRegex", null, "otherRegex"),
+                        "some_metadata.regex" to listOf("someRegex", null, "otherRegex"),
                     ),
                     And(
                         Or(


### PR DESCRIPTION
resolves #908

This PR changes the delimiter symbol of the string search from the `$` sign to a `.` sign. This symbol is not specially encoded in urls. For me this worked on webkit, curl, firefox and chrome. 

Some tools which use ts, like openapi-genereator-cli, have a problem with the dot, since it can not be used in a variable name. The $ sign can be used there. However, kotlin cant use either of them. So this might not an argument for or against this change.

## PR Checklist
- [x] All necessary documentation has been adapted.
   The documentation needs to be changed, but this needs to wait for #906.
- [x] The implemented feature is covered by an appropriate test.
