### PR TITLE
fix(lapis-e2e): remove tests that rely on order without specifying lapis to sort output

### DIFF
--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -27,8 +27,10 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(6);
-    expect(result[0].primaryKey).to.equal('key_5');
-    expect(result[0].m).to.equal('TGGG');
+    const match = result.find(
+      (item: { primaryKey: string; m: string | any[] }) => item.primaryKey === 'key_5' && item.m === 'TGGG'
+    );
+    expect(match).to.exist;
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -19,7 +19,7 @@ describe('The /alignedNucleotideSequence endpoint', () => {
       return 0;
     });
     expect(result[0].primaryKey).to.equal('key_1001493');
-    expect(result[0].main).to.have.length(59806);
+    expect(result[0].main).to.have.length(29903);
   });
 
   it('should return aligned nucleotide sequences for multi segmented sequences', async () => {

--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -4,7 +4,6 @@ import {
   expectIsZstdEncoded,
   lapisMultiSegmentedSequenceController,
   lapisSingleSegmentedSequenceController,
-  sequenceData,
 } from './common';
 
 describe('The /alignedNucleotideSequence endpoint', () => {
@@ -14,8 +13,11 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    expect(result[0].primaryKey).to.equal('key_3259931');
-    expect(result[0].main).to.have.length(29903);
+    const match = result.find(
+      (item: { primaryKey: string; main: string | any[] }) =>
+        item.primaryKey === 'key_3259931' && item.main?.length === 29903
+    );
+    expect(match).to.exist;
   });
 
   it('should return aligned nucleotide sequences for multi segmented sequences', async () => {

--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -13,7 +13,7 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    result.data.sort((a: any, b: any) => {
+    result.sort((a: any, b: any) => {
       if (a.primaryKey < b.primaryKey) return -1;
       if (a.primaryKey > b.primaryKey) return 1;
       return 0;
@@ -29,7 +29,7 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(6);
-    result.data.sort((a: any, b: any) => {
+    result.sort((a: any, b: any) => {
       if (a.primaryKey < b.primaryKey) return -1;
       if (a.primaryKey > b.primaryKey) return 1;
       return 0;

--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -18,8 +18,8 @@ describe('The /alignedNucleotideSequence endpoint', () => {
       if (a.primaryKey > b.primaryKey) return 1;
       return 0;
     });
-    expect(result[0].primaryKey).to.equal('key_3259931');
-    expect(result[0].main).to.have.length(29903);
+    expect(result[0].primaryKey).to.equal('key_1001493');
+    expect(result[0].main).to.have.length(59806);
   });
 
   it('should return aligned nucleotide sequences for multi segmented sequences', async () => {
@@ -34,8 +34,8 @@ describe('The /alignedNucleotideSequence endpoint', () => {
       if (a.primaryKey > b.primaryKey) return 1;
       return 0;
     });
-    expect(result[0].primaryKey).to.equal('key_5');
-    expect(result[0].m).to.equal('TGGG');
+    expect(result[0].primaryKey).to.equal('key_0');
+    expect(result[0].m).to.equal('CGGG');
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -13,11 +13,9 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    result.sort((a: any, b: any) => {
-      if (a.primaryKey < b.primaryKey) return -1;
-      if (a.primaryKey > b.primaryKey) return 1;
-      return 0;
-    });
+    result.sort((a: { primaryKey: string }, b: { primaryKey: string }) =>
+      a.primaryKey.localeCompare(b.primaryKey)
+    );
     expect(result[0].primaryKey).to.equal('key_1001493');
     expect(result[0].main).to.have.length(29903);
   });
@@ -29,11 +27,9 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(6);
-    result.sort((a: any, b: any) => {
-      if (a.primaryKey < b.primaryKey) return -1;
-      if (a.primaryKey > b.primaryKey) return 1;
-      return 0;
-    });
+    result.sort((a: { primaryKey: string }, b: { primaryKey: string }) =>
+      a.primaryKey.localeCompare(b.primaryKey)
+    );
     expect(result[0].primaryKey).to.equal('key_0');
     expect(result[0].m).to.equal('CGGG');
   });

--- a/lapis-e2e/test/alignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/alignedNucleotideSequence.spec.ts
@@ -13,11 +13,13 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    const match = result.find(
-      (item: { primaryKey: string; main: string | any[] }) =>
-        item.primaryKey === 'key_3259931' && item.main?.length === 29903
-    );
-    expect(match).to.exist;
+    result.data.sort((a: any, b: any) => {
+      if (a.primaryKey < b.primaryKey) return -1;
+      if (a.primaryKey > b.primaryKey) return 1;
+      return 0;
+    });
+    expect(result[0].primaryKey).to.equal('key_3259931');
+    expect(result[0].main).to.have.length(29903);
   });
 
   it('should return aligned nucleotide sequences for multi segmented sequences', async () => {
@@ -27,10 +29,13 @@ describe('The /alignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(6);
-    const match = result.find(
-      (item: { primaryKey: string; m: string | any[] }) => item.primaryKey === 'key_5' && item.m === 'TGGG'
-    );
-    expect(match).to.exist;
+    result.data.sort((a: any, b: any) => {
+      if (a.primaryKey < b.primaryKey) return -1;
+      if (a.primaryKey > b.primaryKey) return 1;
+      return 0;
+    });
+    expect(result[0].primaryKey).to.equal('key_5');
+    expect(result[0].m).to.equal('TGGG');
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis-e2e/test/aminoAcidInsertions.spec.ts
+++ b/lapis-e2e/test/aminoAcidInsertions.spec.ts
@@ -105,16 +105,18 @@ insertion,count,insertedSymbols,position,sequenceName
     `.trim()
     );
 
-    expect(resultText).to.contain(
-      String.raw`
-ins_S:143:T,1,T,143,S
-ins_S:210:IV,1,IV,210,S
-ins_S:214:EPE,5,EPE,214,S
-ins_S:247:SGE,1,SGE,247,S
-ins_ORF1a:3602:F,1,F,3602,ORF1a
-ins_ORF1a:3602:FEP,1,FEP,3602,ORF1a
-`.trim()
-    );
+    const expectedLines = [
+      'ins_S:143:T,1,T,143,S',
+      'ins_S:210:IV,1,IV,210,S',
+      'ins_S:214:EPE,5,EPE,214,S',
+      'ins_S:247:SGE,1,SGE,247,S',
+      'ins_ORF1a:3602:F,1,F,3602,ORF1a',
+      'ins_ORF1a:3602:FEP,1,FEP,3602,ORF1a',
+    ];
+
+    expectedLines.forEach(line => {
+      expect(resultText).to.contain(line);
+    });
   });
 
   it('should return the data as TSV', async () => {
@@ -133,15 +135,17 @@ insertion	count	insertedSymbols	position	sequenceName
     `.trim()
     );
 
-    expect(resultText).to.contain(
-      String.raw`
-ins_S:143:T	1	T	143	S
-ins_S:210:IV	1	IV	210	S
-ins_S:214:EPE	5	EPE	214	S
-ins_S:247:SGE	1	SGE	247	S
-ins_ORF1a:3602:F	1	F	3602	ORF1a
-ins_ORF1a:3602:FEP	1	FEP	3602	ORF1a
-    `.trim()
-    );
+    const expectedLines = [
+      'ins_S:143:T\t1\tT\t143\tS',
+      'ins_S:210:IV\t1\tIV\t210\tS',
+      'ins_S:214:EPE\t5\tEPE\t214\tS',
+      'ins_S:247:SGE\t1\tSGE\t247\tS',
+      'ins_ORF1a:3602:F\t1\tF\t3602\tORF1a',
+      'ins_ORF1a:3602:FEP\t1\tFEP\t3602\tORF1a',
+    ];
+
+    expectedLines.forEach(line => {
+      expect(resultText).to.contain(line);
+    });
   });
 });

--- a/lapis-e2e/test/aminoAcidSequence.spec.ts
+++ b/lapis-e2e/test/aminoAcidSequence.spec.ts
@@ -9,8 +9,11 @@ describe('The /alignedAminoAcidSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    expect(result[0].primaryKey).to.equal('key_3259931');
-    expect(result[0].s).to.have.length(1274);
+    const match = result.find(
+      (item: { primaryKey: string; s: string | any[] }) =>
+        item.primaryKey === 'key_3259931' && item.s?.length === 1274
+    );
+    expect(match).to.exist;
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis-e2e/test/aminoAcidSequence.spec.ts
+++ b/lapis-e2e/test/aminoAcidSequence.spec.ts
@@ -9,11 +9,11 @@ describe('The /alignedAminoAcidSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    const match = result.find(
-      (item: { primaryKey: string; s: string | any[] }) =>
-        item.primaryKey === 'key_3259931' && item.s?.length === 1274
+    result.sort((a: { primaryKey: string }, b: { primaryKey: string }) =>
+      a.primaryKey.localeCompare(b.primaryKey)
     );
-    expect(match).to.exist;
+    expect(result[0].primaryKey).to.equal('key_1001493');
+    expect(result[0].s).to.have.length(1274);
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis-e2e/test/details.spec.ts
+++ b/lapis-e2e/test/details.spec.ts
@@ -17,9 +17,6 @@ describe('The /details endpoint', () => {
       return 0;
     });
     expect(result.data[1]).to.be.deep.equal({
-      age: undefined,
-      country: undefined,
-      date: undefined,
       division: 'Zürich',
       pangoLineage: 'B.1.617.2',
     });

--- a/lapis-e2e/test/details.spec.ts
+++ b/lapis-e2e/test/details.spec.ts
@@ -11,7 +11,15 @@ describe('The /details endpoint', () => {
     });
 
     expect(result.data).to.have.length(2);
-    expect(result.data[0]).to.be.deep.equal({
+    result.data.sort((a: any, b: any) => {
+      if (a.division < b.division) return -1;
+      if (a.division > b.division) return 1;
+      return 0;
+    });
+    expect(result.data[1]).to.be.deep.equal({
+      age: undefined,
+      country: undefined,
+      date: undefined,
       division: 'Zürich',
       pangoLineage: 'B.1.617.2',
     });
@@ -25,7 +33,12 @@ describe('The /details endpoint', () => {
     });
 
     expect(result.data).to.have.length(2);
-    expect(result.data[0]).to.be.deep.equal({
+    result.data.sort((a: any, b: any) => {
+      if (a.division < b.division) return -1;
+      if (a.division > b.division) return 1;
+      return 0;
+    });
+    expect(result.data[1]).to.be.deep.equal({
       age: 54,
       country: 'Switzerland',
       date: '2021-07-19',

--- a/lapis-e2e/test/details.spec.ts
+++ b/lapis-e2e/test/details.spec.ts
@@ -11,11 +11,9 @@ describe('The /details endpoint', () => {
     });
 
     expect(result.data).to.have.length(2);
-    result.data.sort((a: any, b: any) => {
-      if (a.division < b.division) return -1;
-      if (a.division > b.division) return 1;
-      return 0;
-    });
+    result.data.sort((a: { division: string }, b: { division: string }) =>
+      a.division.localeCompare(b.division)
+    );
     expect(result.data[1]).to.be.deep.equal({
       division: 'Zürich',
       pangoLineage: 'B.1.617.2',
@@ -30,11 +28,9 @@ describe('The /details endpoint', () => {
     });
 
     expect(result.data).to.have.length(2);
-    result.data.sort((a: any, b: any) => {
-      if (a.division < b.division) return -1;
-      if (a.division > b.division) return 1;
-      return 0;
-    });
+    result.data.sort((a: { division: string }, b: { division: string }) =>
+      a.division.localeCompare(b.division)
+    );
     expect(result.data[1]).to.be.deep.equal({
       age: 54,
       country: 'Switzerland',

--- a/lapis-e2e/test/nucleotideInsertions.spec.ts
+++ b/lapis-e2e/test/nucleotideInsertions.spec.ts
@@ -35,44 +35,42 @@ describe('The /nucleotideInsertions endpoint', () => {
   it('should order by specified fields', async () => {
     const ascendingOrderedResult = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
-        orderBy: [{ field: 'count', type: 'ascending' }],
+        orderBy: [{ field: 'insertion', type: 'ascending' }],
       },
     });
-    // the first two positions both have count 1 so their order could change
-    expect(ascendingOrderedResult.data[2]).to.have.property('insertion', 'ins_5959:TAT');
+    expect(ascendingOrderedResult.data[0]).to.have.property('insertion', 'ins_22204:CAGAA');
+    expect(ascendingOrderedResult.data).to.have.length(4);
 
     const descendingOrderedResult = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
-        orderBy: [{ field: 'count', type: 'descending' }],
+        orderBy: [{ field: 'insertion', type: 'descending' }],
       },
     });
 
-    expect(descendingOrderedResult.data[0]).to.have.property('insertion', 'ins_25701:CCC');
+    expect(descendingOrderedResult.data).to.have.length(4);
+    expect(descendingOrderedResult.data[3]).to.have.property('insertion', 'ins_22204:CAGAA');
   });
 
   it('should apply limit and offset', async () => {
     const resultWithLimit = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
-        orderBy: [{ field: 'count', type: 'ascending' }],
+        orderBy: [{ field: 'insertion', type: 'ascending' }],
         limit: 4,
       },
     });
 
     expect(resultWithLimit.data).to.have.length(4);
-    expect(resultWithLimit.data[0]).to.have.property('count', 1);
-    expect(resultWithLimit.data[3]).to.have.property('count', 17);
-    expect(resultWithLimit.data[3]).to.have.property('insertion', 'ins_25701:CCC');
 
     const resultWithLimitAndOffset = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
-        orderBy: [{ field: 'count', type: 'descending' }],
+        orderBy: [{ field: 'insertion', type: 'ascending' }],
         limit: 4,
         offset: 1,
       },
     });
 
     expect(resultWithLimitAndOffset.data).to.have.length(3);
-    expect(resultWithLimitAndOffset.data[0]).to.deep.equal(resultWithLimit.data[2]);
+    expect(resultWithLimitAndOffset.data[0]).to.deep.equal(resultWithLimit.data[1]);
   });
 
   it('should correctly handle nucleotide insertion requests', async () => {

--- a/lapis-e2e/test/nucleotideInsertions.spec.ts
+++ b/lapis-e2e/test/nucleotideInsertions.spec.ts
@@ -54,23 +54,26 @@ describe('The /nucleotideInsertions endpoint', () => {
     const resultWithLimit = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
         orderBy: [{ field: 'count', type: 'ascending' }],
-        limit: 2,
+        limit: 3,
       },
     });
 
-    expect(resultWithLimit.data).to.have.length(2);
+    expect(resultWithLimit.data).to.have.length(3);
+    expect(resultWithLimit.data[0]).to.have.property('count', '2');
+    expect(resultWithLimit.data[1]).to.have.property('count', '2');
+    expect(resultWithLimit.data[2]).to.have.property('count', '2');
     expect(resultWithLimit.data[1]).to.have.property('insertion', 'ins_22339:GCTGGT');
 
     const resultWithLimitAndOffset = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
         orderBy: [{ field: 'count', type: 'ascending' }],
-        limit: 2,
+        limit: 3,
         offset: 1,
       },
     });
 
-    expect(resultWithLimitAndOffset.data).to.have.length(2);
-    expect(resultWithLimitAndOffset.data[0]).to.deep.equal(resultWithLimit.data[1]);
+    expect(resultWithLimitAndOffset.data).to.have.length(3);
+    expect(resultWithLimitAndOffset.data[0]).to.deep.equal(resultWithLimit.data[2]);
   });
 
   it('should correctly handle nucleotide insertion requests', async () => {

--- a/lapis-e2e/test/nucleotideInsertions.spec.ts
+++ b/lapis-e2e/test/nucleotideInsertions.spec.ts
@@ -38,8 +38,8 @@ describe('The /nucleotideInsertions endpoint', () => {
         orderBy: [{ field: 'count', type: 'ascending' }],
       },
     });
-
-    expect(ascendingOrderedResult.data[0]).to.have.property('insertion', 'ins_22339:GCTGGT');
+    // the first two positions both have count 1 so their order could change
+    expect(ascendingOrderedResult.data[2]).to.have.property('insertion', 'ins_5959:TAT');
 
     const descendingOrderedResult = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
@@ -54,20 +54,19 @@ describe('The /nucleotideInsertions endpoint', () => {
     const resultWithLimit = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
         orderBy: [{ field: 'count', type: 'ascending' }],
-        limit: 3,
+        limit: 4,
       },
     });
 
-    expect(resultWithLimit.data).to.have.length(3);
-    expect(resultWithLimit.data[0]).to.have.property('count', '2');
-    expect(resultWithLimit.data[1]).to.have.property('count', '2');
-    expect(resultWithLimit.data[2]).to.have.property('count', '2');
-    expect(resultWithLimit.data[1]).to.have.property('insertion', 'ins_22339:GCTGGT');
+    expect(resultWithLimit.data).to.have.length(4);
+    expect(resultWithLimit.data[0]).to.have.property('count', 1);
+    expect(resultWithLimit.data[3]).to.have.property('count', 17);
+    expect(resultWithLimit.data[3]).to.have.property('insertion', 'ins_25701:CCC');
 
     const resultWithLimitAndOffset = await lapisClient.postNucleotideInsertions({
       insertionsRequest: {
-        orderBy: [{ field: 'count', type: 'ascending' }],
-        limit: 3,
+        orderBy: [{ field: 'count', type: 'descending' }],
+        limit: 4,
         offset: 1,
       },
     });

--- a/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
@@ -8,11 +8,11 @@ describe('The /unalignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    const match = result.find(
-      (item: { primaryKey: string; main: string | any[] }) =>
-        item.primaryKey === 'key_3086369' && item.main?.length === 29903
+    result.sort((a: { primaryKey: string }, b: { primaryKey: string }) =>
+      a.primaryKey.localeCompare(b.primaryKey)
     );
-    expect(match).to.exist;
+    expect(result[0].primaryKey).to.equal('key_1001493');
+    expect(result[0].main).to.have.length(29903);
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
@@ -8,8 +8,11 @@ describe('The /unalignedNucleotideSequence endpoint', () => {
     });
 
     expect(result).to.have.length(100);
-    expect(result[0].primaryKey).to.equal('key_3086369');
-    expect(result[0].main).to.have.length(29903);
+    const match = result.find(
+      (item: { primaryKey: string; main: string | any[] }) =>
+        item.primaryKey === 'key_3086369' && item.main?.length === 29903
+    );
+    expect(match).to.exist;
   });
 
   it('should order ascending by specified fields', async () => {

--- a/lapis/docker-compose.yml
+++ b/lapis/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   lapisOpen:
     image: ghcr.io/genspectrum/lapis:${LAPIS_TAG}
+    platform: linux/amd64
     ports:
       - "8090:8080"
     command: --silo.url=http://silo:8081
@@ -16,6 +17,7 @@ services:
 
   silo:
     image: ghcr.io/genspectrum/lapis-silo:${SILO_TAG}
+    platform: linux/amd64
     ports:
       - "8091:8081"
     command: api
@@ -27,6 +29,7 @@ services:
 
   siloPreprocessing:
     image: ghcr.io/genspectrum/lapis-silo:${SILO_TAG}
+    platform: linux/amd64
     command: preprocessing
     volumes:
       - ../lapis-e2e/testData/singleSegmented:/preprocessing/input
@@ -36,6 +39,7 @@ services:
 
   siloMultisegmented:
     image: ghcr.io/genspectrum/lapis-silo:${SILO_TAG}
+    platform: linux/amd64
     ports:
       - "8093:8081"
     command: api
@@ -47,6 +51,7 @@ services:
 
   siloPreprocessingMultisegmented:
     image: ghcr.io/genspectrum/lapis-silo:${SILO_TAG}
+    platform: linux/amd64
     command: preprocessing
     volumes:
       - ../lapis-e2e/testData/multiSegmented:/preprocessing/input
@@ -56,6 +61,7 @@ services:
 
   lapisMultiSegmented:
     image: ghcr.io/genspectrum/lapis:${LAPIS_TAG}
+    platform: linux/amd64
     ports:
       - "8094:8080"
     command: --silo.url=http://siloMultisegmented:8081
@@ -71,6 +77,7 @@ services:
 
   lapisProtected:
     image: ghcr.io/genspectrum/lapis:${LAPIS_TAG}
+    platform: linux/amd64
     ports:
       - "8092:8080"
     command: --silo.url=http://silo:8081 --lapis.accessKeys.path=/workspace/access_keys.yaml


### PR DESCRIPTION
resolves https://github.com/GenSpectrum/LAPIS/issues/1162

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
