### PR TITLE
chore(lapis): fix compiler warnings

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/AccessKeys.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/AccessKeys.kt
@@ -8,7 +8,7 @@ import java.io.File
 
 @Component
 class AccessKeysReader(
-    @Value("\${lapis.accessKeys.path:#{null}}") private val accessKeysFile: String?,
+    @param:Value("\${lapis.accessKeys.path:#{null}}") private val accessKeysFile: String?,
     private val yamlObjectMapper: YamlObjectMapper,
 ) {
     fun read(): AccessKeys {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
@@ -24,29 +24,29 @@ private const val REPORT_TO =
 
 @Schema(description = LAPIS_INFO_DESCRIPTION)
 data class LapisInfo(
-    @Schema(
+    @field:Schema(
         description = LAPIS_DATA_VERSION_RESPONSE_DESCRIPTION,
         example = LAPIS_DATA_VERSION_EXAMPLE,
     )
     var dataVersion: String? = null,
-    @Schema(
+    @field:Schema(
         description = REQUEST_ID_HEADER_DESCRIPTION,
         example = "dfb342ea-3607-4caf-b35e-9aba75d06f81",
     )
     var requestId: String? = null,
-    @Schema(
+    @field:Schema(
         description = REQUEST_INFO_STRING_DESCRIPTION,
         example = "my_instance on my.server.com at 2024-01-01T12:00:00.0000",
     )
     var requestInfo: String? = null,
-    @Schema(example = REPORT_TO)
+    @field:Schema(example = REPORT_TO)
     val reportTo: String = REPORT_TO,
-    @Schema(
+    @field:Schema(
         description = VERSION_DESCRIPTION,
         example = "1.2.3",
     )
     val lapisVersion: String? = null,
-    @Schema(
+    @field:Schema(
         description = SILO_VERSION_DESCRIPTION,
         example = "2.3.4",
     )

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -18,7 +18,7 @@ const val COUNT_PROPERTY = "count"
 
 data class AggregationData(
     val count: Int,
-    @Schema(hidden = true) val fields: Map<String, JsonNode>,
+    @param:Schema(hidden = true) val fields: Map<String, JsonNode>,
 )
 
 data class DetailsData(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloUris.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloUris.kt
@@ -6,7 +6,7 @@ import java.net.URI
 
 @Component
 class SiloUris(
-    @Value("\${silo.url}") private val siloUrl: String,
+    @param:Value("\${silo.url}") private val siloUrl: String,
 ) {
     val query = URI("$siloUrl/query")
     val info = URI("$siloUrl/info")

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/SwaggerUiTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/SwaggerUiTest.kt
@@ -18,7 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 class SwaggerUiTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @Test
     fun `Swagger UI endpoint is reachable`() {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/auth/ProtectedDataAuthorizationTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/auth/ProtectedDataAuthorizationTest.kt
@@ -49,7 +49,7 @@ private const val FORBIDDEN_TO_ACCESS_ENDPOINT_ERROR = """
 @SpringBootTest(properties = ["lapis.databaseConfig.path=src/test/resources/config/protectedDataDatabaseConfig.yaml"])
 @AutoConfigureMockMvc
 class ProtectedDataAuthorizationTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
@@ -23,7 +23,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest
 @AutoConfigureMockMvc
 class ExceptionHandlerTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var lapisController: LapisController

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/InfoControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/InfoControllerTest.kt
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest
 @AutoConfigureMockMvc
 class InfoControllerTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LandingPageControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LandingPageControllerTest.kt
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest
 @AutoConfigureMockMvc
 class LandingPageControllerTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @Test
     fun `WHEN calling landing page THEN returns hello json`() {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
@@ -38,7 +38,7 @@ import java.util.stream.Stream
 @SpringBootTest
 @AutoConfigureMockMvc
 class LapisControllerCommonFieldsTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCompressionTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCompressionTest.kt
@@ -52,7 +52,7 @@ const val COMPRESSION_FORMAT_ZSTD = "zstd"
 @SpringBootTest
 @AutoConfigureMockMvc
 class LapisControllerCompressionTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDataFormatTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDataFormatTest.kt
@@ -37,8 +37,8 @@ private const val DATA_VERSION = "1234"
 @SpringBootTest
 @AutoConfigureMockMvc
 class LapisControllerDataFormatTest(
-    @Autowired private val mockMvc: MockMvc,
-    @Autowired private val objectMapper: ObjectMapper,
+    @param:Autowired private val mockMvc: MockMvc,
+    @param:Autowired private val objectMapper: ObjectMapper,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDownloadAsFileTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDownloadAsFileTest.kt
@@ -43,7 +43,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest
 @AutoConfigureMockMvc
 class LapisControllerDownloadAsFileTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerPhyloTreeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerPhyloTreeTest.kt
@@ -24,7 +24,7 @@ private const val DATA_VERSION = "1234"
 @SpringBootTest
 @AutoConfigureMockMvc
 class LapisControllerPhyloTreeTest(
-    @Autowired private val mockMvc: MockMvc,
+    @param:Autowired private val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
@@ -43,7 +43,7 @@ import java.util.stream.Stream
 @SpringBootTest
 @AutoConfigureMockMvc
 class LapisControllerTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     @MockkBean
     lateinit var siloQueryModelMock: SiloQueryModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
@@ -41,7 +41,7 @@ private const val SEGMENT_NAME = "otherSegment"
 )
 @AutoConfigureMockMvc
 class MultiSegmentedSequenceControllerTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     val returnedValue = MockDataForEndpoints
         .sequenceEndpointMockData(SEGMENT_NAME)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MutationsOverTimeControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MutationsOverTimeControllerTest.kt
@@ -37,8 +37,8 @@ import java.time.LocalDate
 @SpringBootTest
 @AutoConfigureMockMvc
 class NucleotideMutationsOverTimeControllerTest(
-    @Autowired val mockMvc: MockMvc,
-    @Autowired val objectMapper: ObjectMapper,
+    @param:Autowired val mockMvc: MockMvc,
+    @param:Autowired val objectMapper: ObjectMapper,
 ) {
     @MockkBean
     lateinit var modelMock: MutationsOverTimeModel
@@ -209,8 +209,8 @@ class NucleotideMutationsOverTimeControllerTest(
 @SpringBootTest
 @AutoConfigureMockMvc
 class AminoAcidMutationsOverTimeControllerTest(
-    @Autowired val mockMvc: MockMvc,
-    @Autowired val objectMapper: ObjectMapper,
+    @param:Autowired val mockMvc: MockMvc,
+    @param:Autowired val objectMapper: ObjectMapper,
 ) {
     @MockkBean
     lateinit var modelMock: MutationsOverTimeModel

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceControllerTest.kt
@@ -34,7 +34,7 @@ private const val SEGMENT_NAME = "otherSegment"
 )
 @AutoConfigureMockMvc
 class SingleSegmentedSequenceControllerTest(
-    @Autowired val mockMvc: MockMvc,
+    @param:Autowired val mockMvc: MockMvc,
 ) {
     val returnedValue = MockDataForEndpoints
         .sequenceEndpointMockData("otherSegment")

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/response/MutationResponseTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/response/MutationResponseTest.kt
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class MutationResponseTest(
-    @Autowired private val objectMapper: ObjectMapper,
+    @param:Autowired private val objectMapper: ObjectMapper,
 ) {
     @Test
     fun `GIVEN null sequence name THEN is not in serialized json`() {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -45,9 +45,9 @@ private const val DATA_VERSION_HEADER = "data-version"
 
 @SpringBootTest(properties = ["silo.url=http://localhost:$MOCK_SERVER_PORT"])
 class SiloClientTest(
-    @Autowired private val underTest: SiloClient,
-    @Autowired private val requestIdContext: RequestIdContext,
-    @Autowired private val dataVersion: DataVersion,
+    @param:Autowired private val underTest: SiloClient,
+    @param:Autowired private val requestIdContext: RequestIdContext,
+    @param:Autowired private val dataVersion: DataVersion,
 ) {
     private lateinit var mockServer: ClientAndServer
 
@@ -566,11 +566,11 @@ class SiloClientTest(
 
 @SpringBootTest(properties = ["silo.url=http://localhost:$MOCK_SERVER_PORT"])
 class SiloClientAndCacheInvalidatorTest(
-    @Autowired private val siloClient: SiloClient,
-    @Autowired private val dataVersionCacheInvalidator: DataVersionCacheInvalidator,
-    @Autowired private val requestIdContext: RequestIdContext,
-    @Autowired private val dataVersion: DataVersion,
-    @Autowired private val siloVersion: SiloVersion,
+    @param:Autowired private val siloClient: SiloClient,
+    @param:Autowired private val dataVersionCacheInvalidator: DataVersionCacheInvalidator,
+    @param:Autowired private val requestIdContext: RequestIdContext,
+    @param:Autowired private val dataVersion: DataVersion,
+    @param:Autowired private val siloVersion: SiloVersion,
 ) {
     private lateinit var mockServer: ClientAndServer
 


### PR DESCRIPTION
It said:
"This annotation is currently applied to the value parameter only, but in the future it will also be applied to field.
 - To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.
 - To keep applying to the value parameter only, use the '@param:' annotation target."
 
https://youtrack.jetbrains.com/issue/KT-73255


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
