### PR TITLE
feat(lapis): pass through `coverage` from SILO in mutation endpoints

### DIFF
--- a/lapis-e2e/test/aminoAcidMutations.spec.ts
+++ b/lapis-e2e/test/aminoAcidMutations.spec.ts
@@ -88,6 +88,7 @@ describe('The /aminoAcidMutations endpoint', () => {
   it('should correctly handle nucleotide insertion requests', async () => {
     const expectedFirstResultWithNucleotideInsertion = {
       count: 1,
+      coverage: 1,
       mutation: 'E:T9I',
       mutationFrom: 'T',
       mutationTo: 'I',
@@ -109,6 +110,7 @@ describe('The /aminoAcidMutations endpoint', () => {
   it('should correctly handle amino acid insertion requests', async () => {
     const expectedFirstResultWithAminoAcidInsertion = {
       count: 1,
+      coverage: 1,
       mutation: 'N:A220V',
       mutationFrom: 'A',
       mutationTo: 'V',
@@ -140,15 +142,15 @@ describe('The /aminoAcidMutations endpoint', () => {
 
     expect(resultText).to.contain(
       String.raw`
-mutation,count,proportion,sequenceName,mutationFrom,mutationTo,position
+mutation,count,coverage,proportion,sequenceName,mutationFrom,mutationTo,position
     `.trim()
     );
 
     expect(resultText).to.contain(
       String.raw`
-N:A220V,1,0.058823529411764705,N,A,V,220
-S:A222V,3,0.1875,S,A,V,222
-ORF1a:A2529V,3,0.17647058823529413,ORF1a,A,V,2529
+N:A220V,1,17,0.058823529411764705,N,A,V,220
+S:A222V,3,16,0.1875,S,A,V,222
+ORF1a:A2529V,3,17,0.17647058823529413,ORF1a,A,V,2529
 `.trim()
     );
   });
@@ -166,15 +168,15 @@ ORF1a:A2529V,3,0.17647058823529413,ORF1a,A,V,2529
 
     expect(resultText).to.contain(
       String.raw`
-mutation	count	proportion	sequenceName	mutationFrom	mutationTo	position
+mutation	count	coverage	proportion	sequenceName	mutationFrom	mutationTo	position
     `.trim()
     );
 
     expect(resultText).to.contain(
       String.raw`
-N:A220V	1	0.058823529411764705	N	A	V	220
-S:A222V	3	0.1875	S	A	V	222
-ORF1a:A2529V	3	0.17647058823529413	ORF1a	A	V	2529
+N:A220V	1	17	0.058823529411764705	N	A	V	220
+S:A222V	3	16	0.1875	S	A	V	222
+ORF1a:A2529V	3	17	0.17647058823529413	ORF1a	A	V	2529
     `.trim()
     );
   });

--- a/lapis-e2e/test/nucleotideMutations.spec.ts
+++ b/lapis-e2e/test/nucleotideMutations.spec.ts
@@ -106,6 +106,7 @@ describe('The /nucleotideMutations endpoint', () => {
   it('should correctly handle nucleotide insertion requests', async () => {
     const expectedFirstResultWithNucleotideInsertion = {
       count: 1,
+      coverage: 1,
       mutation: 'C241T',
       proportion: 1.0,
       mutationFrom: 'C',
@@ -127,6 +128,7 @@ describe('The /nucleotideMutations endpoint', () => {
   it('should correctly handle amino acid insertion requests', async () => {
     const expectedFirstResultWithAminoAcidInsertion = {
       count: 1,
+      coverage: 1,
       mutation: 'G210T',
       proportion: 1.0,
       mutationFrom: 'G',
@@ -158,15 +160,15 @@ describe('The /nucleotideMutations endpoint', () => {
 
     expect(resultText).to.contain(
       String.raw`
-mutation,count,proportion,sequenceName,mutationFrom,mutationTo,position
+mutation,count,coverage,proportion,sequenceName,mutationFrom,mutationTo,position
     `.trim()
     );
 
     expect(resultText).to.contain(
       String.raw`
-C7029T,1,0.0625,,C,T,7029
-C71-,1,0.058823529411764705,,C,-,71
-C7124T,2,0.11764705882352941,,C,T,7124
+C7029T,1,16,0.0625,,C,T,7029
+C71-,1,17,0.058823529411764705,,C,-,71
+C7124T,2,17,0.11764705882352941,,C,T,7124
 `.trim()
     );
   });
@@ -184,15 +186,15 @@ C7124T,2,0.11764705882352941,,C,T,7124
 
     expect(resultText).to.contain(
       String.raw`
-mutation	count	proportion	sequenceName	mutationFrom	mutationTo	position
+mutation	count	coverage	proportion	sequenceName	mutationFrom	mutationTo	position
     `.trim()
     );
 
     expect(resultText).to.contain(
       String.raw`
-C7029T	1	0.0625		C	T	7029
-C71-	1	0.058823529411764705		C	-	71
-C7124T	2	0.11764705882352941		C	T	7124
+C7029T	1	16	0.0625		C	T	7029
+C71-	1	17	0.058823529411764705		C	-	71
+C7124T	2	17	0.11764705882352941		C	T	7124
     `.trim()
     );
   });

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -59,6 +59,7 @@ class SiloQueryModel(
             NucleotideMutationResponse(
                 mutation = mutation,
                 count = it.count,
+                coverage = it.coverage,
                 proportion = it.proportion,
                 sequenceName = when (referenceGenomeSchema.isSingleSegmented()) {
                     true -> null
@@ -89,6 +90,7 @@ class SiloQueryModel(
             AminoAcidMutationResponse(
                 mutation = "${it.sequenceName}:${it.mutation}",
                 count = it.count,
+                coverage = it.coverage,
                 proportion = it.proportion,
                 sequenceName = it.sequenceName,
                 mutationFrom = it.mutationFrom,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -466,11 +466,16 @@ private fun nucleotideMutationProportionSchema() =
             .example(0.54321)
             .description(
                 "Number of sequences with this mutation divided by the total number sequences matching the " +
-                    "given filter criteria with non-ambiguous reads at that position",
+                    "given filter criteria with non-ambiguous reads at that position (i.e. count/coverage).",
             ),
         "count" to IntegerSchema()
             .example(1234)
             .description("Total number of sequences with this mutation matching the given sequence filter criteria"),
+        "coverage" to IntegerSchema()
+            .example(2345)
+            .description(
+                "Total number of sequences with non-ambiguous reads matching the given sequence filter criteria",
+            ),
         "sequenceName" to StringSchema()
             .example("sequence1")
             .description(
@@ -496,11 +501,16 @@ private fun aminoAcidMutationProportionSchema() =
             .example(0.54321)
             .description(
                 "Number of sequences with this mutation divided by the total number sequences matching the " +
-                    "given filter criteria with non-ambiguous reads at that position",
+                    "given filter criteria with non-ambiguous reads at that position (i.e. count/coverage).",
             ),
         "count" to IntegerSchema()
             .example(42)
             .description("Total number of sequences with this mutation matching the given sequence filter criteria"),
+        "coverage" to IntegerSchema()
+            .example(2345)
+            .description(
+                "Total number of sequences with non-ambiguous reads matching the given sequence filter criteria",
+            ),
         "sequenceName" to StringSchema()
             .example("ORF1a")
             .description("The name of the gene in which the mutation occurs."),

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
@@ -50,6 +50,7 @@ data class LapisInfo(
 data class NucleotideMutationResponse(
     val mutation: String,
     val count: Int,
+    val coverage: Int,
     val proportion: Double,
     val sequenceName: String?,
     val mutationFrom: String,
@@ -60,6 +61,7 @@ data class NucleotideMutationResponse(
         listOf(
             mutation,
             count.toString(),
+            coverage.toString(),
             proportion.toString(),
             sequenceName ?: "",
             mutationFrom,
@@ -71,6 +73,7 @@ data class NucleotideMutationResponse(
         listOf(
             "mutation",
             "count",
+            "coverage",
             "proportion",
             "sequenceName",
             "mutationFrom",
@@ -82,6 +85,7 @@ data class NucleotideMutationResponse(
 data class AminoAcidMutationResponse(
     val mutation: String,
     val count: Int,
+    val coverage: Int,
     val proportion: Double,
     val sequenceName: String,
     val mutationFrom: String,
@@ -92,6 +96,7 @@ data class AminoAcidMutationResponse(
         listOf(
             mutation,
             count.toString(),
+            coverage.toString(),
             proportion.toString(),
             sequenceName,
             mutationFrom,
@@ -103,6 +108,7 @@ data class AminoAcidMutationResponse(
         listOf(
             "mutation",
             "count",
+            "coverage",
             "proportion",
             "sequenceName",
             "mutationFrom",

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -90,6 +90,7 @@ data class MutationData(
     val mutationFrom: String,
     val mutationTo: String,
     val position: Int,
+    val coverage: Int,
 )
 
 data class InsertionData(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
@@ -141,6 +141,7 @@ class LapisControllerTest(
             .andExpect(jsonPath("\$.data[0].mutation").value("the mutation"))
             .andExpect(jsonPath("\$.data[0].proportion").value(0.5))
             .andExpect(jsonPath("\$.data[0].count").value(42))
+            .andExpect(jsonPath("\$.data[0].coverage").value(52))
             .andExpect(header().stringValues("Lapis-Data-Version", "1234"))
             .andExpect(jsonPath("\$.info.dataVersion").value(1234))
     }
@@ -196,6 +197,7 @@ class LapisControllerTest(
                     containsInAnyOrder(
                         "mutation",
                         "proportion",
+                        "coverage",
                         "count",
                         "sequenceName",
                         "mutationFrom",
@@ -499,6 +501,7 @@ private fun someNucleotideMutationProportion() =
     NucleotideMutationResponse(
         mutation = "the mutation",
         count = 42,
+        coverage = 52,
         proportion = 0.5,
         sequenceName = "sequenceName",
         mutationFrom = "G",
@@ -510,6 +513,7 @@ private fun someAminoAcidMutationProportion() =
     AminoAcidMutationResponse(
         mutation = "the mutation",
         count = 42,
+        coverage = 52,
         proportion = 0.5,
         sequenceName = "sequenceName",
         mutationFrom = "G",

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MockData.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MockData.kt
@@ -303,6 +303,7 @@ object MockDataForEndpoints {
             NucleotideMutationResponse(
                 mutation = "sequenceName:A1234T",
                 count = 2345,
+                coverage = 3456,
                 proportion = 0.987,
                 sequenceName = "sequenceName",
                 mutationFrom = "A",
@@ -315,6 +316,7 @@ object MockDataForEndpoints {
                 {
                     "mutation": "sequenceName:A1234T",
                     "count": 2345,
+                    "coverage": 3456,
                     "proportion": 0.987,
                     "sequenceName": "sequenceName",
                     "mutationFrom": "A",
@@ -324,13 +326,13 @@ object MockDataForEndpoints {
             ]
         """.trimIndent(),
         expectedCsv = """
-            mutation,count,proportion,sequenceName,mutationFrom,mutationTo,position
-            sequenceName:A1234T,2345,0.987,sequenceName,A,T,1234
+            mutation,count,coverage,proportion,sequenceName,mutationFrom,mutationTo,position
+            sequenceName:A1234T,2345,3456,0.987,sequenceName,A,T,1234
             
         """.trimIndent(),
         expectedTsv = """
-            mutation	count	proportion	sequenceName	mutationFrom	mutationTo	position
-            sequenceName:A1234T	2345	0.987	sequenceName	A	T	1234
+            mutation	count	coverage	proportion	sequenceName	mutationFrom	mutationTo	position
+            sequenceName:A1234T	2345	3456	0.987	sequenceName	A	T	1234
             
         """.trimIndent(),
     )
@@ -341,6 +343,7 @@ object MockDataForEndpoints {
             AminoAcidMutationResponse(
                 mutation = "sequenceName:A1234T",
                 count = 2345,
+                coverage = 3456,
                 proportion = 0.987,
                 sequenceName = "sequenceName",
                 mutationFrom = "A",
@@ -353,6 +356,7 @@ object MockDataForEndpoints {
                 {
                     "mutation": "sequenceName:A1234T",
                     "count": 2345,
+                    "coverage": 3456,
                     "proportion": 0.987,
                     "sequenceName": "sequenceName",
                     "mutationFrom": "A",
@@ -362,13 +366,13 @@ object MockDataForEndpoints {
             ]
         """.trimIndent(),
         expectedCsv = """
-            mutation,count,proportion,sequenceName,mutationFrom,mutationTo,position
-            sequenceName:A1234T,2345,0.987,sequenceName,A,T,1234
+            mutation,count,coverage,proportion,sequenceName,mutationFrom,mutationTo,position
+            sequenceName:A1234T,2345,3456,0.987,sequenceName,A,T,1234
             
         """.trimIndent(),
         expectedTsv = """
-            mutation	count	proportion	sequenceName	mutationFrom	mutationTo	position
-            sequenceName:A1234T	2345	0.987	sequenceName	A	T	1234
+            mutation	count	coverage	proportion	sequenceName	mutationFrom	mutationTo	position
+            sequenceName:A1234T	2345	3456	0.987	sequenceName	A	T	1234
             
         """.trimIndent(),
     )

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
@@ -31,6 +31,7 @@ import java.util.stream.Stream
 private val someMutationData = MutationData(
     mutation = "A1234B",
     count = 1234,
+    coverage = 2345,
     proportion = 0.1234,
     sequenceName = "sequenceName",
     mutationFrom = "A",
@@ -118,6 +119,7 @@ class SiloQueryModelTest {
         val expectedMutation = NucleotideMutationResponse(
             mutation = "A1234B",
             count = 1234,
+            coverage = 2345,
             proportion = 0.1234,
             sequenceName = null,
             mutationFrom = "A",
@@ -140,6 +142,7 @@ class SiloQueryModelTest {
         val expectedMutation = NucleotideMutationResponse(
             mutation = "sequenceName:A1234B",
             count = 1234,
+            coverage = 2345,
             proportion = 0.1234,
             sequenceName = "sequenceName",
             mutationFrom = "A",
@@ -161,6 +164,7 @@ class SiloQueryModelTest {
         val expectedMutation = AminoAcidMutationResponse(
             mutation = "sequenceName:A1234B",
             count = 1234,
+            coverage = 2345,
             proportion = 0.1234,
             sequenceName = "sequenceName",
             mutationFrom = "A",

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -106,8 +106,8 @@ class SiloClientTest(
                 .withContentType(MediaType.APPLICATION_JSON_UTF_8)
                 .withBody(
                     """
-{"count": 51,"mutation": "C3037T","mutationFrom": "C","mutationTo": "T","position": 3037,"proportion": 1,"sequenceName": "main"}
-{"count": 52,"mutation": "C14408T","mutationFrom": "C","mutationTo": "T","position": 14408,"proportion": 1,"sequenceName": "main"}
+{"count": 51,"mutation": "C3037T","mutationFrom": "C","mutationTo": "T","position": 3037,"proportion": 1,"sequenceName": "main","coverage":100}
+{"count": 52,"mutation": "C14408T","mutationFrom": "C","mutationTo": "T","position": 14408,"proportion": 1,"sequenceName": "main","coverage":101}
                     """,
                 ),
         )
@@ -127,6 +127,7 @@ class SiloClientTest(
                     mutationFrom = "C",
                     mutationTo = "T",
                     position = 3037,
+                    coverage = 100,
                 ),
                 MutationData(
                     mutation = "C14408T",
@@ -136,6 +137,7 @@ class SiloClientTest(
                     mutationFrom = "C",
                     mutationTo = "T",
                     position = 14408,
+                    coverage = 101,
                 ),
             ),
         )


### PR DESCRIPTION
resolves #1091

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
