### PR TITLE
fix(lapis): pass correctly escaped stop codon to SILO

### DIFF
--- a/.idea/runConfigurations/LapisOpen.xml
+++ b/.idea/runConfigurations/LapisOpen.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="LapisOpen" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ALTERNATIVE_JRE_PATH" value="21" />
+    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <module name="lapis.main" />
     <option name="PROGRAM_PARAMETERS" value="--silo.url=http://localhost:8091 --lapis.databaseConfig.path=lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml --referenceGenomeFilename=lapis-e2e/testData/singleSegmented/reference_genomes.json --server.port=8090" />

--- a/lapis-e2e/test/aggregatedQueries/aminoAcidInsertionWithStopCodon.json
+++ b/lapis-e2e/test/aggregatedQueries/aminoAcidInsertionWithStopCodon.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "an amino acid insertions with stop codon: ins_ORF8:123:*AA",
+  "lapisRequest": {
+    "aminoAcidInsertions": ["ins_ORF8:123:*AA"]
+  },
+  "expected": [
+    {
+      "count": 1
+    }
+  ]
+}

--- a/lapis-e2e/test/aggregatedQueries/aminoAcidInsertionWithWildcard.json
+++ b/lapis-e2e/test/aggregatedQueries/aminoAcidInsertionWithWildcard.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "an amino acid insertions with wildcard: ins_ORF8:123:?",
+  "lapisRequest": {
+    "aminoAcidInsertions": ["ins_ORF8:123:?"]
+  },
+  "expected": [
+    {
+      "count": 5
+    }
+  ]
+}

--- a/lapis-e2e/test/aggregatedQueries/aminoAcidInsertionWithWildcardAndStopCodon.json
+++ b/lapis-e2e/test/aggregatedQueries/aminoAcidInsertionWithWildcardAndStopCodon.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "an amino acid insertions with wildcard: ins_ORF8:123:T?*?",
+  "lapisRequest": {
+    "aminoAcidInsertions": ["ins_ORF8:123:T?*?"]
+  },
+  "expected": [
+    {
+      "count": 2
+    }
+  ]
+}

--- a/lapis-e2e/test/aminoAcidInsertions.spec.ts
+++ b/lapis-e2e/test/aminoAcidInsertions.spec.ts
@@ -9,7 +9,7 @@ describe('The /aminoAcidInsertions endpoint', () => {
       insertionsRequest: { country: 'Switzerland' },
     });
 
-    expect(result.data).to.have.length(6);
+    expect(result.data).to.have.length(11);
 
     const specificInsertion = result.data.find(insertionData => insertionData.insertion === someInsertion);
     expect(specificInsertion?.count).to.equal(5);

--- a/lapis/README.md
+++ b/lapis/README.md
@@ -90,3 +90,21 @@ For example:
 ```
 ./gradlew bootRun --args='--silo.url=http://localhost:8091 --lapis.databaseConfig.path=../lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml --referenceGenomeFilename=../lapis-e2e/testData/singleSegmented/reference_genomes.json  --server.port=8090'
 ```
+
+## OpenApi Docs
+
+To generate the OpenApi docs run
+```bash
+./gradlew generateOpenApiDocs
+```
+
+To generate the OpenApi docs for an instance with multi-segmented reference genome run
+```bash
+./gradlew generateOpenApiDocs -Psegmented=true
+```
+
+To generate the OpenApi docs for a protected instance run
+```bash
+./gradlew generateOpenApiDocs -PopennessLevel=protected
+```
+

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -19,8 +19,10 @@ import mu.KotlinLogging
 import org.antlr.v4.runtime.RuleContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.request.ESCAPED_STOP_CODON
 import org.genspectrum.lapis.request.LAPIS_INSERTION_AMBIGUITY_SYMBOL
 import org.genspectrum.lapis.request.SILO_INSERTION_AMBIGUITY_SYMBOL
+import org.genspectrum.lapis.request.STOP_CODON
 import org.genspectrum.lapis.silo.AminoAcidInsertionContains
 import org.genspectrum.lapis.silo.AminoAcidSymbolEquals
 import org.genspectrum.lapis.silo.And
@@ -131,7 +133,7 @@ class VariantQueryCustomListener(
         expressionStack.addLast(
             NucleotideInsertionContains(
                 ctx.position().text.toInt(),
-                value.uppercase(),
+                value,
                 null,
             ),
         )
@@ -159,7 +161,7 @@ class VariantQueryCustomListener(
         expressionStack.addLast(
             AminoAcidInsertionContains(
                 ctx.position().text.toInt(),
-                value.uppercase(),
+                value,
                 gene,
             ),
         )
@@ -195,9 +197,10 @@ class VariantQueryCustomListener(
 
 fun mapInsertionSymbol(ctx: RuleContext): String =
     when (ctx.text) {
+        STOP_CODON -> ESCAPED_STOP_CODON
         LAPIS_INSERTION_AMBIGUITY_SYMBOL -> SILO_INSERTION_AMBIGUITY_SYMBOL
         else -> ctx.text
-    }
+    }.uppercase()
 
 class SiloNotImplementedError(
     message: String?,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidInsertion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidInsertion.kt
@@ -9,6 +9,9 @@ import org.springframework.boot.jackson.JsonComponent
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
 
+const val STOP_CODON = "*"
+const val ESCAPED_STOP_CODON = "\\*"
+
 data class AminoAcidInsertion(
     val position: Int,
     val gene: String,
@@ -35,7 +38,7 @@ data class AminoAcidInsertion(
                 )
             val geneName = referenceGenomeSchema.getGeneFromLowercaseName(geneLowerCase).name
 
-            val insertions = matchGroups["insertions"]?.value?.replace(
+            val insertions = matchGroups["insertions"]?.value?.replace(STOP_CODON, ESCAPED_STOP_CODON)?.replace(
                 LAPIS_INSERTION_AMBIGUITY_SYMBOL,
                 SILO_INSERTION_AMBIGUITY_SYMBOL,
             )?.uppercase()
@@ -54,7 +57,7 @@ data class AminoAcidInsertion(
 
 private val AMINO_ACID_INSERTION_REGEX =
     Regex(
-        """^ins_(?<gene>[a-zA-Z0-9_-]+):(?<position>\d+):(?<insertions>(([a-zA-Z?]|(\.\*))+))$""",
+        """^ins_(?<gene>[a-zA-Z0-9_-]+):(?<position>\d+):(?<insertions>(([a-zA-Z?]|(\*))+))$""",
         setOf(
             RegexOption.IGNORE_CASE,
         ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -405,6 +405,15 @@ class VariantQueryFacadeTest {
     }
 
     @Test
+    fun `given a valid variantQuery with a stop codon expression then returns SILO query`() {
+        val variantQuery = "ins_S:501:A*C"
+
+        val result = underTest.map(variantQuery)
+
+        assertThat(result, equalTo(AminoAcidInsertionContains(501, "A\\*C", "S")))
+    }
+
+    @Test
     fun `given a valid variantQuery with a 'AA insertion' expression with lower case then returns SILO query`() {
         val variantQuery = "ins_ORF1a:501:ePe"
 
@@ -429,6 +438,15 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         assertThat(result, equalTo(AminoAcidInsertionContains(501, "E.*E.*", "S")))
+    }
+
+    @Test
+    fun `given a valid variantQuery with a 'AA insertion' with stop codon and wildcard then returns SILO query`() {
+        val variantQuery = "ins_S:501:E?*E"
+
+        val result = underTest.map(variantQuery)
+
+        assertThat(result, equalTo(AminoAcidInsertionContains(501, "E.*\\*E", "S")))
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidInsertionTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidInsertionTest.kt
@@ -61,14 +61,6 @@ class AminoAcidInsertionTest {
                     AminoAcidInsertion(123, "gene1", ".*"),
                 ),
                 Arguments.of(
-                    "\"ins_gene1:123:.*CD\"",
-                    AminoAcidInsertion(123, "gene1", ".*CD"),
-                ),
-                Arguments.of(
-                    "\"ins_gene1:123:AB.*.*\"",
-                    AminoAcidInsertion(123, "gene1", "AB.*.*"),
-                ),
-                Arguments.of(
                     "\"ins_gene1:123:?CD\"",
                     AminoAcidInsertion(123, "gene1", ".*CD"),
                 ),
@@ -77,8 +69,16 @@ class AminoAcidInsertionTest {
                     AminoAcidInsertion(123, "gene1", "AB.*.*"),
                 ),
                 Arguments.of(
-                    "\"ins_gene1:123:AB.*?CD\"",
-                    AminoAcidInsertion(123, "gene1", "AB.*.*CD"),
+                    "\"ins_gene1:123:AB*\"",
+                    AminoAcidInsertion(123, "gene1", "AB\\*"),
+                ),
+                Arguments.of(
+                    "\"ins_gene1:123:A*B\"",
+                    AminoAcidInsertion(123, "gene1", "A\\*B"),
+                ),
+                Arguments.of(
+                    "\"ins_gene1:123:A*?B\"",
+                    AminoAcidInsertion(123, "gene1", "A\\*.*B"),
                 ),
                 Arguments.of(
                     "\"ins_gene1:123:abCd\"",
@@ -104,6 +104,8 @@ class AminoAcidInsertionTest {
                 Arguments.of("\"ins_123:ABCD\""),
                 Arguments.of("\"ins_gene1\$name&with/invalid)chars:123:A\""),
                 Arguments.of("\"ins_notInReferenceGenome:123:ABCD\""),
+                Arguments.of("\"ins_gene1:123:.*CD\""),
+                Arguments.of("\"ins_gene1:123:AB.*.*\""),
             )
     }
 }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -518,6 +518,17 @@ class SiloQueryTest {
                     """,
                 ),
                 Arguments.of(
+                    AminoAcidInsertionContains(1234, "A\\*B", "someGene"),
+                    """
+                        {
+                            "type": "AminoAcidInsertionContains",
+                            "position": 1234,
+                            "value": "A\\*B",
+                            "sequenceName":"someGene"
+                        }
+                    """,
+                ),
+                Arguments.of(
                     DateBetween("fieldName", LocalDate.of(2021, 3, 31), LocalDate.of(2022, 6, 3)),
                     """
                         {


### PR DESCRIPTION
Resolves #1105

Escapes the stop codon correctly, when passing it to SILO. 

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
