### PR TITLE
fix(lapis): advanced queries: make `.regex` case-insensitive

### DIFF
--- a/.github/workflows/lapis.yml
+++ b/.github/workflows/lapis.yml
@@ -148,7 +148,7 @@ jobs:
           docker compose -f lapis/docker-compose.yml up -d --wait
           cd lapis-e2e && npm run test
         env:
-          SILO_TAG: latest
+          SILO_TAG: commit-b239b4750dc829869b39d44e136bd14484859e3f
           LAPIS_TAG: ${{ steps.lapisBranchTag.outputs.lapisTag }}
 
       - name: Store Logs

--- a/.github/workflows/lapis.yml
+++ b/.github/workflows/lapis.yml
@@ -148,7 +148,7 @@ jobs:
           docker compose -f lapis/docker-compose.yml up -d --wait
           cd lapis-e2e && npm run test
         env:
-          SILO_TAG: commit-b239b4750dc829869b39d44e136bd14484859e3f
+          SILO_TAG: commit-b239b4750dc829869b39d44e136bd14484859e3f # TODO(#1202): revert to latest
           LAPIS_TAG: ${{ steps.lapisBranchTag.outputs.lapisTag }}
 
       - name: Store Logs

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -1,7 +1,6 @@
 package org.genspectrum.lapis.model
 
 import AdvancedQueryBaseListener
-import AdvancedQueryParser
 import AdvancedQueryParser.AndContext
 import AdvancedQueryParser.MaybeContext
 import AdvancedQueryParser.NOfQueryContext
@@ -42,14 +41,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeParseException
 import java.util.Locale
 import kotlin.collections.ArrayDeque
-import kotlin.collections.Map
-import kotlin.collections.associateBy
-import kotlin.collections.joinToString
-import kotlin.collections.listOf
-import kotlin.collections.mutableListOf
-import kotlin.collections.plus
-import kotlin.collections.plusAssign
-import kotlin.collections.reversed
 
 fun getFieldOrThrow(
     metadataFieldsByName: Map<String, DatabaseMetadata>,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -1,6 +1,7 @@
 package org.genspectrum.lapis.model
 
 import AdvancedQueryBaseListener
+import AdvancedQueryParser
 import AdvancedQueryParser.AndContext
 import AdvancedQueryParser.MaybeContext
 import AdvancedQueryParser.NOfQueryContext
@@ -41,6 +42,14 @@ import java.time.LocalDate
 import java.time.format.DateTimeParseException
 import java.util.Locale
 import kotlin.collections.ArrayDeque
+import kotlin.collections.Map
+import kotlin.collections.associateBy
+import kotlin.collections.joinToString
+import kotlin.collections.listOf
+import kotlin.collections.mutableListOf
+import kotlin.collections.plus
+import kotlin.collections.plusAssign
+import kotlin.collections.reversed
 
 fun getFieldOrThrow(
     metadataFieldsByName: Map<String, DatabaseMetadata>,
@@ -174,8 +183,8 @@ class AdvancedQueryCustomListener(
         val metadataName = ctx.name().text
         val metadataValue = ctx.value().text.trim('\'')
 
-        if (metadataName.endsWith(".regex")) {
-            val fieldName = metadataName.substringBeforeLast(".regex")
+        if (metadataName.endsWith(".regex", ignoreCase = true)) {
+            val fieldName = metadataName.substringBeforeLast(".")
             val field = getFieldOrThrow(metadataFieldsByName, fieldName)
 
             if (field.type !== MetadataType.STRING) {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
@@ -640,11 +640,6 @@ class AdvancedQueryFacadeTest {
                     "Metadata field floatFieldTo does not exist",
                 ),
                 InvalidTestCase(
-                    "non-string field with regex",
-                    "date.regex = 'this should not be allowed'",
-                    "Metadata field 'date' of type DATE does not support regex search.",
-                ),
-                InvalidTestCase(
                     "invalid boolean field",
                     "test_boolean_column=maybe",
                     "'maybe' is not a valid boolean",
@@ -674,7 +669,13 @@ class AdvancedQueryFacadeTest {
                     expected = StringSearch("some_metadata", "value"),
                 ),
             ),
-            invalid = listOf(),
+            invalid = listOf(
+                InvalidTestCase(
+                    "non-string field with regex",
+                    "date.regex = 'this should not be allowed'",
+                    "Metadata field 'date' of type DATE does not support regex search.",
+                ),
+            ),
         )
 
         private val isNullCases = TestCaseCollection(


### PR DESCRIPTION
also refactor the test to make it easier to grasp what is already tested

resolves #1187


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
