### PR TITLE
test(lapis-e2e): fix mutation e2e tests

### DIFF
--- a/lapis-e2e/test/aminoAcidMutations.spec.ts
+++ b/lapis-e2e/test/aminoAcidMutations.spec.ts
@@ -39,13 +39,6 @@ describe('The /aminoAcidMutations endpoint', () => {
     const mutation = result.data[0];
     expect(mutation).to.deep.equal({
       mutation: 'ORF1a:A1306S',
-      count: undefined,
-      coverage: undefined,
-      mutationFrom: undefined,
-      mutationTo: undefined,
-      position: undefined,
-      proportion: undefined,
-      sequenceName: undefined,
     });
   });
 

--- a/lapis-e2e/test/nucleotideMutations.spec.ts
+++ b/lapis-e2e/test/nucleotideMutations.spec.ts
@@ -39,13 +39,6 @@ describe('The /nucleotideMutations endpoint', () => {
     const mutation = result.data[0];
     expect(mutation).to.deep.equal({
       mutation: 'A1-',
-      count: undefined,
-      coverage: undefined,
-      mutationFrom: undefined,
-      mutationTo: undefined,
-      position: undefined,
-      proportion: undefined,
-      sequenceName: undefined,
     });
   });
 


### PR DESCRIPTION
I think this was introduced by first merging #1149 (which added the tests) and then merging a non-rebased #1135 (which changed the open api generator version).

resolves #

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
