### PR TITLE
feat(lapis): allow regex search for all string fields by default

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -20,6 +20,7 @@ const Configuration = {
         ],
         "header-max-length": [RuleConfigSeverity.Disabled],
         "body-max-line-length": [RuleConfigSeverity.Disabled],
+        "footer-max-line-length": [RuleConfigSeverity.Disabled],
     }
 };
 

--- a/lapis-docs/src/components/FiltersTable/getFilters.tsx
+++ b/lapis-docs/src/components/FiltersTable/getFilters.tsx
@@ -39,21 +39,17 @@ export function getFilters(config: Config) {
                 description: `Filters the "${metadata.name}" column" with exact match`,
             };
 
-            if (metadata.lapisAllowsRegexSearch) {
-                const allowRegexSearchDescription = {
-                    name: `${metadata.name}.regex`,
-                    type: metadata.type,
-                    description: `Filters the "${metadata.name}" column using a regular expression,`,
-                    link: {
-                        href: '/concepts/string-search',
-                        text: 'string search',
-                    },
-                };
+            const allowRegexSearchDescription = {
+                name: `${metadata.name}.regex`,
+                type: metadata.type,
+                description: `Filters the "${metadata.name}" column using a regular expression,`,
+                link: {
+                    href: '/concepts/string-search',
+                    text: 'string search',
+                },
+            };
 
-                return [stringDescription, allowRegexSearchDescription];
-            }
-
-            return [stringDescription];
+            return [stringDescription, allowRegexSearchDescription];
         }
 
         if (metadata.type === 'pango_lineage') {

--- a/lapis-docs/src/components/QueryGenerator/FiltersSelection.tsx
+++ b/lapis-docs/src/components/QueryGenerator/FiltersSelection.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const FiltersSelection = (props: Props) => {
-    const { config, filters, onFiltersChange } = props;
+    const { config } = props;
     return (
         <div>
             <div>
@@ -27,7 +27,7 @@ export const FiltersSelection = (props: Props) => {
                         );
                     }
 
-                    if (metadata.type === 'string' && metadata.lapisAllowsRegexSearch) {
+                    if (metadata.type === 'string') {
                         return (
                             <>
                                 <FilterField key={metadata.name} name={metadata.name} {...props} />

--- a/lapis-docs/src/config.ts
+++ b/lapis-docs/src/config.ts
@@ -14,7 +14,6 @@ export type MetadataType =
 export type Metadata = {
     name: string;
     type: MetadataType;
-    lapisAllowsRegexSearch?: boolean;
     generateLineageIndex?: boolean;
 };
 
@@ -59,8 +58,4 @@ export function hasPangoLineage(config: Config): boolean {
             m.generateLineageIndex === true &&
             (m.name.toLowerCase().includes('pangolineage') || m.name.toLowerCase().includes('pango_lineage')),
     );
-}
-
-export function hasRegexSearchFields(config: Config): boolean {
-    return config.schema.metadata.some((m) => m.lapisAllowsRegexSearch === true);
 }

--- a/lapis-docs/src/content/docs/concepts/string-search.mdx
+++ b/lapis-docs/src/content/docs/concepts/string-search.mdx
@@ -3,20 +3,10 @@ title: String search
 description: String search
 ---
 
-import { OnlyIf } from '../../../components/OnlyIf.tsx';
-import { getConfig, hasRegexSearchFields } from '../../../config.ts';
-
-{/* prettier-ignore */}
-<OnlyIf condition={!hasRegexSearchFields(getConfig())}>
-:::note
-This feature is not available in this LAPIS instance, because none of the string fields are configured accordingly.
-:::
-</OnlyIf>
-
 LAPIS allows users to filter string fields in the metadata using [regular expressions](https://en.wikipedia.org/wiki/Regular_expression).
 This is useful when the full string is unknown or when a more complex search is needed.
 
-By default, the string search is disabled for all string fields. It can be enabled by the instance administrator.
+String search is enabled for all string fields.
 A list of searchable fields of this LAPIS instance can be found [here](../references/filters).
 
 The syntax for the string search is a subset of the syntax of the [PCRE](https://www.pcre.org/) library.

--- a/lapis-docs/src/content/docs/maintainer-docs/references/database-configuration.mdx
+++ b/lapis-docs/src/content/docs/maintainer-docs/references/database-configuration.mdx
@@ -46,12 +46,11 @@ it will be beneficial to set `dateToSortBy` to that column.
 
 The metadata object permits the following fields:
 
-| Key                    | Type    | Required | Description                                                                                                   |
-| ---------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| name                   | string  | true     | The name of the metadata field.                                                                               |
-| type                   | enum    | true     | The [type of the metadata](#metadata-types).                                                                  |
-| generateIndex          | boolean | false    | See [Generating an index](#generating-an-index) below                                                         |
-| lapisAllowsRegexSearch | boolean | false    | If true, LAPIS will autogenerate a filter `${name}.regex`. See [String search](../../concepts/string-search). |
+| Key           | Type    | Required | Description                                           |
+| ------------- | ------- | -------- | ----------------------------------------------------- |
+| name          | string  | true     | The name of the metadata field.                       |
+| type          | enum    | true     | The [type of the metadata](#metadata-types).          |
+| generateIndex | boolean | false    | See [Generating an index](#generating-an-index) below |
 
 :::caution
 The `name` must not contain the reserved character `.`.

--- a/lapis-e2e/test/aggregated.spec.ts
+++ b/lapis-e2e/test/aggregated.spec.ts
@@ -175,17 +175,6 @@ describe('The /aggregated endpoint', () => {
     expect(resultJson.error.detail).to.include('variantQuery must have exactly one value');
   });
 
-  it('should return bad request when sending regex filter for field that does not allow it', async () => {
-    const urlParams = new URLSearchParams();
-    urlParams.append('region.regex', 'Euro');
-
-    const result = await getAggregated(urlParams);
-
-    expect(result.status).equals(400);
-    const resultJson = await result.json();
-    expect(resultJson.error.detail).to.include("'region.regex' is not a valid sequence filter");
-  });
-
   it('should apply limit and offset', async () => {
     const resultWithLimit = await lapisClient.postAggregated({
       aggregatedPostRequest: {

--- a/lapis-e2e/testData/multiSegmented/testDatabaseConfig.yaml
+++ b/lapis-e2e/testData/multiSegmented/testDatabaseConfig.yaml
@@ -4,12 +4,10 @@ schema:
   metadata:
     - name: primaryKey
       type: string
-      lapisAllowsRegexSearch: true
     - name: date
       type: date
     - name: country
       type: string
-      lapisAllowsRegexSearch: true
       generateIndex: true
   primaryKey: primaryKey
   dateToSortBy: date

--- a/lapis-e2e/testData/singleSegmented/protectedTestDatabaseConfig.yaml
+++ b/lapis-e2e/testData/singleSegmented/protectedTestDatabaseConfig.yaml
@@ -4,7 +4,6 @@ schema:
   metadata:
     - name: primaryKey
       type: string
-      lapisAllowsRegexSearch: true
     - name: date
       type: date
     - name: region
@@ -12,16 +11,13 @@ schema:
       generateIndex: true
     - name: country
       type: string
-      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: pangoLineage
       type: string
       generateIndex: true
       generateLineageIndex: true
-      lapisAllowsRegexSearch: true
     - name: division
       type: string
-      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: age
       type: int

--- a/lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml
+++ b/lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml
@@ -4,7 +4,6 @@ schema:
   metadata:
     - name: primaryKey
       type: string
-      lapisAllowsRegexSearch: true
     - name: date
       type: date
     - name: region
@@ -12,16 +11,13 @@ schema:
       generateIndex: true
     - name: country
       type: string
-      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: pangoLineage
       type: string
       generateIndex: true
       generateLineageIndex: true
-      lapisAllowsRegexSearch: true
     - name: division
       type: string
-      lapisAllowsRegexSearch: true
       generateIndex: true
     - name: age
       type: int

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfig.kt
@@ -21,7 +21,6 @@ data class DatabaseMetadata(
     val name: String,
     val type: MetadataType,
     val valuesAreUnique: Boolean = false,
-    val lapisAllowsRegexSearch: Boolean = false,
     val generateLineageIndex: Boolean = false,
 )
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidator.kt
@@ -11,12 +11,6 @@ class DatabaseConfigValidator {
                     "Metadata field name '${it.name}' contains the reserved character '.'",
                 )
             }
-
-            if (it.lapisAllowsRegexSearch && it.type != MetadataType.STRING) {
-                throw IllegalArgumentException(
-                    "Metadata field '${it.name}' has lapisAllowsRegexSearch set to true, but is not of type STRING.",
-                )
-            }
         }
 
         return databaseConfig

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/SequenceFilterFields.kt
@@ -55,17 +55,13 @@ private fun mapToSequenceFilterField(databaseMetadata: DatabaseMetadata) =
                 )
             }
 
-            when (databaseMetadata.lapisAllowsRegexSearch) {
-                true -> listOf(
-                    baseField,
-                    SequenceFilterField(
-                        name = "${databaseMetadata.name}.regex",
-                        type = SequenceFilterFieldType.StringSearch(databaseMetadata.name),
-                    ),
-                )
-
-                false -> listOf(baseField)
-            }
+            listOf(
+                baseField,
+                SequenceFilterField(
+                    name = "${databaseMetadata.name}.regex",
+                    type = SequenceFilterFieldType.StringSearch(databaseMetadata.name),
+                ),
+            )
         }
 
         MetadataType.DATE -> listOf(
@@ -112,8 +108,8 @@ private fun mapToSequenceFilterField(databaseMetadata: DatabaseMetadata) =
         )
     }
 
-public const val VARIANT_QUERY_FIELD = "variantQuery"
-public const val ADVANCED_QUERY_FIELD = "advancedQuery"
+const val VARIANT_QUERY_FIELD = "variantQuery"
+const val ADVANCED_QUERY_FIELD = "advancedQuery"
 
 private fun mapToSequenceFilterFieldsFromFeatures(databaseFeature: DatabaseFeature) =
     when (databaseFeature.name) {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/DummyDatabaseConfig.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/DummyDatabaseConfig.kt
@@ -16,7 +16,7 @@ val dummyDatabaseConfig = DatabaseConfig(
         listOf(
             DatabaseMetadata(DATE_FIELD, MetadataType.DATE),
             DatabaseMetadata(PANGO_LINEAGE_FIELD, MetadataType.STRING, generateLineageIndex = true),
-            DatabaseMetadata("some_metadata", MetadataType.STRING, lapisAllowsRegexSearch = true),
+            DatabaseMetadata("some_metadata", MetadataType.STRING),
             DatabaseMetadata("other_metadata", MetadataType.STRING),
             DatabaseMetadata("floatField", MetadataType.FLOAT),
             DatabaseMetadata("intField", MetadataType.INT),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidatorTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/config/DatabaseConfigValidatorTest.kt
@@ -45,28 +45,4 @@ class DatabaseConfigValidatorTest {
             `is`("Metadata field name 'field.with.regex.separator' contains the reserved character '.'"),
         )
     }
-
-    @Test
-    fun `GIVEN lapisAllowsRegexSearch on non-string field THEN config is invalid`() {
-        val invalidConfig = DatabaseConfig(
-            DatabaseSchema(
-                instanceName = "test",
-                primaryKey = "primaryKey",
-                opennessLevel = OpennessLevel.OPEN,
-                metadata = listOf(
-                    DatabaseMetadata(
-                        name = "test field",
-                        type = MetadataType.INT,
-                        lapisAllowsRegexSearch = true,
-                    ),
-                ),
-            ),
-        )
-
-        val exception = assertThrows<IllegalArgumentException> { underTest.validate(invalidConfig) }
-        assertThat(
-            exception.message,
-            `is`("Metadata field 'test field' has lapisAllowsRegexSearch set to true, but is not of type STRING."),
-        )
-    }
 }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/config/SequenceFilterFieldsTest.kt
@@ -16,13 +16,12 @@ class SequenceFilterFieldsTest {
     }
 
     @Test
-    fun `given database config with a string field allowing regex then contains a string and string search field`() {
+    fun `given database config with a string field then contains a string and string search field`() {
         val input = databaseConfigWithFields(
             listOf(
                 DatabaseMetadata(
                     name = "fieldName",
                     type = MetadataType.STRING,
-                    lapisAllowsRegexSearch = true,
                 ),
             ),
         )
@@ -44,48 +43,13 @@ class SequenceFilterFieldsTest {
     }
 
     @Test
-    fun `given database config with a string field forbidding regex then only contains a string field`() {
-        val input = databaseConfigWithFields(listOf(DatabaseMetadata("fieldName", MetadataType.STRING)))
-
-        val underTest = SequenceFilterFields.fromDatabaseConfig(input)
-
-        assertThat(underTest.fields, aMapWithSize(1))
-        assertThat(
-            underTest.fields,
-            hasEntry("fieldname", SequenceFilterField("fieldName", SequenceFilterFieldType.String)),
-        )
-    }
-
-    @Test
-    fun `GIVEN database config with a field with lineage index THEN contains a lineage field`() {
+    fun `GIVEN config with a field with lineage index THEN contains a lineage and regex field`() {
         val input = databaseConfigWithFields(
             listOf(
                 DatabaseMetadata(
                     name = "pangoLineage",
                     type = MetadataType.STRING,
                     generateLineageIndex = true,
-                ),
-            ),
-        )
-
-        val underTest = SequenceFilterFields.fromDatabaseConfig(input)
-
-        assertThat(underTest.fields, aMapWithSize(1))
-        assertThat(
-            underTest.fields,
-            hasEntry("pangolineage", SequenceFilterField("pangoLineage", SequenceFilterFieldType.Lineage)),
-        )
-    }
-
-    @Test
-    fun `GIVEN config with a field with lineage index and regex search THEN contains a lineage and regex field`() {
-        val input = databaseConfigWithFields(
-            listOf(
-                DatabaseMetadata(
-                    name = "pangoLineage",
-                    type = MetadataType.STRING,
-                    generateLineageIndex = true,
-                    lapisAllowsRegexSearch = true,
                 ),
             ),
         )

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
@@ -758,6 +758,11 @@ class AdvancedQueryFacadeTest {
                     "IsNull(floatField>=1)",
                     "Failed to parse advanced query (line 1:17): mismatched input '>=' expecting",
                 ),
+                InvalidTestCase(
+                    "non-string field with regex",
+                    "date.regex = 'this should not be allowed'",
+                    "Metadata field 'date' of type DATE does not support regex search.",
+                ),
             )
     }
 


### PR DESCRIPTION
BREAKING CHANGE: `lapisAllowsRegexSearch` on string metadata fields in the database config is not necessary anymore, regex search is always enabled for all string fields.

resolves #1175


## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
