### PR TITLE
mark sections of the docs that are generated from the config

### DIFF
--- a/lapis-docs/Dockerfile
+++ b/lapis-docs/Dockerfile
@@ -13,4 +13,6 @@ VOLUME /config
 
 HEALTHCHECK --start-period=60s CMD curl --fail --silent localhost:3000$BASE_URL | grep "Welcome to LAPIS" || exit 1
 
-CMD npm ci && npm run build && npm run preview -- --host 0.0.0.0 --port 3000
+RUN npm ci
+
+CMD npm run build && npm run preview -- --host 0.0.0.0 --port 3000

--- a/lapis-docs/astro.config.mjs
+++ b/lapis-docs/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
-import { hasFeature } from './src/config.ts';
 
 import tailwind from '@astrojs/tailwind';
 
@@ -70,7 +69,7 @@ export default defineConfig({
                 },
                 {
                     label: 'Concepts',
-                    items: filterAvailableConcepts([
+                    items: [
                         {
                             label: 'Data versions',
                             link: '/concepts/data-versions',
@@ -86,7 +85,6 @@ export default defineConfig({
                         {
                             label: 'Pango lineage query',
                             link: '/concepts/pango-lineage-query',
-                            onlyIfFeature: 'sarsCoV2VariantQuery',
                         },
                         {
                             label: 'Request methods: GET and POST',
@@ -99,7 +97,6 @@ export default defineConfig({
                         {
                             label: 'Variant query',
                             link: '/concepts/variant-query',
-                            onlyIfFeature: 'sarsCoV2VariantQuery',
                         },
                         {
                             label: 'String search',
@@ -109,7 +106,7 @@ export default defineConfig({
                             label: 'Request Id',
                             link: '/concepts/request-id',
                         },
-                    ]),
+                    ],
                 },
                 {
                     label: 'Tutorials',
@@ -215,16 +212,3 @@ export default defineConfig({
     base: process.env.BASE_URL,
     site: process.env.ASTRO_SITE,
 });
-
-/**
- * TODO Not sure if this is actually a good solution. The filtering now happens at compile time but ideally, it happens
- *   at runtime (so that the user/maintainer does not need to re-compile for their own config).
- */
-function filterAvailableConcepts(pages) {
-    return pages
-        .filter((p) => !p.onlyIfFeature || hasFeature(p.onlyIfFeature))
-        .map(({ label, link }) => ({
-            label,
-            link,
-        }));
-}

--- a/lapis-docs/src/config.ts
+++ b/lapis-docs/src/config.ts
@@ -15,6 +15,7 @@ export type Metadata = {
     name: string;
     type: MetadataType;
     lapisAllowsRegexSearch?: boolean;
+    generateLineageIndex?: boolean;
 };
 
 export type Feature = {
@@ -50,4 +51,16 @@ export function hasFeature(feature: string): boolean {
         getConfig();
     }
     return _featuresNames!.has(feature);
+}
+
+export function hasPangoLineage(config: Config): boolean {
+    return config.schema.metadata.some(
+        (m) =>
+            m.generateLineageIndex === true &&
+            (m.name.toLowerCase().includes('pangolineage') || m.name.toLowerCase().includes('pango_lineage')),
+    );
+}
+
+export function hasRegexSearchFields(config: Config): boolean {
+    return config.schema.metadata.some((m) => m.lapisAllowsRegexSearch === true);
 }

--- a/lapis-docs/src/content/docs/concepts/pango-lineage-query.mdx
+++ b/lapis-docs/src/content/docs/concepts/pango-lineage-query.mdx
@@ -4,9 +4,14 @@ description: Pango lineage query
 ---
 
 import { OnlyIf } from '../../../components/OnlyIf.tsx';
-import { getConfig, hasFeature } from '../../../config.ts';
+import { getConfig, hasPangoLineage, hasFeature } from '../../../config.ts';
 
-<OnlyIf condition={!!getConfig().schema.metadata.find(m => m.type === 'pango_lineage')}>
+{/* prettier-ignore */}
+<OnlyIf condition={!hasPangoLineage(getConfig())}>
+:::note
+This feature is not available in this LAPIS instance, because none of the fields seems to be a Pango lineage field.
+:::
+</OnlyIf>
 
 Pango lineage names inherit the hierarchical nature of genetic lineages. For example, B.1.1 is a sub-lineage of B.1.
 More information about the pango nomenclature can be found on the website of the
@@ -24,5 +29,3 @@ maximal-length name (e.g., B.1.617.2) will get an alias. A list of aliases can b
 the alias AY so that AY.1 would be a sub-lineage of B.1.617.2. LAPIS is aware of aliases. Filtering B.1.617.2\* will
 include every lineage that starts with AY. It is further possible to search for B.1.617.2.1 which will then return the
 same results as AY.1.
-
-</OnlyIf>

--- a/lapis-docs/src/content/docs/concepts/string-search.mdx
+++ b/lapis-docs/src/content/docs/concepts/string-search.mdx
@@ -3,6 +3,16 @@ title: String search
 description: String search
 ---
 
+import { OnlyIf } from '../../../components/OnlyIf.tsx';
+import { getConfig, hasRegexSearchFields } from '../../../config.ts';
+
+{/* prettier-ignore */}
+<OnlyIf condition={!hasRegexSearchFields(getConfig())}>
+:::note
+This feature is not available in this LAPIS instance, because none of the string fields are configured accordingly.
+:::
+</OnlyIf>
+
 LAPIS allows users to filter string fields in the metadata using [regular expressions](https://en.wikipedia.org/wiki/Regular_expression).
 This is useful when the full string is unknown or when a more complex search is needed.
 

--- a/lapis-docs/src/content/docs/concepts/variant-query.mdx
+++ b/lapis-docs/src/content/docs/concepts/variant-query.mdx
@@ -6,7 +6,13 @@ description: Variant query
 import { OnlyIf } from '../../../components/OnlyIf.tsx';
 import { hasFeature } from '../../../config.ts';
 
+{/* prettier-ignore */}
 <OnlyIf condition={hasFeature('sarsCoV2VariantQuery')}>
+:::note
+This feature is not enabled for this LAPIS instance.
+It must be enabled in the `features` section of the database configuration by the maintainer of the instance.
+:::
+</OnlyIf>
 
 LAPIS offers a special query language to specify variants. A variant query can be used to filter sequences and be passed
 to the server through the query parameter `variantQuery`. It is not allowed to use the `variantQuery` parameter
@@ -60,5 +66,3 @@ LAPIS supports a ternary logic to query [ambiguous nucleotide symbols](../concep
 ```
 MAYBE(123W)
 ```
-
-</OnlyIf>

--- a/lapis-docs/src/content/docs/getting-started/generate-your-request.mdx
+++ b/lapis-docs/src/content/docs/getting-started/generate-your-request.mdx
@@ -8,4 +8,9 @@ import { getLapisUrl } from '../../../lapisUrl.js';
 import { getReferenceGenomes } from '../../../reference_genomes.js';
 import { QueryGenerator } from '../../../components/QueryGenerator/QueryGenerator.tsx';
 
+:::note
+This generator is tailored to the configuration of the underlying LAPIS instance.
+Available fields may differ between instances.
+:::
+
 <QueryGenerator client:load config={getConfig()} referenceGenomes={getReferenceGenomes()} lapisUrl={getLapisUrl()} />

--- a/lapis-docs/src/content/docs/references/database-config.mdx
+++ b/lapis-docs/src/content/docs/references/database-config.mdx
@@ -5,6 +5,10 @@ description: database config
 
 import DatabaseConfig from '../../../components/DatabaseConfig.astro';
 
+:::note
+This page is generated from the underlying LAPIS configuration.
+:::
+
 This instance of LAPIS uses the following configuration file:
 
 <DatabaseConfig />

--- a/lapis-docs/src/content/docs/references/fields.mdx
+++ b/lapis-docs/src/content/docs/references/fields.mdx
@@ -5,6 +5,10 @@ description: Fields
 
 import FieldsTable from '../../../components/FieldsTable.astro';
 
-This instance of LAPIS supports the following fields.
+:::note
+This page is generated from the underlying LAPIS configuration.
+:::
+
+This instance of LAPIS supports the following fields:
 
 <FieldsTable />

--- a/lapis-docs/src/content/docs/references/filters.mdx
+++ b/lapis-docs/src/content/docs/references/filters.mdx
@@ -5,6 +5,10 @@ description: Filters
 
 import FiltersTable from '../../../components/FiltersTable/FiltersTable.astro';
 
+:::note
+This page is generated from the underlying LAPIS configuration.
+:::
+
 This instance of LAPIS supports the following sequence filters:
 
 <FiltersTable />

--- a/lapis-docs/src/content/docs/references/open-api-definition.mdx
+++ b/lapis-docs/src/content/docs/references/open-api-definition.mdx
@@ -5,4 +5,8 @@ description: Open API / Swagger
 
 import SwaggerUIContainer from '../../../components/SwaggerUIContainer.astro';
 
+:::note
+The SwaggerUI is generated from the LAPIS database config and thus it is specific to the underlying LAPIS instance.
+:::
+
 <SwaggerUIContainer />

--- a/lapis-docs/src/content/docs/references/reference-genomes.mdx
+++ b/lapis-docs/src/content/docs/references/reference-genomes.mdx
@@ -5,6 +5,10 @@ description: reference genome
 
 import RefereneceGenome from '../../../components/ReferenceGenome.astro';
 
+:::note
+This page is generated from the underlying LAPIS configuration.
+:::
+
 This instance of LAPIS uses the following reference genome:
 
 <RefereneceGenome />


### PR DESCRIPTION
resolves #928

This also fixes pango lineage docs (we can't be sure anymore which lineage fields are pango lineages).
Also, all sections are now always available.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
