### PR TITLE
feat(lapis): add LAPIS version to info response

### DIFF
--- a/.github/workflows/lapis-docs.yml
+++ b/.github/workflows/lapis-docs.yml
@@ -59,6 +59,10 @@ jobs:
           context: ./lapis-docs
           push: true
           tags: ${{ steps.dockerMetadata.outputs.tags }}
+          cache-from: type=gha,scope=lapis-docs-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=lapis-docs-${{ github.ref }}
+          build-args: |
+            VERSION=${{ github.sha }}
 
       - name: Start Docker container and check that it responds
         run: |

--- a/.github/workflows/lapis.yml
+++ b/.github/workflows/lapis.yml
@@ -60,6 +60,8 @@ jobs:
           cache-to: type=gha,mode=max,scope=lapis-${{ github.ref }}
           platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
+          build-args: |
+            VERSION=${{ github.sha }}
 
   endToEndTests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-lapis.yml
+++ b/.github/workflows/release-lapis.yml
@@ -58,19 +58,47 @@ jobs:
           check-name: Build Docs Docker Image And Run E2E Tests
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Tag Already Built Images With Release Tags
+      - name: Docker metadata
         if: ${{ steps.release.outputs.release_created }}
-        run: |
-          MAJOR=${{ steps.release.outputs.major }}
-          MINOR=${{ steps.release.outputs.minor }}
-          PATCH=${{ steps.release.outputs.patch }}
-          TAGS=("$MAJOR.$MINOR" "$MAJOR.$MINOR.$PATCH")
-          # TODO (#777) include $MAJOR only for releases >= 1.0
-          # TAGS=("$MAJOR" "$MAJOR.$MINOR" "$MAJOR.$MINOR.$PATCH") - don't include major-only for pre-1.0
-          IMAGES=("${{ env.LAPIS_DOCKER_IMAGE_NAME }}" "${{ env.DOCS_DOCKER_IMAGE_NAME }}")
-          
-          for IMAGE in "${IMAGES[@]}"; do
-            for TAG in "${TAGS[@]}"; do
-              docker buildx imagetools create --tag $IMAGE:$TAG $IMAGE:latest
-            done
-          done
+        id: dockerMetadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.LAPIS_DOCKER_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+            type=raw,value=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+
+      - name: Build and push LAPIS image
+        if: ${{ steps.release.outputs.release_created }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lapis
+          tags: ${{ steps.dockerMetadata.outputs.tags }}
+          cache-from: type=gha,scope=lapis-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=lapis-${{ github.ref }}
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: true
+          build-args: |
+            VERSION=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+
+      - name: Docs Docker metadata
+        if: ${{ steps.release.outputs.release_created }}
+        id: docsDockerMetadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCS_DOCKER_IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+            type=raw,value=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
+
+      - name: Build and push LAPIS Docs image
+        if: ${{ steps.release.outputs.release_created }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lapis-docs
+          push: true
+          tags: ${{ steps.docsDockerMetadata.outputs.tags }}
+          cache-from: type=gha,scope=lapis-docs-${{ github.ref }}
+          cache-to: type=gha,mode=max,scope=lapis-docs-${{ github.ref }}
+          build-args: |
+            VERSION=${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}

--- a/lapis-docs/Dockerfile
+++ b/lapis-docs/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:lts-alpine as build-deps
+ARG VERSION="unspecified"
 
 WORKDIR /app
 
@@ -14,5 +15,6 @@ VOLUME /config
 HEALTHCHECK --start-period=60s CMD curl --fail --silent localhost:3000$BASE_URL | grep "Welcome to LAPIS" || exit 1
 
 RUN npm ci
+RUN echo ${VERSION} > version.txt
 
 CMD npm run build && npm run preview -- --host 0.0.0.0 --port 3000

--- a/lapis-docs/astro.config.mjs
+++ b/lapis-docs/astro.config.mjs
@@ -3,12 +3,21 @@ import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
 
 import tailwind from '@astrojs/tailwind';
+import fs from 'fs';
+
+function getVersion() {
+    try {
+        return `(version ${fs.readFileSync('version.txt').toString().trim().substring(0, 7)})`;
+    } catch (e) {
+        return '';
+    }
+}
 
 // https://astro.build/config
 export default defineConfig({
     integrations: [
         starlight({
-            title: 'LAPIS',
+            title: `LAPIS ${getVersion()}`,
             social: {
                 github: 'https://github.com/GenSpectrum/LAPIS',
             },

--- a/lapis-e2e/test/common.spec.ts
+++ b/lapis-e2e/test/common.spec.ts
@@ -196,6 +196,20 @@ describe('All endpoints', () => {
         }
         expect(body).not.to.be.empty;
       });
+
+      if (!route.servesFasta) {
+        it('should return info', async () => {
+          const response = await get();
+
+          const info = (await response.json()).info;
+
+          expect(info).to.have.property('dataVersion').and.to.match(/\d+/);
+          expect(info).to.have.property('lapisVersion').and.to.be.not.empty;
+          expect(info).to.have.property('requestId').and.to.be.not.empty;
+          expect(info).to.have.property('requestInfo').and.to.be.not.empty;
+          expect(info).to.have.property('reportTo').and.to.be.not.empty;
+        });
+      }
     });
   }
 });

--- a/lapis-e2e/test/common.ts
+++ b/lapis-e2e/test/common.ts
@@ -1,5 +1,6 @@
 import {
   Configuration,
+  InfoControllerApi,
   LapisControllerApi,
   Middleware,
   SingleSegmentedSequenceControllerApi,
@@ -40,6 +41,9 @@ const middleware: Middleware = {
 };
 
 export const lapisClient = new LapisControllerApi(new Configuration({ basePath })).withMiddleware(middleware);
+export const lapisInfoClient = new InfoControllerApi(new Configuration({ basePath })).withMiddleware(
+  middleware
+);
 export const lapisClientProtected = new LapisControllerApiProtected(
   new ConfigurationProtected({ basePath: basePathProtected })
 ).withMiddleware(middleware);

--- a/lapis-e2e/test/info.spec.ts
+++ b/lapis-e2e/test/info.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { lapisInfoClient } from './common';
+
+describe('The info endpoind', () => {
+  it('should return all infos', async () => {
+    const info = await lapisInfoClient.getInfo();
+
+    console.log(info);
+
+    expect(info.dataVersion).to.match(/\d+/);
+    expect(info.lapisVersion).to.be.not.empty;
+    expect(info.requestId).to.be.not.empty;
+    expect(info.requestInfo).to.be.not.empty;
+    expect(info.reportTo).to.be.not.empty;
+  });
+});

--- a/lapis/Dockerfile
+++ b/lapis/Dockerfile
@@ -7,6 +7,7 @@ COPY . ./
 RUN ./gradlew bootJar
 
 FROM eclipse-temurin:21-alpine
+ARG VERSION="unspecified"
 
 WORKDIR /workspace
 
@@ -14,6 +15,7 @@ COPY --from=build /workspace/build/libs/*.jar app.jar
 
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
+RUN echo ${VERSION} > version.txt
 
 EXPOSE 8080
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisApplication.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisApplication.kt
@@ -1,11 +1,14 @@
 package org.genspectrum.lapis
 
+import mu.KotlinLogging
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
 class Lapisv2Application
+
+val log = KotlinLogging.logger {}
 
 fun main(args: Array<String>) {
     val referenceGenomeSchemaArgs = ReferenceGenomeSchema.readFromFileFromProgramArgsOrEnv(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -9,6 +9,7 @@ import mu.KotlinLogging
 import org.genspectrum.lapis.auth.DataOpennessAuthorizationFilterFactory
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.DatabaseConfigValidator
+import org.genspectrum.lapis.config.LapisVersion
 import org.genspectrum.lapis.config.NO_REFERENCE_GENOME_FILENAME_ERROR_MESSAGE
 import org.genspectrum.lapis.config.REFERENCE_GENOME_ENV_VARIABLE_NAME
 import org.genspectrum.lapis.config.REFERENCE_GENOME_FILENAME_ARGS_NAME
@@ -34,6 +35,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.web.filter.CommonsRequestLoggingFilter
 import java.io.File
+
+private const val VERSION_FILE = "version.txt"
 
 @Configuration
 @EnableScheduling
@@ -119,4 +122,13 @@ class LapisSpringConfig {
 
         return ReferenceGenome.readFromFile(filename)
     }
+
+    @Bean
+    fun lapisVersion() =
+        try {
+            LapisVersion(File(VERSION_FILE).readText().trim())
+        } catch (e: Exception) {
+            log.info { "Failed to read $VERSION_FILE, assuming local version: ${e.message}" }
+            LapisVersion("local")
+        }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/LapisVersion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/LapisVersion.kt
@@ -1,0 +1,3 @@
+package org.genspectrum.lapis.config
+
+data class LapisVersion(val version: String)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/InfoController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/InfoController.kt
@@ -1,15 +1,20 @@
 package org.genspectrum.lapis.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletRequest
 import org.genspectrum.lapis.config.DatabaseConfig
+import org.genspectrum.lapis.config.LapisVersion
 import org.genspectrum.lapis.config.ReferenceGenome
 import org.genspectrum.lapis.controller.LapisMediaType.APPLICATION_YAML_VALUE
+import org.genspectrum.lapis.controller.middleware.getRequestInfo
+import org.genspectrum.lapis.logging.RequestIdContext
 import org.genspectrum.lapis.model.SiloQueryModel
 import org.genspectrum.lapis.response.LapisInfo
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 const val INFO_ROUTE = "/info"
 const val DATABASE_CONFIG_ROUTE = "/databaseConfig"
@@ -21,12 +26,19 @@ class InfoController(
     private val siloQueryModel: SiloQueryModel,
     private val databaseConfig: DatabaseConfig,
     private val referenceGenome: ReferenceGenome,
+    private val lapisVersion: LapisVersion,
+    private val requestIdContext: RequestIdContext,
 ) {
     @GetMapping(INFO_ROUTE, produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(description = INFO_ENDPOINT_DESCRIPTION)
-    fun getInfo(): LapisInfo {
+    fun getInfo(request: HttpServletRequest): LapisInfo {
         val siloInfo = siloQueryModel.getInfo()
-        return LapisInfo(siloInfo.dataVersion)
+        return LapisInfo(
+            dataVersion = siloInfo.dataVersion,
+            lapisVersion = lapisVersion.version,
+            requestId = requestIdContext.requestId,
+            requestInfo = getRequestInfo(databaseConfig, URI(request.requestURI)),
+        )
     }
 
     @GetMapping(DATABASE_CONFIG_ROUTE, produces = [MediaType.APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE])

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -348,6 +348,7 @@ private fun infoResponseSchema() =
                 "requestId" to Schema<String>().type("string").description(REQUEST_ID_HEADER_DESCRIPTION),
                 "requestInfo" to Schema<String>().type("string").description(REQUEST_INFO_STRING_DESCRIPTION),
                 "reportTo" to Schema<String>().type("string"),
+                "lapisVersion" to StringSchema().description(VERSION_DESCRIPTION),
             ),
         )
         .required(listOf("reportTo"))

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
@@ -88,6 +88,8 @@ If none if provided in the request, LAPIS will generate one.
 const val REQUEST_INFO_STRING_DESCRIPTION =
     "Some information about the request in human readable form. Intended for debugging."
 
+const val VERSION_DESCRIPTION = "The version of LAPIS that processed the request."
+
 const val DOWNLOAD_AS_FILE_DESCRIPTION =
     """
 Set to true to make your browser trigger a download instead of showing the response content by setting the

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
@@ -6,6 +6,7 @@ import org.genspectrum.lapis.openApi.LAPIS_DATA_VERSION_RESPONSE_DESCRIPTION
 import org.genspectrum.lapis.openApi.LAPIS_INFO_DESCRIPTION
 import org.genspectrum.lapis.openApi.REQUEST_ID_HEADER_DESCRIPTION
 import org.genspectrum.lapis.openApi.REQUEST_INFO_STRING_DESCRIPTION
+import org.genspectrum.lapis.openApi.VERSION_DESCRIPTION
 import org.springframework.http.ProblemDetail
 
 data class LapisResponse<Data>(val data: Data, val info: LapisInfo = LapisInfo())
@@ -35,6 +36,11 @@ data class LapisInfo(
     var requestInfo: String? = null,
     @Schema(example = REPORT_TO)
     val reportTo: String = REPORT_TO,
+    @Schema(
+        description = VERSION_DESCRIPTION,
+        example = "1.2.3",
+    )
+    val lapisVersion: String? = null,
 )
 
 data class NucleotideMutationResponse(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/InfoControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/InfoControllerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import org.genspectrum.lapis.controller.LapisMediaType.APPLICATION_YAML_VALUE
 import org.genspectrum.lapis.model.SiloQueryModel
 import org.genspectrum.lapis.response.InfoData
+import org.hamcrest.Matchers.matchesPattern
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,6 +33,7 @@ class InfoControllerTest(
         mockMvc.perform(getSample(INFO_ROUTE))
             .andExpect(status().isOk)
             .andExpect(jsonPath("\$.dataVersion").value("1234"))
+            .andExpect(jsonPath("\$.lapisVersion").value(matchesPattern(".+")))
     }
 
     @Test


### PR DESCRIPTION
This works by reading a `version.txt` from `./`
* locally, the version should be unspecified
* for branch builds, the version should be the commit hash
* for released versions, the version should be the semver tag


## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
