### PR TITLE
fix(lapis): fix compiler warning

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/CompressionFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/CompressionFilter.kt
@@ -307,6 +307,9 @@ class StringHttpMessageConverterWithUnknownContentLengthInCaseOfCompression(
     environment: Environment,
     private val requestCompression: RequestCompression,
 ) : StringHttpMessageConverter(getCharsetFromEnvironment(environment)) {
+    // The original method is declared in Java as returning Long (can be null)
+    // but in Kotlin it is Long! (platform type) which is not nullable.
+    @Suppress("INCOMPATIBLE_OVERRIDE")
     override fun getContentLength(
         str: String,
         contentType: MediaType?,


### PR DESCRIPTION
resolves #

When building we get a compiler error:
```
Override 'fun getContentLength(str: String, contentType: MediaType?): Long?' has incorrect nullability in its signature compared to the overridden declaration 'fun getContentLength(str: String, contentType: MediaType?): Long'
```

The original method is declared in Java as returning Long (boxed), not long (primitive).

In Java, Long can be null, which aligns with the method docstring: "Returns the content length... or null if not known."

However, Kotlin treats Java’s boxed Long (java.lang.Long) as Long!, which is platform-typed — and when you override such a method, you must match the signature exactly, not make it more nullable.

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] The implemented feature is covered by an appropriate test.
