### PR TITLE
fix(lapis-docs): mention how arrays must be supplied in form urlencoded requests

### DIFF
--- a/.idea/runConfigurations/LapisOpen.xml
+++ b/.idea/runConfigurations/LapisOpen.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="LapisOpen" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
+    <option name="ALTERNATIVE_JRE_PATH" value="21" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <module name="lapis.main" />
     <option name="PROGRAM_PARAMETERS" value="--silo.url=http://localhost:8091 --lapis.databaseConfig.path=lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml --referenceGenomeFilename=lapis-e2e/testData/singleSegmented/reference_genomes.json --server.port=8090" />

--- a/lapis-docs/src/content/docs/concepts/request-methods.mdx
+++ b/lapis-docs/src/content/docs/concepts/request-methods.mdx
@@ -64,6 +64,8 @@ Check out the [fields](../references/fields) and [filters](../references/filters
 LAPIS also supports [URL encoded form data](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) for POST requests.
 The content type must be set to `application/x-www-form-urlencoded` and the query must be encoded as a query string.
 
+Note that arrays must be passed as repeated keys, e.g. `fields=country&fields=date`.
+
 :::tip
 This is useful if you want to send the query directly from a HTML form.
 If `<form>` element has the `method` attribute set to `POST`

--- a/lapis-e2e/test/aggregated.spec.ts
+++ b/lapis-e2e/test/aggregated.spec.ts
@@ -124,7 +124,7 @@ describe('The /aggregated endpoint', () => {
 
     expect(result.status).equals(400);
     const resultJson = await result.json();
-    expect(resultJson.error.detail).to.include('Unknown field: notAField, known values are [primaryKey,');
+    expect(resultJson.error.detail).to.include("Unknown field: 'notAField', known values are [primaryKey,");
   });
 
   it('should return bad request for invalid variant query', async () => {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/Field.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/Field.kt
@@ -14,7 +14,7 @@ class FieldConverter(
     fun convert(source: String): Field {
         val cleaned = caseInsensitiveFieldsCleaner.clean(source)
             ?: throw BadRequestException(
-                "Unknown field: $source, known values are ${caseInsensitiveFieldsCleaner.getKnownFields()}",
+                "Unknown field: '$source', known values are ${caseInsensitiveFieldsCleaner.getKnownFields()}",
             )
 
         return Field(cleaned)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
@@ -445,7 +445,7 @@ class LapisControllerCommonFieldsTest(
             .andExpect(
                 jsonPath(
                     "\$.error.detail",
-                ).value(Matchers.containsString("Unknown field: nonExistingField, known values are [primaryKey,")),
+                ).value(Matchers.containsString("Unknown field: 'nonExistingField', known values are [primaryKey,")),
             )
     }
 


### PR DESCRIPTION
I also did some more research. I's a bit unclear how arrays should actually be supplied, some sources also mentioned `fields=value1,value2`. Spring itself does not accept this, so I guess it's ok that we also don't accept it.

resolves #1089


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
