### PR TITLE
validate that metadata fields do not contain the reserved character `.`

### DIFF
--- a/lapis-docs/src/content/docs/maintainer-docs/references/database-configuration.mdx
+++ b/lapis-docs/src/content/docs/maintainer-docs/references/database-configuration.mdx
@@ -46,11 +46,19 @@ it will be beneficial to set `dateToSortBy` to that column.
 
 The metadata object permits the following fields:
 
-| Key           | Type    | Required | Description                                           |
-| ------------- | ------- | -------- | ----------------------------------------------------- |
-| name          | string  | true     | The name of the feature.                              |
-| type          | enum    | true     | The [type of the metadata](#metadata-types).          |
-| generateIndex | boolean | false    | See [Generating an index](#generating-an-index) below |
+| Key                    | Type    | Required | Description                                                                                                   |
+| ---------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| name                   | string  | true     | The name of the metadata field.                                                                               |
+| type                   | enum    | true     | The [type of the metadata](#metadata-types).                                                                  |
+| generateIndex          | boolean | false    | See [Generating an index](#generating-an-index) below                                                         |
+| lapisAllowsRegexSearch | boolean | false    | If true, LAPIS will autogenerate a filter `${name}.regex`. See [String search](../../concepts/string-search). |
+
+:::caution
+The `name` must not contain the reserved character `.`.
+
+LAPIS uses `.` internally to generate new filters, such as the `$name.regex` filter.
+To avoid conflicts, the `name` must not contain reserved characters.
+:::
 
 ### Metadata Types
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.parameters.HeaderParameter
 import mu.KotlinLogging
 import org.genspectrum.lapis.auth.DataOpennessAuthorizationFilterFactory
 import org.genspectrum.lapis.config.DatabaseConfig
+import org.genspectrum.lapis.config.DatabaseConfigValidator
 import org.genspectrum.lapis.config.NO_REFERENCE_GENOME_FILENAME_ERROR_MESSAGE
 import org.genspectrum.lapis.config.REFERENCE_GENOME_ENV_VARIABLE_NAME
 import org.genspectrum.lapis.config.REFERENCE_GENOME_FILENAME_ARGS_NAME
@@ -66,8 +67,10 @@ class LapisSpringConfig {
     fun databaseConfig(
         @Value("\${lapis.databaseConfig.path}") configPath: String,
         yamlObjectMapper: YamlObjectMapper,
+        databaseConfigValidator: DatabaseConfigValidator,
     ): DatabaseConfig {
-        return yamlObjectMapper.objectMapper.readValue(File(configPath))
+        return yamlObjectMapper.objectMapper.readValue<DatabaseConfig>(File(configPath))
+            .let { databaseConfigValidator.validate(it) }
     }
 
     @Bean

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidator.kt
@@ -1,0 +1,24 @@
+package org.genspectrum.lapis.config
+
+import org.springframework.stereotype.Component
+
+@Component
+class DatabaseConfigValidator {
+    fun validate(databaseConfig: DatabaseConfig): DatabaseConfig {
+        databaseConfig.schema.metadata.forEach {
+            if (it.name.contains('.')) {
+                throw IllegalArgumentException(
+                    "Metadata field name '${it.name}' contains the reserved character '.'",
+                )
+            }
+
+            if (it.lapisAllowsRegexSearch && it.type != MetadataType.STRING) {
+                throw IllegalArgumentException(
+                    "Metadata field '${it.name}' has lapisAllowsRegexSearch set to true, but is not of type STRING.",
+                )
+            }
+        }
+
+        return databaseConfig
+    }
+}

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/LapisApplicationTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/LapisApplicationTest.kt
@@ -1,11 +1,44 @@
 package org.genspectrum.lapis
 
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.ComponentScan
 
 @SpringBootTest
 class LapisApplicationTest {
     @Test
     fun contextLoads() {
     }
+}
+
+class LapisApplicationFailsToLoadContextTest {
+    @Test
+    fun `GIVEN invalid database config THEN lapis crashes on startup`() {
+        val contextRunner: ApplicationContextRunner = ApplicationContextRunner()
+            .withUserConfiguration(LapisSpringConfig::class.java)
+            .withUserConfiguration(ComponentScanConfig::class.java)
+            .withPropertyValues("lapis.databaseConfig.path=src/test/resources/config/invalidTestDatabaseConfig.yaml")
+
+        var cause = assertThrows<Throwable> {
+            contextRunner.run { it!!.getBean("databaseConfig") }
+        }
+
+        while (cause.cause != null) {
+            cause = cause.cause!!
+        }
+
+        assertThat(
+            cause.message,
+            containsString("key.with.reserved.character"),
+        )
+    }
+
+    @TestConfiguration
+    @ComponentScan("org.genspectrum.lapis")
+    class ComponentScanConfig
 }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidatorTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidatorTest.kt
@@ -1,0 +1,72 @@
+package org.genspectrum.lapis.config
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class DatabaseConfigValidatorTest {
+    private val underTest = DatabaseConfigValidator()
+
+    @Test
+    fun `GIVEN valid config THEN accepts it`() {
+        val validConfig = DatabaseConfig(
+            DatabaseSchema(
+                instanceName = "test",
+                primaryKey = "primaryKey",
+                opennessLevel = OpennessLevel.OPEN,
+                metadata = emptyList(),
+            ),
+        )
+
+        assertDoesNotThrow { underTest.validate(validConfig) }
+    }
+
+    @Test
+    fun `GIVEN config with regex separator in metadata field THEN config is invalid`() {
+        val invalidConfig = DatabaseConfig(
+            DatabaseSchema(
+                instanceName = "test",
+                primaryKey = "primaryKey",
+                opennessLevel = OpennessLevel.OPEN,
+                metadata = listOf(
+                    DatabaseMetadata(
+                        name = "field.with.regex.separator",
+                        type = MetadataType.STRING,
+                    ),
+                ),
+            ),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> { underTest.validate(invalidConfig) }
+        assertThat(
+            exception.message,
+            `is`("Metadata field name 'field.with.regex.separator' contains the reserved character '.'"),
+        )
+    }
+
+    @Test
+    fun `GIVEN lapisAllowsRegexSearch on non-string field THEN config is invalid`() {
+        val invalidConfig = DatabaseConfig(
+            DatabaseSchema(
+                instanceName = "test",
+                primaryKey = "primaryKey",
+                opennessLevel = OpennessLevel.OPEN,
+                metadata = listOf(
+                    DatabaseMetadata(
+                        name = "test field",
+                        type = MetadataType.INT,
+                        lapisAllowsRegexSearch = true,
+                    ),
+                ),
+            ),
+        )
+
+        val exception = assertThrows<IllegalArgumentException> { underTest.validate(invalidConfig) }
+        assertThat(
+            exception.message,
+            `is`("Metadata field 'test field' has lapisAllowsRegexSearch set to true, but is not of type STRING."),
+        )
+    }
+}

--- a/lapis/src/test/resources/config/invalidTestDatabaseConfig.yaml
+++ b/lapis/src/test/resources/config/invalidTestDatabaseConfig.yaml
@@ -1,0 +1,9 @@
+schema:
+  instanceName: "invalid because . is reserved for regex separators"
+  opennessLevel: OPEN
+  metadata:
+    - name: primaryKey
+      type: string
+    - name: key.with.reserved.character
+      type: string
+  primaryKey: primaryKey


### PR DESCRIPTION
also validate that `lapisAllowsRegexSearch`-fields are of type string

resolves #976

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
