### PR TITLE
fix(lapis-docs): fix link on landing page

### DIFF
--- a/lapis-docs/src/content/docs/index.mdx
+++ b/lapis-docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
     tagline: Instance for SARS-CoV-2
     actions:
         - text: Introduction
-          link: getting-started/introduction/
+          link: getting-started/introduction
           icon: right-arrow
           variant: primary
         - text: LAPIS on GitHub

--- a/lapis-docs/tests/docs.spec.ts
+++ b/lapis-docs/tests/docs.spec.ts
@@ -127,6 +127,7 @@ test.describe('The documentation', () => {
 
         await page.getByRole('link', { name: 'Introduction' }).click();
         await expect(page).toHaveTitle(/^Introduction/);
+        await expect(page).toHaveURL(thatDoesNotEndWithSlash);
 
         await clickOnAllLinksInNavigation(page);
     });
@@ -183,5 +184,14 @@ async function clickOnAllLinksInNavigation(page: Page) {
         await page.getByRole('link', { name: pageName.title, exact: true }).nth(alreadyClickedTimes).click();
         clickedLinks[pageName.relativeUrl] = alreadyClickedTimes + 1;
         await expect(page).toHaveTitle(new RegExp(`^${pageName.title}`));
+        await expect(page).toHaveURL(thatDoesNotEndWithSlash);
     }
 }
+
+/**
+ * This regex matches any URL that does not end with a slash.
+ * This is important to make relative links work, because they rely on using `..` to go up one level.
+ * - `..` on /foo/bar would be /foo
+ * - `..` on /foo/bar/ would be /foo/bar
+ */
+const thatDoesNotEndWithSlash = /[^\/]$/;


### PR DESCRIPTION
relative links must not end with `/`, so that other relative links on those pages will work In this case, the link `[this tutorial](../maintainer-docs/tutorials/start-lapis-and-silo)` on `/getting-started/introduction` did not work, because when coming from the landing page, you were actually on `/getting-started/introduction/`.

resolves #

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
