### PR TITLE
feat(lapis): return empty lineage definitions when SILO returns an empty file

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -128,6 +128,11 @@ open class CachedSiloClient(
         ) { it.GET() }
 
         val body = response.body()
+
+        if (body.isBlank()) {
+            return emptyMap()
+        }
+
         try {
             return yamlObjectMapper.objectMapper.readValue(body)
         } catch (e: Exception) {


### PR DESCRIPTION


follow up to #1117

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
