### PR TITLE
test: make sort order put nulls as smallest element again in single-field sort

### DIFF
--- a/lapis-e2e/test/details.spec.ts
+++ b/lapis-e2e/test/details.spec.ts
@@ -63,9 +63,9 @@ describe('The /details endpoint', () => {
       },
     });
 
-    expect(ascendingOrderedResult.data.at(-1).division).to.be.undefined;
-    expect(ascendingOrderedResult.data.at(-2).division).to.be.undefined;
-    expect(ascendingOrderedResult.data[0]).to.have.property('division', 'Aargau');
+    expect(ascendingOrderedResult.data.at(-1)).to.have.property('division', 'Zürich');
+    expect(ascendingOrderedResult.data.at(-2)).to.have.property('division', 'Zürich');
+    expect(ascendingOrderedResult.data[0].division).to.be.undefined;
 
     const descendingOrderedResult = await lapisClient.postDetails({
       detailsPostRequest: {
@@ -253,12 +253,12 @@ key_1002052
   it('should order by random', async () => {
     const result = await lapisClient.postDetails({
       detailsPostRequest: {
-        orderBy: [{ field: 'random' }, { field: 'division' }],
+        orderBy: [{ field: 'random' }, { field: 'division', type: 'descending' }],
         fields: ['primaryKey', 'division'],
       },
     });
 
-    expect(result).to.have.nested.property('data[0].division', 'Aargau');
+    expect(result).to.have.nested.property('data[0].division', 'Zürich');
   });
 
   it('variantQuery and advancedQuery should be the same for sequence and regex intersections and unions', async () => {


### PR DESCRIPTION
Makes e2e tests green again after partially reverting a breaking change in SILO

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
