### PR TITLE
feat(lapis): omit sequences with `null` values in unaligned fasta downloads

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
@@ -36,7 +36,8 @@ const val ALIGNED_MULTI_SEGMENTED_NUCLEOTIDE_SEQUENCE_ENDPOINT_DESCRIPTION =
     Only sequences matching the specified sequence filters are considered."""
 const val UNALIGNED_MULTI_SEGMENTED_NUCLEOTIDE_SEQUENCE_ENDPOINT_DESCRIPTION =
     """Returns a string of fasta formatted unaligned nucleotide sequences of the requested segment.
-    Only sequences matching the specified sequence filters are considered."""
+    Only sequences matching the specified sequence filters are considered.
+    Sequences that don't have an unaligned sequence for this segment are omitted."""
 
 const val AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION =
     """The fields to stratify by. If empty, only the overall count is returned"""

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
@@ -256,7 +256,11 @@ class LapisControllerTest(
                 SequenceType.ALIGNED,
                 "geneName",
             )
-        } returns Stream.of(SequenceData("key1", "the sequence"), SequenceData("key2", "the other sequence"))
+        } returns Stream.of(
+            SequenceData("key1", "the sequence"),
+            SequenceData("key2", "the other sequence"),
+            SequenceData("key3", null),
+        )
 
         mockMvc.perform(request("$ALIGNED_AMINO_ACID_SEQUENCES_ROUTE/geneName"))
             .andExpect(status().isOk)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
@@ -33,7 +33,11 @@ import java.util.stream.Stream
 class MultiSegmentedSequenceControllerTest(
     @Autowired val mockMvc: MockMvc,
 ) {
-    val returnedValue: Stream<SequenceData> = Stream.of(SequenceData("sequenceKey", "theSequence"))
+    val returnedValue: Stream<SequenceData> = Stream.of(
+        SequenceData("sequenceKey", "theSequence"),
+        SequenceData("sequenceKeyWithNullValue", null),
+    )
+
     val expectedFasta = """
         >sequenceKey
         theSequence

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceControllerTest.kt
@@ -31,7 +31,11 @@ import java.util.stream.Stream
 class SingleSegmentedSequenceControllerTest(
     @Autowired val mockMvc: MockMvc,
 ) {
-    val returnedValue: Stream<SequenceData> = Stream.of(SequenceData("sequenceKey", "theSequence"))
+    val returnedValue: Stream<SequenceData> = Stream.of(
+        SequenceData("sequenceKey", "theSequence"),
+        SequenceData("sequenceKeyWithNullValue", null),
+    )
+
     val expectedFasta = """
         >sequenceKey
         theSequence

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -149,6 +149,7 @@ class SiloClientTest(
                     """
                         {"primaryKey": "key1","someSequenceName": "ABCD"}
                         {"primaryKey": "key2","someSequenceName": "DEFG"}
+                        {"primaryKey": "key3","someSequenceName": null}
                     """,
                 ),
         )
@@ -159,12 +160,13 @@ class SiloClientTest(
         )
         val result = underTest.sendQuery(query).toList()
 
-        assertThat(result, hasSize(2))
+        assertThat(result, hasSize(3))
         assertThat(
             result,
             containsInAnyOrder(
-                SequenceData("key1", "ABCD"),
-                SequenceData("key2", "DEFG"),
+                SequenceData(sequenceKey = "key1", sequence = "ABCD"),
+                SequenceData(sequenceKey = "key2", sequence = "DEFG"),
+                SequenceData(sequenceKey = "key3", sequence = null),
             ),
         )
     }


### PR DESCRIPTION
closes #912

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
