### PR TITLE
docs(root): document that regex support in LAPIS (as of 0.2.10) requires at least SILO 0.2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ The OpenAPI specification is available at `url.to.lapis:<port>/api-docs` (in JSO
 This table shows which LAPIS version is required for which SILO version.
 Higher versions will also work if they are not specified in the table.
 
-| LAPIS | SILO  |
-|-------|-------|
-| 0.2.1 | 0.2.0 |
-| 0.1   | 0.1.0 |
+| LAPIS  | SILO   |
+|--------|--------|
+| 0.2.10 | 0.2.14 |
+| 0.2.1  | 0.2.0  |
+| 0.1    | 0.1.0  |
 
 ## Repository Structure
 


### PR DESCRIPTION
## PR Checklist
- [x] All necessary documentation has been adapted.
~~- [ ] The implemented feature is covered by an appropriate test.~~
