### PR TITLE
feat(lapis): drop sorting by segment/gene from docs of sequence endpoints

### DIFF
--- a/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
+++ b/lapis-e2e/test/unalignedNucleotideSequence.spec.ts
@@ -174,37 +174,6 @@ describe('The /unalignedNucleotideSequence endpoint', () => {
       });
     });
 
-    it('should order by segment', async () => {
-      const result = await lapisMultiSegmentedSequenceController.postAllUnalignedNucleotideSequences({
-        allNucleotideSequenceRequest: {
-          country: 'Switzerland',
-          dataFormat: 'JSON',
-          orderBy: [{ field: 'L', type: 'descending' }],
-          segments: ['L'],
-        },
-      });
-
-      expect(result).to.have.length(6);
-      expect(result[0]).to.deep.equal({
-        primaryKey: 'key_1',
-        l: 'NACTCT',
-        m: undefined,
-        s: undefined,
-      });
-      expect(result[1]).to.deep.equal({
-        primaryKey: 'key_0',
-        l: 'ACNTCT',
-        m: undefined,
-        s: undefined,
-      });
-      expect(result[2]).to.deep.equal({
-        primaryKey: 'key_2',
-        l: undefined,
-        m: undefined,
-        s: undefined,
-      });
-    });
-
     it('should throw an error for fasta header template when returning JSON', async () => {
       const urlParams = new URLSearchParams({
         dataFormat: 'JSON',

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -132,10 +132,7 @@ fun buildOpenApiSchema(
                         getSequenceFiltersWithFormat(
                             databaseConfig = databaseConfig,
                             sequenceFilterFields = sequenceFilterFields,
-                            orderByFieldsSchema = aminoAcidSequenceOrderByFieldsEnum(
-                                referenceGenomeSchema,
-                                databaseConfig,
-                            ),
+                            orderByFieldsSchema = aminoAcidSequenceOrderByFieldsEnum(databaseConfig),
                             dataFormatSchema = sequencesFormatSchema(),
                         ),
                         databaseConfig = databaseConfig,
@@ -147,10 +144,7 @@ fun buildOpenApiSchema(
                         requestProperties = getSequenceFiltersWithFormat(
                             databaseConfig = databaseConfig,
                             sequenceFilterFields = sequenceFilterFields,
-                            orderByFieldsSchema = aminoAcidSequenceOrderByFieldsEnum(
-                                referenceGenomeSchema,
-                                databaseConfig,
-                            ),
+                            orderByFieldsSchema = aminoAcidSequenceOrderByFieldsEnum(databaseConfig),
                             dataFormatSchema = sequencesFormatSchema(),
                         ),
                         referenceGenomeSchema = referenceGenomeSchema,
@@ -163,10 +157,7 @@ fun buildOpenApiSchema(
                         getSequenceFiltersWithFormat(
                             databaseConfig = databaseConfig,
                             sequenceFilterFields = sequenceFilterFields,
-                            orderByFieldsSchema = nucleotideSequenceOrderByFieldsEnum(
-                                referenceGenomeSchema,
-                                databaseConfig,
-                            ),
+                            orderByFieldsSchema = nucleotideSequenceOrderByFieldsEnum(databaseConfig),
                             dataFormatSchema = sequencesFormatSchema(),
                         ),
                         databaseConfig = databaseConfig,
@@ -178,10 +169,7 @@ fun buildOpenApiSchema(
                         requestProperties = getSequenceFiltersWithFormat(
                             databaseConfig = databaseConfig,
                             sequenceFilterFields = sequenceFilterFields,
-                            orderByFieldsSchema = nucleotideSequenceOrderByFieldsEnum(
-                                referenceGenomeSchema,
-                                databaseConfig,
-                            ),
+                            orderByFieldsSchema = nucleotideSequenceOrderByFieldsEnum(databaseConfig),
                             dataFormatSchema = sequencesFormatSchema(),
                         ),
                         referenceGenomeSchema = referenceGenomeSchema,
@@ -313,11 +301,11 @@ fun buildOpenApiSchema(
                 )
                 .addSchemas(
                     AMINO_ACID_SEQUENCES_ORDER_BY_FIELDS_SCHEMA,
-                    arraySchema(aminoAcidSequenceOrderByFieldsEnum(referenceGenomeSchema, databaseConfig)),
+                    arraySchema(aminoAcidSequenceOrderByFieldsEnum(databaseConfig)),
                 )
                 .addSchemas(
                     NUCLEOTIDE_SEQUENCES_ORDER_BY_FIELDS_SCHEMA,
-                    arraySchema(nucleotideSequenceOrderByFieldsEnum(referenceGenomeSchema, databaseConfig)),
+                    arraySchema(nucleotideSequenceOrderByFieldsEnum(databaseConfig)),
                 )
                 .addSchemas(
                     SEGMENT_SCHEMA,
@@ -881,20 +869,13 @@ private fun mutationsOrderByFieldsEnum() =
 private fun insertionsOrderByFieldsEnum() =
     orderByFieldsEnum(emptyList(), listOf("insertion", "count", "position", "sequenceName", "insertedSymbols"))
 
-private fun aminoAcidSequenceOrderByFieldsEnum(
-    referenceGenomeSchema: ReferenceGenomeSchema,
-    databaseConfig: DatabaseConfig,
-) = orderByFieldsEnum(emptyList(), referenceGenomeSchema.genes.map { it.name } + databaseConfig.schema.primaryKey)
+private fun aminoAcidSequenceOrderByFieldsEnum(databaseConfig: DatabaseConfig) =
+    orderByFieldsEnum(databaseConfig.schema.metadata)
+        .description(AMINO_ACID_SEQUENCES_ORDER_BY_DESCRIPTION)
 
-private fun nucleotideSequenceOrderByFieldsEnum(
-    referenceGenomeSchema: ReferenceGenomeSchema,
-    databaseConfig: DatabaseConfig,
-) = orderByFieldsEnum(
-    emptyList(),
-    referenceGenomeSchema.nucleotideSequences.map {
-        it.name
-    } + databaseConfig.schema.primaryKey,
-)
+private fun nucleotideSequenceOrderByFieldsEnum(databaseConfig: DatabaseConfig) =
+    orderByFieldsEnum(databaseConfig.schema.metadata)
+        .description(NUCLEOTIDE_SEQUENCES_ORDER_BY_DESCRIPTION)
 
 private fun detailsOrderByFieldsEnum(databaseConfig: DatabaseConfig) = orderByFieldsEnum(databaseConfig.schema.metadata)
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
@@ -30,6 +30,8 @@ import org.genspectrum.lapis.controller.NUCLEOTIDE_INSERTIONS_ENDPOINT_DESCRIPTI
 import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATION_ENDPOINT_DESCRIPTION
 import org.genspectrum.lapis.controller.OFFSET_DESCRIPTION
 import org.genspectrum.lapis.controller.SEQUENCES_DATA_FORMAT_DESCRIPTION
+import org.genspectrum.lapis.request.FASTA_HEADER_TEMPLATE_PROPERTY
+import org.genspectrum.lapis.silo.ORDER_BY_RANDOM_FIELD_NAME
 import org.springframework.core.annotation.AliasFor
 import org.springframework.http.HttpHeaders.ACCEPT_ENCODING
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
@@ -134,6 +136,14 @@ const val SEGMENTS_DESCRIPTION =
 
 const val GENES_DESCRIPTION =
     "List of genes to retrieve sequences for. If not provided, all genes will be returned."
+
+const val AMINO_ACID_SEQUENCES_ORDER_BY_DESCRIPTION = "The parts of the fasta header to order by. " +
+    "By default, only the primary key and '$ORDER_BY_RANDOM_FIELD_NAME' are allowed. " +
+    "The other fields are only allowed if they are part of the '$FASTA_HEADER_TEMPLATE_PROPERTY'."
+
+const val NUCLEOTIDE_SEQUENCES_ORDER_BY_DESCRIPTION = "The parts of the fasta header to order by. " +
+    "By default, only the primary key and '$ORDER_BY_RANDOM_FIELD_NAME' are allowed. " +
+    "The other fields are only allowed if they are part of the '$FASTA_HEADER_TEMPLATE_PROPERTY'."
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -409,7 +419,8 @@ annotation class InsertionsOrderByFields
 @Retention(AnnotationRetention.RUNTIME)
 @Parameter(
     schema = Schema(ref = "#/components/schemas/$AMINO_ACID_SEQUENCES_ORDER_BY_FIELDS_SCHEMA"),
-    description = "The parts of the fasta header to order by.",
+    description =
+    AMINO_ACID_SEQUENCES_ORDER_BY_DESCRIPTION,
 )
 annotation class AminoAcidSequencesOrderByFields
 
@@ -417,7 +428,8 @@ annotation class AminoAcidSequencesOrderByFields
 @Retention(AnnotationRetention.RUNTIME)
 @Parameter(
     schema = Schema(ref = "#/components/schemas/$NUCLEOTIDE_SEQUENCES_ORDER_BY_FIELDS_SCHEMA"),
-    description = "The parts of the fasta header to order by.",
+    description =
+    NUCLEOTIDE_SEQUENCES_ORDER_BY_DESCRIPTION,
 )
 annotation class NucleotideSequencesOrderByFields
 


### PR DESCRIPTION


since we don't want to support it anymore.

This is kind of breaking (in the docs), but the functionality didn't change, so I didn't label it as a breaking change.

resolves #1248



## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
