### PR TITLE
feat(lapis): add `fields` property to mutation endpoints

### DIFF
--- a/lapis-e2e/test/aminoAcidMutations.spec.ts
+++ b/lapis-e2e/test/aminoAcidMutations.spec.ts
@@ -29,6 +29,26 @@ describe('The /aminoAcidMutations endpoint', () => {
     expect(commonMutationProportion?.position).to.be.equal(478);
   });
 
+  it('should return only mutation when asking for only mutation', async () => {
+    const result = await lapisClient.postAminoAcidMutations({
+      sequenceFiltersWithMinProportion: { fields: ['mutation'], limit: 1, orderBy: [{ field: 'mutation' }] },
+    });
+
+    expect(result.data).to.have.length(1);
+
+    const mutation = result.data[0];
+    expect(mutation).to.deep.equal({
+      mutation: 'ORF1a:A1306S',
+      count: undefined,
+      coverage: undefined,
+      mutationFrom: undefined,
+      mutationTo: undefined,
+      position: undefined,
+      proportion: undefined,
+      sequenceName: undefined,
+    });
+  });
+
   it('should return mutation proportions for Switzerland with minProportion 0.5', async () => {
     const result = await lapisClient.postAminoAcidMutations({
       sequenceFiltersWithMinProportion: {

--- a/lapis-e2e/test/nucleotideMutations.spec.ts
+++ b/lapis-e2e/test/nucleotideMutations.spec.ts
@@ -29,6 +29,26 @@ describe('The /nucleotideMutations endpoint', () => {
     expect(commonMutationProportion?.position).to.be.equal(28280);
   });
 
+  it('should return only mutation when asking for only mutation', async () => {
+    const result = await lapisClient.postNucleotideMutations({
+      sequenceFiltersWithMinProportion: { fields: ['mutation'], limit: 1, orderBy: [{ field: 'mutation' }] },
+    });
+
+    expect(result.data).to.have.length(1);
+
+    const mutation = result.data[0];
+    expect(mutation).to.deep.equal({
+      mutation: 'A1-',
+      count: undefined,
+      coverage: undefined,
+      mutationFrom: undefined,
+      mutationTo: undefined,
+      position: undefined,
+      proportion: undefined,
+      sequenceName: undefined,
+    });
+  });
+
   it('should return mutations proportions for multi segmented', async () => {
     const result = await lapisClientMultiSegmented.postNucleotideMutations({
       sequenceFiltersWithMinProportion: { country: 'Switzerland' },

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
@@ -54,6 +54,11 @@ const val DETAILS_FIELDS_DESCRIPTION =
 If empty, all fields are returned.
 If requesting CSV or TSV data, the columns are ordered in the same order as the fields are specified here.
 """
+const val MUTATIONS_FIELDS_DESCRIPTION =
+    """The fields that the response items should contain.
+If empty, all fields are returned.
+If requesting CSV or TSV data, the columns are ordered in the same order as the fields are specified here.
+"""
 const val DETAILS_ORDER_BY_FIELDS_DESCRIPTION =
     """The fields of the response to order by. Fields specified here must also be present in \"fields\"."""
 const val LIMIT_DESCRIPTION = """The maximum number of entries to return in the response"""

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
@@ -23,6 +23,7 @@ import org.genspectrum.lapis.controller.LIMIT_DESCRIPTION
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisHeaders.REQUEST_ID
 import org.genspectrum.lapis.controller.LapisMediaType
+import org.genspectrum.lapis.controller.MUTATIONS_FIELDS_DESCRIPTION
 import org.genspectrum.lapis.controller.NUCLEOTIDE_INSERTIONS_ENDPOINT_DESCRIPTION
 import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATION_ENDPOINT_DESCRIPTION
 import org.genspectrum.lapis.controller.OFFSET_DESCRIPTION
@@ -66,6 +67,7 @@ const val FORMAT_SCHEMA = "DataFormat"
 const val SEQUENCES_FORMAT_SCHEMA = "SequencesDataFormat"
 const val FIELDS_TO_AGGREGATE_BY_SCHEMA = "FieldsToAggregateBy"
 const val DETAILS_FIELDS_SCHEMA = "DetailsFields"
+const val MUTATIONS_FIELDS_SCHEMA = "MutationsFields"
 const val GENE_SCHEMA = "Gene"
 const val SEGMENT_SCHEMA = "Segment"
 
@@ -412,6 +414,14 @@ annotation class FieldsToAggregateBy
     description = DETAILS_FIELDS_DESCRIPTION,
 )
 annotation class DetailsFields
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@Parameter(
+    schema = Schema(ref = "#/components/schemas/$MUTATIONS_FIELDS_SCHEMA"),
+    description = MUTATIONS_FIELDS_DESCRIPTION,
+)
+annotation class MutationsFields
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/Field.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/Field.kt
@@ -7,11 +7,15 @@ data class Field(
     val fieldName: String,
 )
 
+fun interface FieldConverter<T> {
+    fun convert(source: String): T
+}
+
 @Component
-class FieldConverter(
+class CaseInsensitiveFieldConverter(
     private val caseInsensitiveFieldsCleaner: CaseInsensitiveFieldsCleaner,
-) {
-    fun convert(source: String): Field {
+) : FieldConverter<Field> {
+    override fun convert(source: String): Field {
         val cleaned = caseInsensitiveFieldsCleaner.clean(source)
             ?: throw BadRequestException(
                 "Unknown field: '$source', known values are ${caseInsensitiveFieldsCleaner.getKnownFields()}",

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
@@ -1,5 +1,7 @@
 package org.genspectrum.lapis.response
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonValue
 import io.swagger.v3.oas.annotations.media.Schema
 import org.genspectrum.lapis.openApi.LAPIS_DATA_VERSION_EXAMPLE
 import org.genspectrum.lapis.openApi.LAPIS_DATA_VERSION_RESPONSE_DESCRIPTION
@@ -50,15 +52,16 @@ data class LapisInfo(
     val siloVersion: String? = null,
 )
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class MutationResponse(
-    val mutation: String,
-    val count: Int,
-    val coverage: Int,
-    val proportion: Double,
-    val sequenceName: String?,
-    val mutationFrom: String,
-    val mutationTo: String,
-    val position: Int,
+    val mutation: String?,
+    val count: Int?,
+    val coverage: Int?,
+    val proportion: Double?,
+    val sequenceName: ExplicitlyNullable<String>?,
+    val mutationFrom: String?,
+    val mutationTo: String?,
+    val position: Int?,
 )
 
 data class InsertionResponse(
@@ -67,4 +70,25 @@ data class InsertionResponse(
     val insertedSymbols: String,
     val position: Int,
     val sequenceName: String?,
+)
+
+/**
+ * In Javascript terms, this is equivalent to using `null` instead of `undefined`.
+ * ExplicitlyNullable is used to serialize null values in JSON when the surrounding class ignores null values,
+ * i.e. treats `null` as `undefined`.
+ * In some cases, you still want to be able to explicitly set `null` on a field.
+ *
+ * Example:
+ * ```
+ * @JsonInclude(JsonInclude.Include.NON_NULL)
+ * data class Example(value: ExplicitlyNullable<String>?)
+ * ```
+ *
+ * - `Example(null)` will be serialized as `{}`.
+ * - `Example(ExplicitlyNullable(null))` will be serialized as `{"value":null}`.
+ * - `Example(ExplicitlyNullable("my value"))` will be serialized as `{"value":"my value"}`.
+ */
+data class ExplicitlyNullable<T>(
+    @get:JsonValue
+    val value: T? = null,
 )

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/ResponseCollections.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/ResponseCollections.kt
@@ -2,6 +2,7 @@ package org.genspectrum.lapis.response
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.NullNode
+import org.genspectrum.lapis.request.MutationsField
 import java.util.stream.Stream
 
 class AggregatedCollection(
@@ -35,30 +36,23 @@ private fun JsonNode.toCsvValue() =
 
 class MutationsCollection(
     override val records: Stream<MutationResponse>,
+    private val fields: List<MutationsField>,
 ) : RecordCollection<MutationResponse> {
-    override fun getHeader() =
-        listOf(
-            "mutation",
-            "count",
-            "coverage",
-            "proportion",
-            "sequenceName",
-            "mutationFrom",
-            "mutationTo",
-            "position",
-        )
+    override fun getHeader() = fields.map { it.value }
 
     override fun mapToCsvValuesList(value: MutationResponse): List<String?> =
-        listOf(
-            value.mutation,
-            value.count.toString(),
-            value.coverage.toString(),
-            value.proportion.toString(),
-            value.sequenceName ?: "",
-            value.mutationFrom,
-            value.mutationTo,
-            value.position.toString(),
-        )
+        fields.map {
+            when (it) {
+                MutationsField.MUTATION -> value.mutation
+                MutationsField.COUNT -> value.count.toString()
+                MutationsField.COVERAGE -> value.coverage.toString()
+                MutationsField.PROPORTION -> value.proportion.toString()
+                MutationsField.SEQUENCE_NAME -> value.sequenceName?.value ?: ""
+                MutationsField.MUTATION_FROM -> value.mutationFrom
+                MutationsField.MUTATION_TO -> value.mutationTo
+                MutationsField.POSITION -> value.position.toString()
+            }
+        }
 }
 
 class InsertionsCollection(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -61,14 +61,14 @@ class AggregationDataDeserializer : JsonDeserializer<AggregationData>() {
 }
 
 data class MutationData(
-    val mutation: String,
-    val count: Int,
-    val proportion: Double,
-    val sequenceName: String,
-    val mutationFrom: String,
-    val mutationTo: String,
-    val position: Int,
-    val coverage: Int,
+    val mutation: String?,
+    val count: Int?,
+    val proportion: Double?,
+    val sequenceName: String?,
+    val mutationFrom: String?,
+    val mutationTo: String?,
+    val position: Int?,
+    val coverage: Int?,
 )
 
 data class InsertionData(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -62,6 +62,7 @@ sealed class SiloAction<ResponseType>(
             orderByFields: List<OrderByField> = emptyList(),
             limit: Int? = null,
             offset: Int? = null,
+            fields: List<String> = emptyList(),
         ): SiloAction<MutationData> =
             MutationsAction(
                 minProportion = minProportion,
@@ -69,6 +70,7 @@ sealed class SiloAction<ResponseType>(
                 limit = limit,
                 offset = offset,
                 randomize = getRandomize(orderByFields),
+                fields = fields,
             )
 
         fun aminoAcidMutations(
@@ -76,6 +78,7 @@ sealed class SiloAction<ResponseType>(
             orderByFields: List<OrderByField> = emptyList(),
             limit: Int? = null,
             offset: Int? = null,
+            fields: List<String> = emptyList(),
         ): SiloAction<MutationData> =
             AminoAcidMutationsAction(
                 minProportion = minProportion,
@@ -83,6 +86,7 @@ sealed class SiloAction<ResponseType>(
                 limit = limit,
                 offset = offset,
                 randomize = getRandomize(orderByFields),
+                fields = fields,
             )
 
         fun details(
@@ -147,65 +151,73 @@ sealed class SiloAction<ResponseType>(
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class AggregatedAction(
+    data class AggregatedAction(
         val groupByFields: List<String>,
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-        val type: String = "Aggregated",
-    ) : SiloAction<AggregationData>(AggregationDataTypeReference(), cacheable = true)
+    ) : SiloAction<AggregationData>(AggregationDataTypeReference(), cacheable = true) {
+        val type: String = "Aggregated"
+    }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class MutationsAction(
+    data class MutationsAction(
         val minProportion: Double?,
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-        val type: String = "Mutations",
-    ) : SiloAction<MutationData>(MutationDataTypeReference(), cacheable = true)
+        val fields: List<String> = emptyList(),
+    ) : SiloAction<MutationData>(MutationDataTypeReference(), cacheable = true) {
+        val type: String = "Mutations"
+    }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class AminoAcidMutationsAction(
+    data class AminoAcidMutationsAction(
         val minProportion: Double?,
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-        val type: String = "AminoAcidMutations",
-    ) : SiloAction<MutationData>(AminoAcidMutationDataTypeReference(), cacheable = true)
+        val fields: List<String> = emptyList(),
+    ) : SiloAction<MutationData>(AminoAcidMutationDataTypeReference(), cacheable = true) {
+        val type: String = "AminoAcidMutations"
+    }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class DetailsAction(
+    data class DetailsAction(
         val fields: List<String> = emptyList(),
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-        val type: String = "Details",
-    ) : SiloAction<DetailsData>(DetailsDataTypeReference(), cacheable = false)
+    ) : SiloAction<DetailsData>(DetailsDataTypeReference(), cacheable = false) {
+        val type: String = "Details"
+    }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class NucleotideInsertionsAction(
+    data class NucleotideInsertionsAction(
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-        val type: String = "Insertions",
-    ) : SiloAction<InsertionData>(InsertionDataTypeReference(), cacheable = true)
+    ) : SiloAction<InsertionData>(InsertionDataTypeReference(), cacheable = true) {
+        val type: String = "Insertions"
+    }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class AminoAcidInsertionsAction(
+    data class AminoAcidInsertionsAction(
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-        val type: String = "AminoAcidInsertions",
-    ) : SiloAction<InsertionData>(InsertionDataTypeReference(), cacheable = true)
+    ) : SiloAction<InsertionData>(InsertionDataTypeReference(), cacheable = true) {
+        val type: String = "AminoAcidInsertions"
+    }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private data class SequenceAction(
+    data class SequenceAction(
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: Boolean? = null,
         override val limit: Int? = null,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
@@ -2,8 +2,10 @@ package org.genspectrum.lapis.controller
 
 import org.genspectrum.lapis.request.Field
 import org.genspectrum.lapis.request.MutationProportionsRequest
+import org.genspectrum.lapis.request.MutationsField
 import org.genspectrum.lapis.request.SequenceFiltersRequest
 import org.genspectrum.lapis.request.SequenceFiltersRequestWithFields
+import org.genspectrum.lapis.response.MutationData
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 
 fun sequenceFiltersRequest(sequenceFilters: Map<String, String>) =
@@ -17,16 +19,18 @@ fun sequenceFiltersRequest(sequenceFilters: Map<String, String>) =
     )
 
 fun mutationProportionsRequest(
-    sequenceFilters: Map<String, String>,
-    minProportion: Double?,
+    sequenceFilters: Map<String, String> = emptyMap(),
+    minProportion: Double? = null,
+    fields: List<MutationsField> = emptyList(),
 ) = MutationProportionsRequest(
-    sequenceFilters.mapValues { listOf(it.value) },
-    emptyList(),
-    emptyList(),
-    emptyList(),
-    emptyList(),
-    minProportion,
-    emptyList(),
+    sequenceFilters = sequenceFilters.mapValues { listOf(it.value) },
+    nucleotideMutations = emptyList(),
+    aaMutations = emptyList(),
+    nucleotideInsertions = emptyList(),
+    aminoAcidInsertions = emptyList(),
+    fields = fields,
+    minProportion = minProportion,
+    orderByFields = emptyList(),
 )
 
 fun sequenceFiltersRequestWithFields(
@@ -53,6 +57,21 @@ fun sequenceFiltersRequestWithArrayValuedFilters(
     emptyList(),
     fields.map { Field(it) },
     emptyList(),
+)
+
+fun mutationData(
+    mutation: String? = null,
+    sequenceName: String? = null,
+    position: Int? = null,
+) = MutationData(
+    mutation = mutation,
+    count = null,
+    coverage = null,
+    proportion = null,
+    sequenceName = sequenceName,
+    mutationFrom = null,
+    mutationTo = null,
+    position = position,
 )
 
 fun MockHttpServletRequestBuilder.withFieldsQuery(fields: List<String>?) =

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
@@ -8,6 +8,7 @@ import org.genspectrum.lapis.model.SiloQueryModel
 import org.genspectrum.lapis.request.DEFAULT_MIN_PROPORTION
 import org.genspectrum.lapis.response.AggregationData
 import org.genspectrum.lapis.response.DetailsData
+import org.genspectrum.lapis.response.ExplicitlyNullable
 import org.genspectrum.lapis.response.InsertionResponse
 import org.genspectrum.lapis.response.MutationResponse
 import org.genspectrum.lapis.silo.DataVersion
@@ -501,7 +502,7 @@ private fun someNucleotideMutationProportion() =
         count = 42,
         coverage = 52,
         proportion = 0.5,
-        sequenceName = "sequenceName",
+        sequenceName = ExplicitlyNullable("sequenceName"),
         mutationFrom = "G",
         mutationTo = "T",
         position = 29741,
@@ -513,7 +514,7 @@ private fun someAminoAcidMutationProportion() =
         count = 42,
         coverage = 52,
         proportion = 0.5,
-        sequenceName = "sequenceName",
+        sequenceName = ExplicitlyNullable("sequenceName"),
         mutationFrom = "G",
         mutationTo = "T",
         position = 29741,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MockData.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MockData.kt
@@ -12,6 +12,7 @@ import org.genspectrum.lapis.controller.LapisMediaType.TEXT_X_FASTA_VALUE
 import org.genspectrum.lapis.model.SiloQueryModel
 import org.genspectrum.lapis.response.AggregationData
 import org.genspectrum.lapis.response.DetailsData
+import org.genspectrum.lapis.response.ExplicitlyNullable
 import org.genspectrum.lapis.response.InsertionResponse
 import org.genspectrum.lapis.response.MutationResponse
 import org.genspectrum.lapis.response.SequenceData
@@ -316,7 +317,7 @@ object MockDataForEndpoints {
                 count = 2345,
                 coverage = 3456,
                 proportion = 0.987,
-                sequenceName = "sequenceName",
+                sequenceName = ExplicitlyNullable("sequenceName"),
                 mutationFrom = "A",
                 mutationTo = "T",
                 position = 1234,
@@ -356,7 +357,7 @@ object MockDataForEndpoints {
                 count = 2345,
                 coverage = 3456,
                 proportion = 0.987,
-                sequenceName = "sequenceName",
+                sequenceName = ExplicitlyNullable("sequenceName"),
                 mutationFrom = "A",
                 mutationTo = "T",
                 position = 1234,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/MutationProportionsRequestTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/MutationProportionsRequestTest.kt
@@ -53,11 +53,12 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        mapOf("country" to listOf("Switzerland")),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
+                        sequenceFilters = mapOf("country" to listOf("Switzerland")),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
@@ -68,11 +69,12 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        mapOf("country" to listOf("Switzerland", "Germany")),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
+                        sequenceFilters = mapOf("country" to listOf("Switzerland", "Germany")),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
@@ -83,11 +85,15 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        emptyMap(),
-                        listOf(NucleotideMutation(null, 1, "-"), NucleotideMutation(null, 23062, "T")),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = listOf(
+                            NucleotideMutation(null, 1, "-"),
+                            NucleotideMutation(null, 23062, "T"),
+                        ),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
@@ -98,11 +104,15 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        emptyMap(),
-                        emptyList(),
-                        listOf(AminoAcidMutation("gene1", 501, "Y"), AminoAcidMutation("gene2", 12, null)),
-                        emptyList(),
-                        emptyList(),
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = listOf(
+                            AminoAcidMutation("gene1", 501, "Y"),
+                            AminoAcidMutation("gene2", 12, null),
+                        ),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
@@ -113,14 +123,15 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        emptyMap(),
-                        emptyList(),
-                        emptyList(),
-                        listOf(
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = listOf(
                             NucleotideInsertion(501, "Y", "other_segment"),
                             NucleotideInsertion(12, "ABCD", null),
                         ),
-                        emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
@@ -131,14 +142,15 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        emptyMap(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
-                        listOf(
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = listOf(
                             AminoAcidInsertion(501, "gene1", "Y"),
                             AminoAcidInsertion(12, "gene2", "ABCD"),
                         ),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
@@ -148,7 +160,15 @@ class MutationProportionsRequestTest {
                         "minProportion": 0.7
                     }
                     """,
-                    MutationProportionsRequest(emptyMap(), emptyList(), emptyList(), emptyList(), emptyList(), 0.7),
+                    MutationProportionsRequest(
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
+                        minProportion = 0.7,
+                    ),
                 ),
                 Arguments.of(
                     """
@@ -157,22 +177,24 @@ class MutationProportionsRequestTest {
                     }
                     """,
                     MutationProportionsRequest(
-                        emptyMap(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),
                 Arguments.of(
                     "{}",
                     MutationProportionsRequest(
-                        emptyMap(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
-                        emptyList(),
+                        sequenceFilters = emptyMap(),
+                        nucleotideMutations = emptyList(),
+                        aaMutations = emptyList(),
+                        nucleotideInsertions = emptyList(),
+                        aminoAcidInsertions = emptyList(),
+                        fields = emptyList(),
                         minProportion = DEFAULT_MIN_PROPORTION,
                     ),
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/response/MutationResponseTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/response/MutationResponseTest.kt
@@ -1,0 +1,76 @@
+package org.genspectrum.lapis.response
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class MutationResponseTest(
+    @Autowired private val objectMapper: ObjectMapper,
+) {
+    @Test
+    fun `GIVEN null sequence name THEN is not in serialized json`() {
+        val underTest = MutationResponse(
+            mutation = "A123T",
+            count = null,
+            coverage = null,
+            proportion = null,
+            sequenceName = null,
+            mutationFrom = null,
+            mutationTo = null,
+            position = null,
+        )
+
+        val json = objectMapper.writeValueAsString(underTest)
+
+        assertThat(
+            json,
+            `is`("""{"mutation":"A123T"}"""),
+        )
+    }
+
+    @Test
+    fun `GIVEN explicitly null sequence name THEN serialized json contains null`() {
+        val underTest = MutationResponse(
+            mutation = "A123T",
+            count = null,
+            coverage = null,
+            proportion = null,
+            sequenceName = ExplicitlyNullable(null),
+            mutationFrom = null,
+            mutationTo = null,
+            position = null,
+        )
+
+        val json = objectMapper.writeValueAsString(underTest)
+
+        assertThat(
+            json,
+            `is`("""{"mutation":"A123T","sequenceName":null}"""),
+        )
+    }
+
+    @Test
+    fun `GIVEN value for sequence name THEN serialized json contains null`() {
+        val underTest = MutationResponse(
+            mutation = "A123T",
+            count = null,
+            coverage = null,
+            proportion = null,
+            sequenceName = ExplicitlyNullable("the sequence"),
+            mutationFrom = null,
+            mutationTo = null,
+            position = null,
+        )
+
+        val json = objectMapper.writeValueAsString(underTest)
+
+        assertThat(
+            json,
+            `is`("""{"mutation":"A123T","sequenceName":"the sequence"}"""),
+        )
+    }
+}


### PR DESCRIPTION
If `fields` is not empty, then the response will only contain the fields that were specified there.

resolves #1092


## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
