### PR TITLE
test(lapis-e2e): fix e2e tests

### DIFF
--- a/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
@@ -11,7 +11,7 @@ describe('The /unalignedNucleotideSequence endpoint', () => {
 
     expect(primaryKeys, 'primaryKeys').to.have.length(100);
     expect(sequences, 'sequences').to.have.length(100);
-    expect(primaryKeys[0]).to.equal('>key_3259931');
+    expect(primaryKeys[0]).to.equal('>key_3086369');
     expect(sequences[0]).to.have.length(29903);
   });
 


### PR DESCRIPTION
Something in the latest bugfixes in SILO must have changed the order (the test does not enforce any order).

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
