### PR TITLE
feat(lapis): abort on startup when silo url has invalid syntax

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloUris.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloUris.kt
@@ -1,0 +1,13 @@
+package org.genspectrum.lapis.silo
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.net.URI
+
+@Component
+class SiloUris(
+    @Value("\${silo.url}") siloUrl: String,
+) {
+    val query = URI("$siloUrl/query")
+    val info = URI("$siloUrl/info")
+}

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloUrisTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloUrisTest.kt
@@ -1,0 +1,24 @@
+package org.genspectrum.lapis.silo
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.net.URISyntaxException
+
+class SiloUrisTest {
+    @Test
+    fun `GIVEN valid silo url THEN returns uris`() {
+        val underTest = SiloUris("http://dummy.silo.url")
+
+        assertThat(underTest.query.toString(), `is`("http://dummy.silo.url/query"))
+        assertThat(underTest.info.toString(), `is`("http://dummy.silo.url/info"))
+    }
+
+    @Test
+    fun `GIVEN invalid silo url THEN throws exception`() {
+        assertThrows<URISyntaxException> {
+            SiloUris("this is not a url")
+        }
+    }
+}


### PR DESCRIPTION
resolves #939

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
