### PR TITLE
refactor(lapis): revert ReferenceGenome to state of #1179

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
@@ -3,7 +3,6 @@ package org.genspectrum.lapis.config
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.genspectrum.lapis.controller.BadRequestException
 import java.io.File
 
 const val REFERENCE_GENOME_SEGMENTS_APPLICATION_ARG_PREFIX = "referenceGenome.segments"
@@ -27,17 +26,9 @@ class ReferenceGenomeSchema(
     private val geneNames: Map<LowercaseName, ReferenceSequenceSchema> = genes
         .associateBy { it.name.lowercase() }
 
-    fun hasNucleotideSequence(name: String): Boolean = nucleotideSequenceNames.containsKey(name.lowercase())
+    fun getNucleotideSequence(name: String): ReferenceSequenceSchema? = nucleotideSequenceNames[name.lowercase()]
 
-    fun getNucleotideSequence(name: String): ReferenceSequenceSchema =
-        nucleotideSequenceNames[name.lowercase()]
-            ?: throw BadRequestException("Unknown nucleotide sequence: $name")
-
-    fun hasGene(name: String): Boolean = geneNames.containsKey(name.lowercase())
-
-    fun getGene(name: String): ReferenceSequenceSchema =
-        geneNames[name.lowercase()]
-            ?: throw BadRequestException("Unknown gene: $name")
+    fun getGene(name: String): ReferenceSequenceSchema? = geneNames[name.lowercase()]
 
     fun isSingleSegmented(): Boolean = nucleotideSequences.size == 1
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -404,10 +404,8 @@ class AdvancedQueryCustomListener(
         val position = ctx.position().text.toInt()
         val name = ctx.name().text
 
-        // Ensure that the geneName is a valid gene or segment
-        when {
-            referenceGenomeSchema.hasGene(name) -> {
-                val gene = referenceGenomeSchema.getGene(name).name
+        when (val gene = referenceGenomeSchema.getGene(name)?.name) {
+            is String -> {
                 // As the set of ambiguous aa and nuc mutations is disjoint, we need to check if the mutation is valid
                 mutatedTo?.first()?.let { validateAminoAcidSymbol(it) }
                 val expression = when (val aaSymbol = mutatedTo) {
@@ -415,9 +413,12 @@ class AdvancedQueryCustomListener(
                     else -> AminoAcidSymbolEquals(gene, position, aaSymbol.uppercase())
                 }
                 expressionStack.addLast(expression)
+                return
             }
-            referenceGenomeSchema.hasNucleotideSequence(name) -> {
-                val segmentName = referenceGenomeSchema.getNucleotideSequence(name).name
+        }
+
+        when (val segmentName = referenceGenomeSchema.getNucleotideSequence(name)?.name) {
+            is String -> {
                 // As nucleotide mutations are a subset of amino acid mutations, we need to check if the mutation is valid
                 mutatedTo?.first()?.let { validateNucleotideSymbol(it) }
                 val expression = when (val nucSymbol = mutatedTo) {
@@ -425,21 +426,20 @@ class AdvancedQueryCustomListener(
                     else -> NucleotideSymbolEquals(segmentName, position, nucSymbol.uppercase())
                 }
                 expressionStack.addLast(expression)
-            }
-            else -> {
-                throw BadRequestException("$name is not a known segment or gene", null)
+                return
             }
         }
+
+        throw BadRequestException("$name is not a known segment or gene", null)
     }
 
     override fun enterNamedInsertionQuery(ctx: NamedInsertionQueryContext) {
         val value = ctx.namedInsertionSymbol().joinToString("", transform = ::mapInsertionSymbol)
         val plainString = ctx.namedInsertionSymbol().joinToString(separator = "") { it.text.uppercase() }
         val name = ctx.name().text
-        // Ensure that the geneName is a valid gene or segment
-        when {
-            referenceGenomeSchema.hasGene(name) -> {
-                val gene = referenceGenomeSchema.getGene(name).name
+
+        when (val gene = referenceGenomeSchema.getGene(name)?.name) {
+            is String -> {
                 plainString.forEach { validateAminoAcidSymbol(it) }
                 expressionStack.addLast(
                     AminoAcidInsertionContains(
@@ -448,9 +448,12 @@ class AdvancedQueryCustomListener(
                         gene,
                     ),
                 )
+                return
             }
-            referenceGenomeSchema.hasNucleotideSequence(name) -> {
-                val sequenceName = referenceGenomeSchema.getNucleotideSequence(name).name
+        }
+
+        when (val sequenceName = referenceGenomeSchema.getNucleotideSequence(name)?.name) {
+            is String -> {
                 plainString.forEach { validateNucleotideSymbol(it) }
                 expressionStack.addLast(
                     NucleotideInsertionContains(
@@ -459,10 +462,10 @@ class AdvancedQueryCustomListener(
                         sequenceName,
                     ),
                 )
-            }
-            else -> {
-                throw BadRequestException("$name is not a known segment or gene", null)
+                return
             }
         }
+
+        throw BadRequestException("$name is not a known segment or gene", null)
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -18,6 +18,7 @@ import VariantQueryParser.PangolineageWithPossibleSublineagesContext
 import org.antlr.v4.runtime.RuleContext
 import org.antlr.v4.runtime.tree.ParseTreeListener
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.log
 import org.genspectrum.lapis.request.ESCAPED_STOP_CODON
 import org.genspectrum.lapis.request.LAPIS_INSERTION_AMBIGUITY_SYMBOL
@@ -133,7 +134,8 @@ class VariantQueryCustomListener(
     override fun enterAaMutationQuery(ctx: AaMutationQueryContext) {
         val position = ctx.position().text.toInt()
         val geneName = ctx.gene().text
-        val gene = referenceGenomeSchema.getGene(geneName).name
+        val gene = referenceGenomeSchema.getGene(geneName)?.name
+            ?: throw BadRequestException("Unknown gene: $geneName")
 
         val expression = when (val aaSymbol = ctx.possiblyAmbiguousAaSymbol()) {
             null -> HasAminoAcidMutation(gene, position)
@@ -146,7 +148,8 @@ class VariantQueryCustomListener(
     override fun enterAaInsertionQuery(ctx: AaInsertionQueryContext) {
         val value = ctx.aaInsertionSymbol().joinToString("", transform = ::mapInsertionSymbol)
         val geneName = ctx.gene().text
-        val gene = referenceGenomeSchema.getGene(geneName).name
+        val gene = referenceGenomeSchema.getGene(geneName)?.name
+            ?: throw BadRequestException("Unknown gene: $geneName")
 
         expressionStack.addLast(
             AminoAcidInsertionContains(


### PR DESCRIPTION
It's cleaner if `getNucleotideSequence` and `getGene` don't throw


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
