### PR TITLE
fix(lapis): only keep old log files for 30 days

### DIFF
--- a/lapis/src/main/resources/logback.xml
+++ b/lapis/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/archived/${LOG_FILE}-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxFileSize>10GB</maxFileSize>
-            <maxHistory>0</maxHistory>
+            <maxHistory>30</maxHistory>
         </rollingPolicy>
     </appender>
 
@@ -27,7 +27,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/archived/${STATISTICS_LOG_FILE}-%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
             <maxFileSize>10GB</maxFileSize>
-            <maxHistory>0</maxHistory>
+            <maxHistory>30</maxHistory>
         </rollingPolicy>
     </appender>
 


### PR DESCRIPTION
The log files on the server were piling up. I think we can safely delete old ones.

https://logback.qos.ch/manual/appenders.html#tbrpMaxHistory

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
