### PR TITLE
refactor(lapis): it's cleaner to hand out `null` when getting an unknown sequence from the reference genome

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
@@ -3,7 +3,6 @@ package org.genspectrum.lapis.config
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.genspectrum.lapis.controller.BadRequestException
 import java.io.File
 
 const val REFERENCE_GENOME_SEGMENTS_APPLICATION_ARG_PREFIX = "referenceGenome.segments"
@@ -27,13 +26,9 @@ class ReferenceGenomeSchema(
     private val geneNames: Map<LowercaseName, ReferenceSequenceSchema> = genes
         .associateBy { it.name.lowercase() }
 
-    fun getNucleotideSequence(name: String): ReferenceSequenceSchema =
-        nucleotideSequenceNames[name.lowercase()]
-            ?: throw BadRequestException("Unknown nucleotide sequence: $name")
+    fun getNucleotideSequence(name: String) = nucleotideSequenceNames[name.lowercase()]
 
-    fun getGene(name: String): ReferenceSequenceSchema =
-        geneNames[name.lowercase()]
-            ?: throw BadRequestException("Unknown gene: $name")
+    fun getGene(name: String) = geneNames[name.lowercase()]
 
     fun isSingleSegmented(): Boolean = nucleotideSequences.size == 1
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -19,6 +19,7 @@ import mu.KotlinLogging
 import org.antlr.v4.runtime.RuleContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.request.ESCAPED_STOP_CODON
 import org.genspectrum.lapis.request.LAPIS_INSERTION_AMBIGUITY_SYMBOL
 import org.genspectrum.lapis.request.SILO_INSERTION_AMBIGUITY_SYMBOL
@@ -144,7 +145,9 @@ class VariantQueryCustomListener(
             return
         }
         val position = ctx.position().text.toInt()
-        val gene = referenceGenomeSchema.getGene(ctx.gene().text).name
+        val geneName = ctx.gene().text
+        val gene = referenceGenomeSchema.getGene(geneName)?.name
+            ?: throw BadRequestException("Unknown gene: $geneName")
 
         val expression = when (val aaSymbol = ctx.possiblyAmbiguousAaSymbol()) {
             null -> HasAminoAcidMutation(gene, position)
@@ -156,7 +159,9 @@ class VariantQueryCustomListener(
 
     override fun enterAaInsertionQuery(ctx: AaInsertionQueryContext) {
         val value = ctx.aaInsertionSymbol().joinToString("", transform = ::mapInsertionSymbol)
-        val gene = referenceGenomeSchema.getGene(ctx.gene().text).name
+        val geneName = ctx.gene().text
+        val gene = referenceGenomeSchema.getGene(geneName)?.name
+            ?: throw BadRequestException("Unknown gene: $geneName")
 
         expressionStack.addLast(
             AminoAcidInsertionContains(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidInsertion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidInsertion.kt
@@ -36,7 +36,8 @@ data class AminoAcidInsertion(
                 ?: throw BadRequestException(
                     "Invalid amino acid insertion: $aminoAcidInsertion: Did not find gene",
                 )
-            val geneName = referenceGenomeSchema.getGene(gene).name
+            val geneName = referenceGenomeSchema.getGene(gene)?.name
+                ?: throw BadRequestException("Unknown gene: $gene")
 
             val insertions = matchGroups["insertions"]?.value?.replace(STOP_CODON, ESCAPED_STOP_CODON)?.replace(
                 LAPIS_INSERTION_AMBIGUITY_SYMBOL,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidMutation.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidMutation.kt
@@ -32,7 +32,8 @@ data class AminoAcidMutation(
 
             val gene = matchGroups["gene"]?.value
                 ?: throw BadRequestException("Invalid amino acid mutation: $aminoAcidMutation: Did not find gene")
-            val geneName = referenceGenomeSchema.getGene(gene).name
+            val geneName = referenceGenomeSchema.getGene(gene)?.name
+                ?: throw BadRequestException("Unknown gene: $gene")
 
             val position = matchGroups["position"]?.value?.toInt()
                 ?: throw BadRequestException(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideInsertion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideInsertion.kt
@@ -41,7 +41,11 @@ data class NucleotideInsertion(
                 )
 
             val segmentName = matchGroups["segment"]?.value
-                ?.let { referenceGenomeSchema.getNucleotideSequence(it).name }
+                ?.let {
+                    referenceGenomeSchema.getNucleotideSequence(it)
+                        ?: throw BadRequestException("Unknown nucleotide sequence: $it")
+                }
+                ?.name
 
             return NucleotideInsertion(
                 position,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideMutation.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideMutation.kt
@@ -36,7 +36,11 @@ data class NucleotideMutation(
                 )
 
             val segmentName = matchGroups["sequenceName"]?.value
-                ?.let { referenceGenomeSchema.getNucleotideSequence(it).name }
+                ?.let {
+                    referenceGenomeSchema.getNucleotideSequence(it)
+                        ?: throw BadRequestException("Unknown nucleotide sequence: $it")
+                }
+                ?.name
 
             return NucleotideMutation(
                 segmentName,


### PR DESCRIPTION


We don't know yet whether we want to handle that as a "bad request" at this point.



## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
