### PR TITLE
fix(lapis): fix Swagger UI layout of GET requests

### DIFF
--- a/.github/workflows/lapis.yml
+++ b/.github/workflows/lapis.yml
@@ -82,18 +82,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build OpenAPI Spec
-        working-directory: lapis
-        run: ./gradlew generateOpenApiDocs
-
-      - name: Build OpenAPI Spec Protected
-        working-directory: lapis
-        run: ./gradlew generateOpenApiDocs -PopennessLevel=protected
-
-      - name: Build OpenAPI Spec Multi segmented
-        working-directory: lapis
-        run: ./gradlew generateOpenApiDocs -Psegmented=true
-
       - name: Cache .npm
         uses: actions/cache@v4
         with:
@@ -105,15 +93,7 @@ jobs:
         working-directory: lapis-e2e
 
       - name: Generate Lapis Client
-        run: npm run generateLapisClient
-        working-directory: lapis-e2e
-
-      - name: Generate Lapis Client Protected
-        run: npm run generateLapisClientProtected
-        working-directory: lapis-e2e
-
-      - name: Generate Lapis Client Multi Segmented
-        run: npm run generateLapisClientMultiSegmented
+        run: ./generateOpenApiClients.sh
         working-directory: lapis-e2e
 
       - name: Check Format

--- a/lapis-e2e/README.md
+++ b/lapis-e2e/README.md
@@ -5,10 +5,8 @@ These end-to-end test the integration of SILO and LAPIS.
 How to execute the tests
 (Given that you have a running LAPIS instance listening on localhost:8090, e.g. via `docker compose up`):
 
-- Generate the OpenAPI docs for LAPIS: `cd ../lapis && ./gradlew generateOpenApiDocs && ./gradlew generateOpenApiDocs -PopennessLevel=protected && ./gradlew generateOpenApiDocs -Psegmented=true`
-- Switch to test directory: `cd ../lapis-e2e/`
 - Install NPM dependencies: `npm install`
-- Generate a Typescript client for LAPIS: `npm run generateLapisClient && npm run generateLapisClientProtected && npm run generateLapisClientMultiSegmented`
+- Generate the Typescript clients for LAPIS: `./generateOpenApiClients.sh`
 - Execute the tests: `npm run test`
 
 To only run single tests:

--- a/lapis-e2e/generateOpenApiClients.sh
+++ b/lapis-e2e/generateOpenApiClients.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "../lapis"
+./gradlew generateOpenApiDocs
+./gradlew generateOpenApiDocs -PopennessLevel=protected
+./gradlew generateOpenApiDocs -Psegmented=true
+
+cd -
+npm run generateLapisClient
+npm run generateLapisClientProtected
+npm run generateLapisClientMultiSegmented

--- a/lapis-e2e/test/aggregated.spec.ts
+++ b/lapis-e2e/test/aggregated.spec.ts
@@ -126,7 +126,7 @@ describe('The /aggregated endpoint', () => {
       },
     });
 
-    expect(ascendingOrderedResult.data[0].division).to.be.null;
+    expect(ascendingOrderedResult.data[0].division).to.be.undefined;
     expect(ascendingOrderedResult.data[1]).to.have.property('division', 'Aargau');
 
     const descendingOrderedResult = await lapisClient.postAggregated({

--- a/lapis-e2e/test/aggregatedQueries/aggregrationFields.json
+++ b/lapis-e2e/test/aggregatedQueries/aggregrationFields.json
@@ -13,8 +13,7 @@
   "expected": [
     {
       "count": 2,
-      "country": "Switzerland",
-      "division": null
+      "country": "Switzerland"
     },
     {
       "count": 6,

--- a/lapis-e2e/test/aggregatedQueries/groupByBoolean.json
+++ b/lapis-e2e/test/aggregatedQueries/groupByBoolean.json
@@ -6,15 +6,14 @@
   "expected": [
     {
       "count": 34,
-      "test_boolean_column": true
+      "testBooleanColumn": true
+    },
+    {
+      "count": 33
     },
     {
       "count": 33,
-      "test_boolean_column": null
-    },
-    {
-      "count": 33,
-      "test_boolean_column": false
+      "testBooleanColumn": false
     }
   ]
 }

--- a/lapis-e2e/test/aminoAcidMutations.spec.ts
+++ b/lapis-e2e/test/aminoAcidMutations.spec.ts
@@ -38,7 +38,14 @@ describe('The /aminoAcidMutations endpoint', () => {
 
     const mutation = result.data[0];
     expect(mutation).to.deep.equal({
+      count: undefined,
+      coverage: undefined,
       mutation: 'ORF1a:A1306S',
+      mutationFrom: undefined,
+      mutationTo: undefined,
+      position: undefined,
+      proportion: undefined,
+      sequenceName: undefined,
     });
   });
 

--- a/lapis-e2e/test/details.spec.ts
+++ b/lapis-e2e/test/details.spec.ts
@@ -19,8 +19,15 @@ describe('The /details endpoint', () => {
       a.division.localeCompare(b.division)
     );
     expect(result.data[1]).to.be.deep.equal({
+      age: undefined,
+      country: undefined,
+      date: undefined,
       division: 'Zürich',
       pangoLineage: 'B.1.617.2',
+      primaryKey: undefined,
+      qcValue: undefined,
+      region: undefined,
+      testBooleanColumn: undefined,
     });
   });
 
@@ -42,9 +49,9 @@ describe('The /details endpoint', () => {
       division: 'Zürich',
       primaryKey: 'key_3128796',
       pangoLineage: 'B.1.617.2',
-      qc_value: 0.96,
+      qcValue: 0.96,
       region: 'Europe',
-      test_boolean_column: false,
+      testBooleanColumn: false,
     });
   });
 
@@ -56,8 +63,8 @@ describe('The /details endpoint', () => {
       },
     });
 
-    expect(ascendingOrderedResult.data[0].division).to.be.null;
-    expect(ascendingOrderedResult.data[1].division).to.be.null;
+    expect(ascendingOrderedResult.data[0].division).to.be.undefined;
+    expect(ascendingOrderedResult.data[1].division).to.be.undefined;
     expect(ascendingOrderedResult.data[2]).to.have.property('division', 'Aargau');
 
     const descendingOrderedResult = await lapisClient.postDetails({
@@ -185,9 +192,9 @@ Solothurn	B.1	key_1002052
       division: 'Zürich',
       primaryKey: 'key_3578231',
       pangoLineage: 'P.1',
-      qc_value: 0.93,
+      qcValue: 0.93,
       region: 'Europe',
-      test_boolean_column: null,
+      testBooleanColumn: undefined,
     };
 
     const result = await lapisClient.postDetails({
@@ -208,9 +215,9 @@ Solothurn	B.1	key_1002052
       division: 'Vaud',
       primaryKey: 'key_3259931',
       pangoLineage: 'AY.43',
-      qc_value: 0.98,
+      qcValue: 0.98,
       region: 'Europe',
-      test_boolean_column: true,
+      testBooleanColumn: true,
     };
 
     const result = await lapisClient.postDetails({
@@ -251,7 +258,7 @@ key_1002052
       },
     });
 
-    expect(result).to.have.nested.property('data[0].division', null);
+    expect(result).to.have.nested.property('data[0].division', undefined);
   });
 
   it('variantQuery and advancedQuery should be the same for sequence and regex intersections and unions', async () => {
@@ -267,14 +274,14 @@ key_1002052
           detailsPostRequest: {
             fields: ['primaryKey'],
             divisionRegex: regexQuery,
-            orderBy: ['primaryKey'],
+            orderBy: [{ field: 'primaryKey' }],
           },
         });
         const resultVariant = await lapisClient.postDetails({
           detailsPostRequest: {
             fields: ['primaryKey'],
             variantQuery: sequenceQuery,
-            orderBy: ['primaryKey'],
+            orderBy: [{ field: 'primaryKey' }],
           },
         });
 
@@ -292,14 +299,14 @@ key_1002052
           detailsPostRequest: {
             fields: ['primaryKey'],
             advancedQuery: advancedQueryIntersection,
-            orderBy: ['primaryKey'],
+            orderBy: [{ field: 'primaryKey' }],
           },
         });
         const resultUnion = await lapisClient.postDetails({
           detailsPostRequest: {
             fields: ['primaryKey'],
             advancedQuery: advancedQueryUnion,
-            orderBy: ['primaryKey'],
+            orderBy: [{ field: 'primaryKey' }],
           },
         });
 

--- a/lapis-e2e/test/nucleotideInsertions.spec.ts
+++ b/lapis-e2e/test/nucleotideInsertions.spec.ts
@@ -24,7 +24,7 @@ describe('The /nucleotideInsertions endpoint', () => {
     expect(specificInsertion?.count).to.equal(17);
     expect(specificInsertion?.insertedSymbols).to.equal('CCC');
     expect(specificInsertion?.position).to.equal(25701);
-    expect(specificInsertion?.sequenceName).to.be.null;
+    expect(specificInsertion?.sequenceName).to.be.undefined;
   });
 
   it('should return nucleotide insertions for multi segmented sequences', async () => {
@@ -119,14 +119,14 @@ describe('The /nucleotideInsertions endpoint', () => {
       insertedSymbols: 'CCC',
       insertion: 'ins_25701:CCC',
       position: 25701,
-      sequenceName: null,
+      sequenceName: undefined,
     });
     expect(result.data[1]).to.deep.equal({
       count: 1,
       insertedSymbols: 'TAT',
       insertion: 'ins_5959:TAT',
       position: 5959,
-      sequenceName: null,
+      sequenceName: undefined,
     });
   });
 

--- a/lapis-e2e/test/nucleotideMutations.spec.ts
+++ b/lapis-e2e/test/nucleotideMutations.spec.ts
@@ -23,7 +23,7 @@ describe('The /nucleotideMutations endpoint', () => {
     );
     expect(commonMutationProportion?.count).to.equal(51);
     expect(commonMutationProportion?.proportion).to.be.approximately(0.5204, 0.0001);
-    expect(commonMutationProportion?.sequenceName).to.be.null;
+    expect(commonMutationProportion?.sequenceName).to.be.undefined;
     expect(commonMutationProportion?.mutationFrom).to.be.equal('G');
     expect(commonMutationProportion?.mutationTo).to.be.equal('C');
     expect(commonMutationProportion?.position).to.be.equal(28280);
@@ -38,7 +38,14 @@ describe('The /nucleotideMutations endpoint', () => {
 
     const mutation = result.data[0];
     expect(mutation).to.deep.equal({
+      count: undefined,
+      coverage: undefined,
       mutation: 'A1-',
+      mutationFrom: undefined,
+      mutationTo: undefined,
+      position: undefined,
+      proportion: undefined,
+      sequenceName: undefined,
     });
   });
 
@@ -125,7 +132,7 @@ describe('The /nucleotideMutations endpoint', () => {
       mutationFrom: 'C',
       mutationTo: 'T',
       position: 241,
-      sequenceName: null,
+      sequenceName: undefined,
     };
 
     const result = await lapisClient.postNucleotideMutations({
@@ -147,7 +154,7 @@ describe('The /nucleotideMutations endpoint', () => {
       mutationFrom: 'G',
       mutationTo: 'T',
       position: 210,
-      sequenceName: null,
+      sequenceName: undefined,
     };
 
     const result = await lapisClient.postNucleotideMutations({

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -64,14 +64,14 @@ fun buildOpenApiSchema(
                 .addSchemas(
                     PRIMITIVE_FIELD_FILTERS_SCHEMA,
                     Schema<String>()
-                        .type("object")
+                        .types(setOf("object"))
                         .description("valid filters for sequence data")
                         .properties(computePrimitiveFieldFilters(databaseConfig, sequenceFilterFields)),
                 )
                 .addSchemas(
                     REQUEST_SCHEMA_WITH_MIN_PROPORTION,
                     Schema<String>()
-                        .type("object")
+                        .types(setOf("object"))
                         .description("valid filters for sequence data")
                         .properties(
                             getSequenceFiltersWithFormat(
@@ -79,7 +79,7 @@ fun buildOpenApiSchema(
                                 sequenceFilterFields = sequenceFilterFields,
                                 orderByFieldsSchema = mutationsOrderByFieldsEnum(),
                                 dataFormatSchema = dataFormatSchema(),
-                            ) + Pair(MIN_PROPORTION_PROPERTY, Schema<String>().type("number")) +
+                            ) + Pair(MIN_PROPORTION_PROPERTY, Schema<String>().types(setOf("number"))) +
                                 Pair(FIELDS_PROPERTY, mutationsFieldsSchema()),
                         ),
                 )
@@ -152,7 +152,7 @@ fun buildOpenApiSchema(
                     AGGREGATED_RESPONSE_SCHEMA,
                     lapisResponseSchema(
                         Schema<String>()
-                            .type("object")
+                            .types(setOf("object"))
                             .description(
                                 "Aggregated sequence data. " +
                                     "If fields are specified, then these fields are also keys in the result. " +
@@ -168,7 +168,7 @@ fun buildOpenApiSchema(
                     DETAILS_RESPONSE_SCHEMA,
                     lapisResponseSchema(
                         Schema<String>()
-                            .type("object")
+                            .types(setOf("object"))
                             .description(
                                 "The response contains the metadata of every sequence matching the sequence filters.",
                             )
@@ -179,7 +179,7 @@ fun buildOpenApiSchema(
                     NUCLEOTIDE_MUTATIONS_RESPONSE_SCHEMA,
                     lapisResponseSchema(
                         Schema<String>()
-                            .type("object")
+                            .types(setOf("object"))
                             .description("The count and proportion of a mutation.")
                             .properties(nucleotideMutationProportionSchema()),
                     ),
@@ -189,7 +189,7 @@ fun buildOpenApiSchema(
                     AMINO_ACID_MUTATIONS_RESPONSE_SCHEMA,
                     lapisResponseSchema(
                         Schema<String>()
-                            .type("object")
+                            .types(setOf("object"))
                             .description("The count and proportion of a mutation.")
                             .properties(aminoAcidMutationProportionSchema()),
                     ),
@@ -198,7 +198,7 @@ fun buildOpenApiSchema(
                     NUCLEOTIDE_INSERTIONS_RESPONSE_SCHEMA,
                     lapisResponseSchema(
                         Schema<String>()
-                            .type("object")
+                            .types(setOf("object"))
                             .description("Nucleotide Insertion data.")
                             .properties(nucleotideInsertionSchema())
                             .required(
@@ -211,7 +211,7 @@ fun buildOpenApiSchema(
                     AMINO_ACID_INSERTIONS_RESPONSE_SCHEMA,
                     lapisResponseSchema(
                         Schema<String>()
-                            .type("object")
+                            .types(setOf("object"))
                             .description("Amino Acid Insertion data.")
                             .properties(aminoAcidInsertionSchema())
                             .required(aminoAcidInsertionSchema().keys.toList()),
@@ -324,26 +324,26 @@ private fun computePrimitiveFieldFilters(
     }
 
 private fun lapisResponseSchema(dataSchema: Schema<Any>) =
-    Schema<Any>().type("object")
+    Schema<Any>().types(setOf("object"))
         .properties(
             mapOf(
-                "data" to Schema<Any>().type("array").items(dataSchema),
+                "data" to Schema<Any>().types(setOf("array")).items(dataSchema),
                 "info" to infoResponseSchema(),
             ),
         )
         .required(listOf("data", "info"))
 
 private fun infoResponseSchema() =
-    Schema<LapisInfo>().type("object")
+    Schema<LapisInfo>().types(setOf("object"))
         .description(LAPIS_INFO_DESCRIPTION)
         .properties(
             mapOf(
-                "dataVersion" to Schema<String>().type("string")
+                "dataVersion" to Schema<String>().types(setOf("string"))
                     .description(LAPIS_DATA_VERSION_RESPONSE_DESCRIPTION)
                     .example(LAPIS_DATA_VERSION_EXAMPLE),
-                "requestId" to Schema<String>().type("string").description(REQUEST_ID_HEADER_DESCRIPTION),
-                "requestInfo" to Schema<String>().type("string").description(REQUEST_INFO_STRING_DESCRIPTION),
-                "reportTo" to Schema<String>().type("string"),
+                "requestId" to Schema<String>().types(setOf("string")).description(REQUEST_ID_HEADER_DESCRIPTION),
+                "requestInfo" to Schema<String>().types(setOf("string")).description(REQUEST_INFO_STRING_DESCRIPTION),
+                "reportTo" to Schema<String>().types(setOf("string")),
                 "lapisVersion" to StringSchema().description(VERSION_DESCRIPTION),
                 "siloVersion" to StringSchema().description(SILO_VERSION_DESCRIPTION),
             ),
@@ -351,12 +351,12 @@ private fun infoResponseSchema() =
         .required(listOf("reportTo"))
 
 private fun aggregatedMetadataFieldSchemas(databaseConfig: DatabaseConfig) =
-    databaseConfig.schema.metadata.associate { it.name to Schema<String>().type(mapToOpenApiType(it.type)) }
+    databaseConfig.schema.metadata.associate { it.name to Schema<String>().types(setOf(mapToOpenApiType(it.type))) }
 
 private fun detailsMetadataFieldSchemas(databaseConfig: DatabaseConfig) =
     databaseConfig.schema
         .metadata
-        .associate { it.name to Schema<String>().type(mapToOpenApiType(it.type)) }
+        .associate { it.name to Schema<String>().types(setOf(mapToOpenApiType(it.type))) }
 
 private fun mapToOpenApiType(type: MetadataType): String =
     when (type) {
@@ -377,13 +377,13 @@ private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
         SequenceFilterFieldType.String ->
             Schema<String>().anyOf(
                 listOf(
-                    nullableStringSchema(fieldType.openApiType),
-                    logicalOrArraySchema(nullableStringSchema(fieldType.openApiType)),
+                    stringSchema(fieldType.openApiType),
+                    logicalOrArraySchema(stringSchema(fieldType.openApiType)),
                 ),
             )
 
         SequenceFilterFieldType.Lineage -> {
-            val fieldSchema = nullableStringSchema(fieldType.openApiType)
+            val fieldSchema = stringSchema(fieldType.openApiType)
                 .description(
                     "Filter sequences by this lineage. " +
                         "You can suffix the filter value with '*' to include sublineages.",
@@ -399,28 +399,30 @@ private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
         is SequenceFilterFieldType.StringSearch ->
             Schema<String>().anyOf(
                 listOf(
-                    nullableStringRegexSchema(fieldType.associatedField),
-                    logicalOrArraySchema(nullableStringRegexSchema(fieldType.associatedField)),
+                    stringRegexSchema(fieldType.associatedField),
+                    logicalOrArraySchema(stringRegexSchema(fieldType.associatedField)),
                 ),
             )
 
-        else -> nullableStringSchema(fieldType.openApiType)
+        else -> stringSchema(fieldType.openApiType)
     }
 
-private fun nullableStringRegexSchema(associatedField: SequenceFilterFieldName) =
-    nullableStringSchema("string")
+private fun stringRegexSchema(associatedField: SequenceFilterFieldName) =
+    stringSchema("string")
         .description(
             "A regex pattern (subset of PCRE) for filtering '$associatedField'. " +
                 "For details on the syntax, see https://github.com/google/re2/wiki/Syntax.",
         )
 
-private fun nullableStringSchema(type: String) = Schema<String>().type(type).nullable(true)
+private fun stringSchema(type: String) =
+    Schema<String>()
+        .types(setOf(type))
 
 private fun requestSchemaForCommonSequenceFilters(
     requestProperties: Map<SequenceFilterFieldName, Schema<out Any>>,
 ): Schema<*> =
-    Schema<String>()
-        .type("object")
+    Schema<Any>()
+        .types(setOf("object"))
         .description("valid filters for sequence data")
         .properties(requestProperties)
 
@@ -429,8 +431,8 @@ private fun requestSchemaWithFields(
     fieldsDescription: String,
     databaseConfig: List<DatabaseMetadata>,
 ): Schema<*> =
-    Schema<String>()
-        .type("object")
+    Schema<Any>()
+        .types(setOf("object"))
         .description("valid filters for sequence data")
         .properties(
             requestProperties + Pair(
@@ -569,33 +571,33 @@ private fun aminoAcidInsertionSchema() =
 
 private fun nucleotideMutations() =
     Schema<List<NucleotideMutation>>()
-        .type("array")
+        .types(setOf("array"))
         .description("Logical \"and\" concatenation of a list of mutations.")
         .items(
             Schema<String>()
-                .type("string")
+                .types(setOf("string"))
                 .example("sequence1:A123T")
                 .description(NUCLEOTIDE_MUTATION_DESCRIPTION),
         )
 
 private fun aminoAcidMutations() =
     Schema<List<AminoAcidMutation>>()
-        .type("array")
+        .types(setOf("array"))
         .description("Logical \"and\" concatenation of a list of mutations.")
         .items(
             Schema<String>()
-                .type("string")
+                .types(setOf("string"))
                 .example("S:123T")
                 .description(AMINO_ACID_MUTATION_DESCRIPTION),
         )
 
 private fun nucleotideInsertions() =
     Schema<List<NucleotideInsertion>>()
-        .type("array")
+        .types(setOf("array"))
         .description("Logical \"and\" concatenation of a list of insertions.")
         .items(
             Schema<String>()
-                .type("string")
+                .types(setOf("string"))
                 .example("ins_123:ATT")
                 .description(
                     """
@@ -607,11 +609,11 @@ private fun nucleotideInsertions() =
 
 private fun aminoAcidInsertions() =
     Schema<List<AminoAcidInsertion>>()
-        .type("array")
+        .types(setOf("array"))
         .description("Logical \"and\" concatenation of a list of insertions.")
         .items(
             Schema<String>()
-                .type("string")
+                .types(setOf("string"))
                 .example("ins_ORF1a:123:ATT")
                 .description(
                     """
@@ -622,20 +624,20 @@ private fun aminoAcidInsertions() =
 
 private fun orderByPostSchema(orderByFieldsSchema: Schema<*>) =
     Schema<List<String>>()
-        .type("array")
+        .types(setOf("array"))
         .items(
             Schema<String>().anyOf(
                 listOf(
                     orderByFieldsSchema,
                     Schema<OrderByField>()
-                        .type("object")
+                        .types(setOf("object"))
                         .description("The fields by which the result is ordered with ascending or descending order.")
                         .required(listOf("field"))
                         .properties(
                             mapOf(
                                 "field" to orderByFieldsSchema,
                                 "type" to Schema<String>()
-                                    .type("string")
+                                    .types(setOf("string"))
                                     ._enum(listOf("ascending", "descending"))
                                     ._default("ascending"),
                             ),
@@ -646,18 +648,18 @@ private fun orderByPostSchema(orderByFieldsSchema: Schema<*>) =
 
 private fun limitSchema() =
     Schema<Int>()
-        .type("integer")
+        .types(setOf("integer"))
         .description(LIMIT_DESCRIPTION)
         .example(100)
 
 private fun offsetSchema() =
     Schema<Int>()
-        .type("integer")
+        .types(setOf("integer"))
         .description(OFFSET_DESCRIPTION)
 
 private fun dataFormatSchema() =
     Schema<String>()
-        .type("string")
+        .types(setOf("string"))
         .description(
             DATA_FORMAT_DESCRIPTION,
         )
@@ -666,7 +668,7 @@ private fun dataFormatSchema() =
 
 private fun sequencesFormatSchema() =
     Schema<String>()
-        .type("string")
+        .types(setOf("string"))
         .description(SEQUENCES_DATA_FORMAT_DESCRIPTION)
         ._enum(listOf(SequencesDataFormat.FASTA, SequencesDataFormat.JSON, SequencesDataFormat.NDJSON))
 
@@ -713,7 +715,7 @@ private fun fieldsEnum(
     databaseConfig: List<DatabaseMetadata> = emptyList(),
     additionalFields: List<String> = emptyList(),
 ) = Schema<String>()
-    .type("string")
+    .types(setOf("string"))
     ._enum(databaseConfig.map { it.name } + additionalFields)
 
 private fun logicalOrArraySchema(schema: Schema<Any>) =
@@ -729,8 +731,8 @@ private fun sequencesResponse(
     referenceSequenceSchemas: List<ReferenceSequenceSchema>,
 ): Schema<*> {
     val baseSchema = Schema<Any>()
-        .type("object")
-        .addProperty(schema.primaryKey, Schema<String>().type("string"))
+        .types(setOf("object"))
+        .addProperty(schema.primaryKey, Schema<String>().types(setOf("string")))
         .addRequiredItem(schema.primaryKey)
 
     return when (referenceSequenceSchemas.size == 1) {
@@ -739,7 +741,7 @@ private fun sequencesResponse(
                 .addProperty(
                     referenceSequenceSchemas[0].name,
                     Schema<String>()
-                        .type("string")
+                        .types(setOf("string"))
                         .description("The sequence data."),
                 )
                 .addRequiredItem(referenceSequenceSchemas[0].name)
@@ -747,7 +749,7 @@ private fun sequencesResponse(
 
         false -> {
             for (nucleotideSequence in referenceSequenceSchemas) {
-                baseSchema.addProperty(nucleotideSequence.name, Schema<String>().type("string"))
+                baseSchema.addProperty(nucleotideSequence.name, Schema<String>().types(setOf("string")))
             }
             baseSchema
                 .description(


### PR DESCRIPTION
in #1135 we upgraded to org.springdoc:springdoc-openapi-starter-webmvc-ui 2.8.6. Since version 2.8.0, they use OpenAPI version 3.1 as default which was breaking for us, because the generated spec didn't look as expected anymore

resolves #1193



## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
