### PR TITLE
fix(lapis): don't show the single segmented sequence download when there are no nucleotide sequences

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceController.kt
@@ -40,11 +40,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-const val IS_SINGLE_SEGMENT_SEQUENCE_EXPRESSION =
-    "#{'\${$REFERENCE_GENOME_SEGMENTS_APPLICATION_ARG_PREFIX}'.split(',').length == 1}"
+const val SHOW_SINGLE_SEGMENTED_CONTROLLER =
+    "#{'\${$REFERENCE_GENOME_SEGMENTS_APPLICATION_ARG_PREFIX}'.split(',').length == 1 &&" +
+        "'\${$REFERENCE_GENOME_SEGMENTS_APPLICATION_ARG_PREFIX}' > ''}"
 
 @RestController
-@ConditionalOnExpression(IS_SINGLE_SEGMENT_SEQUENCE_EXPRESSION)
+@ConditionalOnExpression(SHOW_SINGLE_SEGMENTED_CONTROLLER)
 @RequestMapping("/sample")
 class SingleSegmentedSequenceController(
     private val siloQueryModel: SiloQueryModel,


### PR DESCRIPTION

In the context of https://github.com/loculus-project/loculus/issues/3388


This will simply show no endpoint to download nucleotide sequences when there are none in the reference genomes. Without this change, it shows the single segmented endpoints that throw index out of bounds exceptions:
https://github.com/GenSpectrum/LAPIS/blob/c6f625e22074731e12f6cdbcb68344350e65503e/lapis/src/main/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceController.kt#L109

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
