### PR TITLE
fix(lapis-docs): update link in docs introduction.mdx

### DIFF
--- a/lapis-docs/src/content/docs/getting-started/introduction.mdx
+++ b/lapis-docs/src/content/docs/getting-started/introduction.mdx
@@ -43,5 +43,5 @@ If you have any trouble, feel free to reach out to us.
 
 :::note
 This documentation also includes a section about how to set up your own instance of LAPIS.
-Refer to [this tutorial](../maintainer-docs/tutorials/start-lapis-and-silo) for a quick start guide.
+Refer to [this tutorial](../../maintainer-docs/tutorials/start-lapis-and-silo) for a quick start guide.
 :::


### PR DESCRIPTION
Link in introduction is broken, link should be https://lapis-three.vercel.app/maintainer-docs/tutorials/start-lapis-and-silo:

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/92a7e34c-ab77-452c-adeb-cfe1f0c6a5e6">

