### PR TITLE
fix(lapis): get rid of logger config deprecation warnings in the log

### DIFF
--- a/lapis/src/main/resources/logback.xml
+++ b/lapis/src/main/resources/logback.xml
@@ -32,9 +32,9 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>${PATTERN}</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="info">

--- a/lapis/src/test/resources/logback-test.xml
+++ b/lapis/src/test/resources/logback-test.xml
@@ -1,8 +1,8 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>%date %level [%thread] [%X{RequestId}] %class: %message%n</Pattern>
-        </layout>
+        </encoder>
     </appender>
 
     <root level="info">


### PR DESCRIPTION
Instead of `<layout><pattern></pattern></layout>` we now have to use `<encoder><pattern></pattern></encoder>`.
https://logback.qos.ch/codes.html#layoutInsteadOfEncoder

resolves #972

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
