### PR TITLE
fix(lapis): advanced queries: disallow `isNull(<fieldName>.regex)` for all field types

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -238,20 +238,12 @@ class AdvancedQueryCustomListener(
     override fun enterIsNullQuery(ctx: AdvancedQueryParser.IsNullQueryContext) {
         val metadataName = ctx.name().text
 
-        var name = metadataName
-        if (metadataName.endsWith(".regex")) {
-            name = metadataName.substringBeforeLast(".regex")
-        }
-
-        val field: DatabaseMetadata = getFieldOrThrow(metadataFieldsByName, name)
+        val field: DatabaseMetadata = getFieldOrThrow(metadataFieldsByName, metadataName)
         when (field.type) {
             MetadataType.STRING -> {
                 if (field.generateLineageIndex) {
                     expressionStack.addLast(LineageEquals(field.name, null, false))
                 } else {
-                    if (metadataName.endsWith(".regex")) {
-                        throw BadRequestException("Filter IsNull($name) instead of IsNull($metadataName)", null)
-                    }
                     expressionStack.addLast(StringEquals(field.name, null))
                 }
             }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
@@ -744,9 +744,19 @@ class AdvancedQueryFacadeTest {
                     "Failed to parse advanced query (line 1:20): mismatched input '=' expecting",
                 ),
                 InvalidTestCase(
-                    "metadata regex with IsNull",
+                    "metadata regex with value in IsNull",
                     "IsNull(some_metadata.regex='country')",
                     "Failed to parse advanced query (line 1:26): mismatched input '=' expecting",
+                ),
+                InvalidTestCase(
+                    "metadata regex in IsNull",
+                    "IsNull(some_metadata.regex)",
+                    "Metadata field some_metadata.regex does not exist",
+                ),
+                InvalidTestCase(
+                    "boolean.regex in IsNull",
+                    "IsNull(test_boolean_column.regex)",
+                    "Metadata field test_boolean_column.regex does not exist",
                 ),
                 InvalidTestCase(
                     "intField with IsNull",


### PR DESCRIPTION


I accidentally found this while doing #1194 

e.g. dates don't allow regex search, thus `isNull(date.regex)` should be rejected



## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
