### PR TITLE
1213 mutations over time add model for nucleotide mutations

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -8,7 +8,7 @@ import org.genspectrum.lapis.config.VARIANT_QUERY_FIELD
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.request.AminoAcidInsertion
 import org.genspectrum.lapis.request.AminoAcidMutation
-import org.genspectrum.lapis.request.CommonSequenceFilters
+import org.genspectrum.lapis.request.BaseSequenceFilters
 import org.genspectrum.lapis.request.MaybeMutation
 import org.genspectrum.lapis.request.NucleotideInsertion
 import org.genspectrum.lapis.request.NucleotideMutation
@@ -51,7 +51,7 @@ class SiloFilterExpressionMapper(
     private val variantQueryFacade: VariantQueryFacade,
     private val advancedQueryFacade: AdvancedQueryFacade,
 ) {
-    fun map(sequenceFilters: CommonSequenceFilters): SiloFilterExpression {
+    fun map(sequenceFilters: BaseSequenceFilters): SiloFilterExpression {
         if (sequenceFilters.isEmpty()) {
             return True
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/DateRange.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/DateRange.kt
@@ -1,0 +1,17 @@
+package org.genspectrum.lapis.model.mutationsOverTime
+
+import java.time.LocalDate
+
+data class DateRange(
+    var dateFrom: LocalDate?,
+    var dateTo: LocalDate?,
+) {
+    fun containsDate(date: LocalDate): Boolean {
+        if (dateFrom == null && dateTo == null) {
+            return false
+        }
+
+        return (dateFrom == null || date >= dateFrom) &&
+            (dateTo == null || date <= dateTo)
+    }
+}

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/MutationsOverTime.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/MutationsOverTime.kt
@@ -1,0 +1,187 @@
+package org.genspectrum.lapis.model.mutationsOverTime
+
+import org.genspectrum.lapis.model.SiloFilterExpressionMapper
+import org.genspectrum.lapis.model.nucleotideSymbols
+import org.genspectrum.lapis.request.BaseSequenceFilters
+import org.genspectrum.lapis.request.NucleotideMutation
+import org.genspectrum.lapis.response.AggregationData
+import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.DateBetween
+import org.genspectrum.lapis.silo.HasNucleotideMutation
+import org.genspectrum.lapis.silo.NucleotideSymbolEquals
+import org.genspectrum.lapis.silo.Or
+import org.genspectrum.lapis.silo.SiloAction
+import org.genspectrum.lapis.silo.SiloClient
+import org.genspectrum.lapis.silo.SiloFilterExpression
+import org.genspectrum.lapis.silo.SiloQuery
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+data class MutationOverTimeResponse(
+    var rowLabels: List<NucleotideMutation>,
+    var columnLabels: List<DateRange>,
+    var data: List<List<MutationOverTimeCell>>,
+)
+
+data class MutationOverTimeCell(
+    var count: Int,
+    var coverage: Int,
+)
+
+@Component
+class MutationsOverTime(
+    private val siloClient: SiloClient,
+    private val siloFilterExpressionMapper: SiloFilterExpressionMapper,
+) {
+    fun evaluate(
+        mutations: List<NucleotideMutation>,
+        dateRanges: List<DateRange>,
+        lapisFilter: BaseSequenceFilters,
+        dateField: String,
+    ): MutationOverTimeResponse {
+        if (mutations.isEmpty() || dateRanges.isEmpty()) {
+            return MutationOverTimeResponse(
+                rowLabels = mutations,
+                columnLabels = dateRanges,
+                data = emptyList(),
+            )
+        }
+
+        val dateQuery =
+            DateBetween(column = dateField, from = dateRanges[0].dateFrom, to = dateRanges.last().dateTo)
+
+        val siloExpressionFromLapisFilter = siloFilterExpressionMapper.map(lapisFilter)
+
+        val data = mutations.parallelStream().map { mutation ->
+            val counts = queryCounts(
+                mutation = mutation,
+                baseSiloFilterExpression = siloExpressionFromLapisFilter,
+                dateQuery = dateQuery,
+                dateField = dateField,
+            )
+            val coverage = queryCoverage(
+                mutation = mutation,
+                baseSiloFilterExpression = siloExpressionFromLapisFilter,
+                dateQuery = dateQuery,
+                dateField = dateField,
+            )
+
+            buildResultRow(dateRanges, counts, coverage, dateField)
+        }.toList()
+
+        return MutationOverTimeResponse(
+            rowLabels = mutations,
+            columnLabels = dateRanges,
+            data = data,
+        )
+    }
+
+    private fun queryCounts(
+        mutation: NucleotideMutation,
+        baseSiloFilterExpression: SiloFilterExpression,
+        dateQuery: DateBetween,
+        dateField: String,
+    ): List<AggregationData> {
+        val mutationQuery = when (mutation.symbol) {
+            null -> HasNucleotideMutation(mutation.sequenceName, mutation.position)
+            else -> NucleotideSymbolEquals(
+                mutation.sequenceName,
+                mutation.position,
+                mutation.symbol,
+            )
+        }
+
+        return sendQuery(
+            dateQuery = dateQuery,
+            baseSiloFilterExpression = baseSiloFilterExpression,
+            dateField = dateField,
+            mutationQuery = mutationQuery,
+        )
+    }
+
+    private fun queryCoverage(
+        mutation: NucleotideMutation,
+        baseSiloFilterExpression: SiloFilterExpression,
+        dateQuery: DateBetween,
+        dateField: String,
+    ): List<AggregationData> {
+        val coverageQuery = Or(
+            nucleotideSymbols.map {
+                NucleotideSymbolEquals(
+                    sequenceName = mutation.sequenceName,
+                    position = mutation.position,
+                    symbol = it.toString(),
+                )
+            },
+        )
+
+        return sendQuery(
+            dateQuery = dateQuery,
+            baseSiloFilterExpression = baseSiloFilterExpression,
+            dateField = dateField,
+            mutationQuery = coverageQuery,
+        )
+    }
+
+    private fun sendQuery(
+        baseSiloFilterExpression: SiloFilterExpression,
+        dateQuery: SiloFilterExpression,
+        mutationQuery: SiloFilterExpression,
+        dateField: String,
+    ): List<AggregationData> =
+        siloClient.sendQuery(
+            SiloQuery(
+                SiloAction.aggregated(
+                    listOf(dateField),
+                    emptyList(),
+                    null,
+                    null,
+                ),
+                And(
+                    children = listOf(
+                        baseSiloFilterExpression,
+                        mutationQuery,
+                        dateQuery,
+                    ),
+                ),
+            ),
+        ).toList()
+
+    private fun buildResultRow(
+        dateRanges: List<DateRange>,
+        counts: List<AggregationData>,
+        coverage: List<AggregationData>,
+        dateField: String,
+    ): List<MutationOverTimeCell> {
+        val result = Array(dateRanges.size) { MutationOverTimeCell(0, 0) }
+
+        counts.forEach { dateCount ->
+            val dateString = dateCount.fields[dateField]?.asText()
+            val index = findDateRangeIndex(dateRanges, dateString)
+            index?.let { result[it] = result[it].copy(count = result[it].count + dateCount.count) }
+        }
+
+        coverage.forEach { cov ->
+            val dateStr = cov.fields[dateField]?.asText()
+            val index = findDateRangeIndex(dateRanges, dateStr)
+            index?.let { result[it] = result[it].copy(coverage = result[it].coverage + cov.count) }
+        }
+
+        return result.toList()
+    }
+
+    private fun findDateRangeIndex(
+        dateRanges: List<DateRange>,
+        dateString: String?,
+    ): Int? {
+        if (dateString == null) {
+            return null
+        }
+
+        val date = LocalDate.parse(dateString)
+
+        return dateRanges.indexOfFirst {
+            it.containsDate(date)
+        }.takeIf { it >= 0 }
+    }
+}

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
@@ -10,15 +10,12 @@ import org.springframework.util.MultiValueMap
 typealias SequenceFilters = Map<String, List<String?>>
 typealias GetRequestSequenceFilters = MultiValueMap<String, String>
 
-interface CommonSequenceFilters {
+interface BaseSequenceFilters {
     val sequenceFilters: SequenceFilters
     val nucleotideMutations: List<NucleotideMutation>
     val aaMutations: List<AminoAcidMutation>
     val nucleotideInsertions: List<NucleotideInsertion>
     val aminoAcidInsertions: List<AminoAcidInsertion>
-    val orderByFields: List<OrderByField>
-    val limit: Int?
-    val offset: Int?
 
     fun isEmpty() =
         sequenceFilters.isEmpty() &&
@@ -26,6 +23,12 @@ interface CommonSequenceFilters {
             aaMutations.isEmpty() &&
             nucleotideInsertions.isEmpty() &&
             aminoAcidInsertions.isEmpty()
+}
+
+interface CommonSequenceFilters : BaseSequenceFilters {
+    val orderByFields: List<OrderByField>
+    val limit: Int?
+    val offset: Int?
 }
 
 fun parseCommonFields(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/DateRangeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/DateRangeTest.kt
@@ -1,0 +1,38 @@
+package org.genspectrum.lapis.model.mutationsOverTime
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class DateRangeTest {
+    @Test
+    fun `given a date range without start and end dates, containsDate should return false`() {
+        val dateRange = DateRange(null, null)
+        assertFalse(dateRange.containsDate(LocalDate.parse("2023-10-01")))
+    }
+
+    @Test
+    fun `given a date range with from and no to dates, containsDate should return true for dates greater than from `() {
+        val dateRange = DateRange(LocalDate.parse("2023-01-01"), null)
+        assert(dateRange.containsDate(LocalDate.parse("2023-10-01")))
+        assertFalse(dateRange.containsDate(LocalDate.parse("2021-10-01")))
+    }
+
+    @Test
+    fun `given a date range with to and no from dates, containsDate should return true for dates smaller than to `() {
+        val dateRange = DateRange(null, LocalDate.parse("2023-01-01"))
+        assertFalse(dateRange.containsDate(LocalDate.parse("2023-10-01")))
+        assert(dateRange.containsDate(LocalDate.parse("2021-10-01")))
+    }
+
+    @Test
+    fun `given a date range with from and to dates, containsDate should return true for dates inside range`() {
+        val dateRange = DateRange(LocalDate.parse("2022-01-01"), LocalDate.parse("2023-01-01"))
+        assert(dateRange.containsDate(LocalDate.parse("2022-10-01")))
+        assert(dateRange.containsDate(LocalDate.parse("2022-01-01")))
+        assert(dateRange.containsDate(LocalDate.parse("2023-01-01")))
+
+        assertFalse(dateRange.containsDate(LocalDate.parse("2021-10-01")))
+        assertFalse(dateRange.containsDate(LocalDate.parse("2024-10-01")))
+    }
+}

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/MutationsOverTimeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/MutationsOverTimeTest.kt
@@ -1,0 +1,354 @@
+package org.genspectrum.lapis.model.mutationsOverTime
+
+import com.fasterxml.jackson.databind.node.TextNode
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.genspectrum.lapis.model.SiloFilterExpressionMapper
+import org.genspectrum.lapis.request.AminoAcidInsertion
+import org.genspectrum.lapis.request.AminoAcidMutation
+import org.genspectrum.lapis.request.BaseSequenceFilters
+import org.genspectrum.lapis.request.NucleotideInsertion
+import org.genspectrum.lapis.request.NucleotideMutation
+import org.genspectrum.lapis.request.SequenceFilters
+import org.genspectrum.lapis.response.AggregationData
+import org.genspectrum.lapis.silo.And
+import org.genspectrum.lapis.silo.DateBetween
+import org.genspectrum.lapis.silo.NucleotideSymbolEquals
+import org.genspectrum.lapis.silo.Or
+import org.genspectrum.lapis.silo.SiloAction
+import org.genspectrum.lapis.silo.SiloClient
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import java.time.LocalDate
+import java.util.stream.Stream
+
+private data class TestLapisFilter(
+    override val sequenceFilters: SequenceFilters,
+    override val nucleotideMutations: List<NucleotideMutation>,
+    override val aaMutations: List<AminoAcidMutation>,
+    override val nucleotideInsertions: List<NucleotideInsertion>,
+    override val aminoAcidInsertions: List<AminoAcidInsertion>,
+) : BaseSequenceFilters
+
+const val DUMMY_DATE_FIELD = "date"
+private val DUMMY_LAPIS_FILTER = TestLapisFilter(emptyMap(), emptyList(), emptyList(), emptyList(), emptyList())
+
+@SpringBootTest
+class MutationsOverTimeTest {
+    @MockK
+    private lateinit var siloQueryClient: SiloClient
+
+    @Autowired
+    private lateinit var siloFilterExpressionMapper: SiloFilterExpressionMapper
+
+    private lateinit var underTest: MutationsOverTime
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        underTest = MutationsOverTime(siloQueryClient, siloFilterExpressionMapper)
+    }
+
+    @Test
+    fun `given an empty list of mutations, then it returns an empty list`() {
+        val mutations = emptyList<NucleotideMutation>()
+        val dateRanges = listOf(
+            DateRange(dateFrom = LocalDate.parse("2021-01-01"), dateTo = LocalDate.parse("2021-12-31")),
+            DateRange(dateFrom = LocalDate.parse("2022-01-01"), dateTo = LocalDate.parse("2022-12-31")),
+        )
+        val result = underTest.evaluate(
+            mutations = mutations,
+            dateRanges = dateRanges,
+            lapisFilter = DUMMY_LAPIS_FILTER,
+            dateField = DUMMY_DATE_FIELD,
+        )
+
+        assertThat(result.rowLabels, equalTo(emptyList()))
+        assertThat(result.data, equalTo(emptyList()))
+        assertThat(result.columnLabels, equalTo(dateRanges))
+    }
+
+    @Test
+    fun `given an empty list of date ranges, then it returns an empty list`() {
+        val mutations = listOf(
+            NucleotideMutation(sequenceName = "sequence1", position = 123, symbol = "T"),
+            NucleotideMutation(sequenceName = "sequence1", position = 234, symbol = "G"),
+        )
+        val dateRanges = emptyList<DateRange>()
+        val result = underTest.evaluate(
+            mutations = mutations,
+            dateRanges = dateRanges,
+            lapisFilter = DUMMY_LAPIS_FILTER,
+            dateField = DUMMY_DATE_FIELD,
+        )
+
+        assertThat(result.rowLabels, equalTo(mutations))
+        assertThat(result.data, equalTo(emptyList()))
+        assertThat(result.columnLabels, equalTo(emptyList()))
+    }
+
+    @Test
+    fun `given a list of mutations and date ranges, then it returns the count and coverage data`() {
+        every {
+            siloQueryClient.sendQuery<AggregationData>(
+                match { query ->
+                    query.action == SiloAction.aggregated(
+                        listOf(DUMMY_DATE_FIELD),
+                        emptyList(),
+                        null,
+                        null,
+                    ) &&
+                        query.filterExpression is And &&
+                        (query.filterExpression as And).children.any {
+                            it is NucleotideSymbolEquals &&
+                                it.sequenceName == "sequence1" &&
+                                it.position == 123 &&
+                                it.symbol == "T"
+                        } &&
+                        (query.filterExpression as And).children.any {
+                            it is DateBetween &&
+                                it.column == DUMMY_DATE_FIELD &&
+                                it.from == LocalDate.parse("2021-01-01") &&
+                                it.to == LocalDate.parse("2022-12-31")
+                        }
+                },
+            )
+        } answers {
+            Stream.of(
+                AggregationData(1, fields = mapOf("date" to TextNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
+            )
+        }
+
+        every {
+            siloQueryClient.sendQuery<AggregationData>(
+                match { query ->
+                    query.action == SiloAction.aggregated(
+                        listOf(DUMMY_DATE_FIELD),
+                        emptyList(),
+                        null,
+                        null,
+                    ) &&
+                        query.filterExpression is And &&
+                        (query.filterExpression as And).children.any {
+                            it is NucleotideSymbolEquals &&
+                                it.sequenceName == "sequence1" &&
+                                it.position == 234 &&
+                                it.symbol == "G"
+                        } &&
+                        (query.filterExpression as And).children.any {
+                            it is DateBetween &&
+                                it.column == DUMMY_DATE_FIELD &&
+                                it.from == LocalDate.parse("2021-01-01") &&
+                                it.to == LocalDate.parse("2022-12-31")
+                        }
+                },
+            )
+        } answers {
+            Stream.of(
+                AggregationData(3, fields = mapOf("date" to TextNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(2, fields = mapOf("date" to TextNode("2022-07-01"))),
+            )
+        }
+
+        every {
+            siloQueryClient.sendQuery<AggregationData>(
+                match { query ->
+                    query.action == SiloAction.aggregated(
+                        listOf(DUMMY_DATE_FIELD),
+                        emptyList(),
+                        null,
+                        null,
+                    ) &&
+                        query.filterExpression is And &&
+                        (query.filterExpression as And).children.any {
+                            it is Or &&
+                                (it).children.all { child ->
+                                    child is NucleotideSymbolEquals &&
+                                        child.sequenceName == "sequence1" &&
+                                        child.position == 123 &&
+                                        child.symbol in listOf("A", "C", "T", "G")
+                                }
+                        } &&
+                        (query.filterExpression as And).children.any {
+                            it is DateBetween &&
+                                it.column == DUMMY_DATE_FIELD &&
+                                it.from == LocalDate.parse("2021-01-01") &&
+                                it.to == LocalDate.parse("2022-12-31")
+                        }
+                },
+            )
+        } answers {
+            Stream.of(
+                AggregationData(5, fields = mapOf("date" to TextNode("2021-06-01"))),
+                AggregationData(6, fields = mapOf("date" to TextNode("2022-06-01"))),
+            )
+        }
+
+        every {
+            siloQueryClient.sendQuery<AggregationData>(
+                match { query ->
+                    query.action == SiloAction.aggregated(
+                        listOf(DUMMY_DATE_FIELD),
+                        emptyList(),
+                        null,
+                        null,
+                    ) &&
+                        query.filterExpression is And &&
+                        (query.filterExpression as And).children.any {
+                            it is Or &&
+                                (it).children.all { child ->
+                                    child is NucleotideSymbolEquals &&
+                                        child.sequenceName == "sequence1" &&
+                                        child.position == 234 &&
+                                        child.symbol in listOf("A", "C", "T", "G")
+                                }
+                        } &&
+                        (query.filterExpression as And).children.any {
+                            it is DateBetween &&
+                                it.column == DUMMY_DATE_FIELD &&
+                                it.from == LocalDate.parse("2021-01-01") &&
+                                it.to == LocalDate.parse("2022-12-31")
+                        }
+                },
+            )
+        } answers {
+            Stream.of(
+                AggregationData(0, fields = mapOf("date" to TextNode("2021-06-01"))),
+                AggregationData(1, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
+            )
+        }
+
+        val mutations = listOf(
+            NucleotideMutation(sequenceName = "sequence1", position = 123, symbol = "T"),
+            NucleotideMutation(sequenceName = "sequence1", position = 234, symbol = "G"),
+        )
+        val dateRanges = listOf(
+            DateRange(dateFrom = LocalDate.parse("2021-01-01"), dateTo = LocalDate.parse("2021-12-31")),
+            DateRange(dateFrom = LocalDate.parse("2022-01-01"), dateTo = LocalDate.parse("2022-12-31")),
+        )
+
+        val result = underTest.evaluate(
+            mutations = mutations,
+            lapisFilter = DUMMY_LAPIS_FILTER,
+            dateField = DUMMY_DATE_FIELD,
+            dateRanges = dateRanges,
+        )
+
+        assertThat(result.rowLabels, equalTo(mutations))
+        assertThat(result.columnLabels, equalTo(dateRanges))
+        assertThat(
+            result.data,
+            equalTo(
+                listOf(
+                    listOf(
+                        MutationOverTimeCell(count = 1, coverage = 5),
+                        MutationOverTimeCell(count = 2, coverage = 6),
+                    ),
+                    listOf(
+                        MutationOverTimeCell(count = 3, coverage = 0),
+                        MutationOverTimeCell(count = 4, coverage = 2),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `given a list of mutations and date ranges and no data for a mutation, then it returns zero`() {
+        every {
+            siloQueryClient.sendQuery<AggregationData>(
+                match { query ->
+                    query.action == SiloAction.aggregated(
+                        listOf(DUMMY_DATE_FIELD),
+                        emptyList(),
+                        null,
+                        null,
+                    ) &&
+                        query.filterExpression is And &&
+                        (query.filterExpression as And).children.any {
+                            it is NucleotideSymbolEquals &&
+                                it.sequenceName == "sequence1" &&
+                                it.position == 123 &&
+                                it.symbol == "T"
+                        } &&
+                        (query.filterExpression as And).children.any {
+                            it is DateBetween &&
+                                it.column == DUMMY_DATE_FIELD &&
+                                it.from == LocalDate.parse("2021-01-01") &&
+                                it.to == LocalDate.parse("2022-12-31")
+                        }
+                },
+            )
+        } answers {
+            Stream.empty()
+        }
+
+        every {
+            siloQueryClient.sendQuery<AggregationData>(
+                match { query ->
+                    query.action == SiloAction.aggregated(
+                        listOf(DUMMY_DATE_FIELD),
+                        emptyList(),
+                        null,
+                        null,
+                    ) &&
+                        query.filterExpression is And &&
+                        (query.filterExpression as And).children.any {
+                            it is Or &&
+                                (it).children.all { child ->
+                                    child is NucleotideSymbolEquals &&
+                                        child.sequenceName == "sequence1" &&
+                                        child.position == 123 &&
+                                        child.symbol in listOf("A", "C", "T", "G")
+                                }
+                        } &&
+                        (query.filterExpression as And).children.any {
+                            it is DateBetween &&
+                                it.column == DUMMY_DATE_FIELD &&
+                                it.from == LocalDate.parse("2021-01-01") &&
+                                it.to == LocalDate.parse("2022-12-31")
+                        }
+                },
+            )
+        } answers {
+            Stream.empty()
+        }
+
+        val mutations = listOf(
+            NucleotideMutation(sequenceName = "sequence1", position = 123, symbol = "T"),
+        )
+        val dateRanges = listOf(
+            DateRange(dateFrom = LocalDate.parse("2021-01-01"), dateTo = LocalDate.parse("2021-12-31")),
+            DateRange(dateFrom = LocalDate.parse("2022-01-01"), dateTo = LocalDate.parse("2022-12-31")),
+        )
+
+        val result = underTest.evaluate(
+            mutations = mutations,
+            lapisFilter = DUMMY_LAPIS_FILTER,
+            dateField = DUMMY_DATE_FIELD,
+            dateRanges = dateRanges,
+        )
+
+        assertThat(result.rowLabels, equalTo(mutations))
+        assertThat(result.columnLabels, equalTo(dateRanges))
+        assertThat(
+            result.data,
+            equalTo(
+                listOf(
+                    listOf(
+                        MutationOverTimeCell(count = 0, coverage = 0),
+                        MutationOverTimeCell(count = 0, coverage = 0),
+                    ),
+                ),
+            ),
+        )
+    }
+}

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -63,7 +63,7 @@ class SiloClientTest(
 
         someQuery = SiloQuery(
             SiloAction.aggregated(),
-            StringEquals("theColumn", "a value that is difference for each test method: $counter"),
+            StringEquals("theColumn", "a value that is different for each test method: $counter"),
         )
         counter++
     }


### PR DESCRIPTION
resolves #1213

This adds the first model to evaluate the mutations over time, for a given set of dateRanges and nucleotide mutations. This needs to be extended in #1214 to also work for amino acid mutations.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
