### PR TITLE
feat(lapis): support TSV with escaped special characters

### DIFF
--- a/lapis-docs/src/content/docs/concepts/response-format.mdx
+++ b/lapis-docs/src/content/docs/concepts/response-format.mdx
@@ -10,6 +10,13 @@ A '200' response code indicates a successful request, while any other code signi
 
 Endpoints typically support returning data in JSON, [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) or
 [TSV](https://en.wikipedia.org/wiki/Tab-separated_values), with JSON being the default.
+
+:::note
+LAPIS returns RFC 4180 compliant TSV and CSV files, which means that cells that contain a new line (or delimiter) are quoted.
+This can cause issues when simply splitting at every occurence of a new line character.
+We also offer the TSV-ESCAPED data format, where new lines and delimiters are escaped instead of quoted (IANA TSV).
+:::
+
 Genomic sequences (such as those from `unalignedNucleotideSequences`, `alignedAminoAcidSequences`, etc.) are provided in the
 [FASTA format](https://en.wikipedia.org/wiki/FASTA_format) by default,
 but can also be requested in JSON or [NDJSON](https://github.com/ndjson/ndjson-spec) format.

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/Headers.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/Headers.kt
@@ -1,5 +1,6 @@
 package org.genspectrum.lapis.controller
 
+import org.genspectrum.lapis.controller.middleware.ESCAPED_ACCEPT_HEADER_PARAMETER
 import org.genspectrum.lapis.controller.middleware.HEADERS_ACCEPT_HEADER_PARAMETER
 import org.springframework.http.MediaType
 
@@ -15,6 +16,7 @@ object LapisMediaType {
     const val TEXT_CSV_WITHOUT_HEADERS_VALUE = "text/csv;$HEADERS_ACCEPT_HEADER_PARAMETER=false"
     val TEXT_CSV: MediaType = MediaType.parseMediaType(TEXT_CSV_VALUE)
     const val TEXT_TSV_VALUE = "text/tab-separated-values"
+    const val TEXT_TSV_ESCAPED_VALUE = "text/tab-separated-values;$ESCAPED_ACCEPT_HEADER_PARAMETER=true"
     val TEXT_TSV: MediaType = MediaType.parseMediaType(TEXT_TSV_VALUE)
     const val APPLICATION_YAML_VALUE = "application/yaml"
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/DataFormatParameterFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/DataFormatParameterFilter.kt
@@ -16,12 +16,14 @@ import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 const val HEADERS_ACCEPT_HEADER_PARAMETER = "headers"
+const val ESCAPED_ACCEPT_HEADER_PARAMETER = "escaped"
 
 object DataFormat {
     const val JSON = "JSON"
     const val CSV = "CSV"
     const val CSV_WITHOUT_HEADERS = "CSV-WITHOUT-HEADERS"
     const val TSV = "TSV"
+    const val TSV_ESCAPED = "TSV-ESCAPED"
 }
 
 enum class SequencesDataFormat(
@@ -82,6 +84,7 @@ class DataFormatParameterFilter(
             DataFormat.CSV -> LapisMediaType.TEXT_CSV_VALUE
             DataFormat.CSV_WITHOUT_HEADERS -> LapisMediaType.TEXT_CSV_WITHOUT_HEADERS_VALUE
             DataFormat.TSV -> LapisMediaType.TEXT_TSV_VALUE
+            DataFormat.TSV_ESCAPED -> LapisMediaType.TEXT_TSV_ESCAPED_VALUE
             DataFormat.JSON -> MediaType.APPLICATION_JSON_VALUE
             SequencesDataFormat.FASTA.value -> LapisMediaType.TEXT_X_FASTA_VALUE
             SequencesDataFormat.NDJSON.value -> MediaType.APPLICATION_NDJSON_VALUE

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -906,7 +906,15 @@ private fun dataFormatSchema() =
         .description(
             DATA_FORMAT_DESCRIPTION,
         )
-        ._enum(listOf(DataFormat.JSON, DataFormat.CSV, DataFormat.CSV_WITHOUT_HEADERS, DataFormat.TSV))
+        ._enum(
+            listOf(
+                DataFormat.JSON,
+                DataFormat.CSV,
+                DataFormat.CSV_WITHOUT_HEADERS,
+                DataFormat.TSV,
+                DataFormat.TSV_ESCAPED,
+            ),
+        )
         ._default(DataFormat.JSON)
 
 private fun sequencesFormatSchema() =

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/CsvWriter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/CsvWriter.kt
@@ -3,6 +3,7 @@ package org.genspectrum.lapis.response
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
 import org.springframework.stereotype.Component
+import java.io.Flushable
 import java.util.stream.Stream
 
 interface RecordCollection<T> {
@@ -42,6 +43,63 @@ class CsvWriter {
             }
         }
     }
+}
+
+/**
+ * The IANA TSV Writer implements TSV output according to this spec:
+ * https://www.iana.org/assignments/media-types/text/tab-separated-values
+ *
+ * It escapes Tabs and newlines in cell values (instead of quoting the cell content).
+ * Rudimentary TSV parsing with simple splitting will not handle quoted cell values,
+ * and thus can cause issues, this is why this implementation was added.
+ *
+ * The class is called TSV writer, but it's still possible to set other delimiters.
+ *
+ * Newlines will be escaped as \n, tabs as \t, and other delimiters as \<delimiter>.
+ */
+@Component
+class IanaTsvWriter {
+    fun write(
+        appendable: Appendable,
+        includeHeaders: Boolean,
+        data: RecordCollection<*>,
+        delimiter: Delimiter,
+    ) {
+        if (includeHeaders) {
+            writeRow(appendable, data.getHeader(), delimiter)
+        }
+        data.getCsvRecords().forEach { record ->
+            writeRow(appendable, record.map { it.orEmpty() }, delimiter)
+        }
+    }
+
+    private fun writeRow(
+        appendable: Appendable,
+        cells: List<String>,
+        delimiter: Delimiter,
+    ) {
+        val row = getRow(cells, delimiter)
+        appendable.appendLine(row)
+        if (appendable is Flushable) {
+            (appendable as Flushable).flush()
+        }
+    }
+
+    private fun getRow(
+        record: List<String>,
+        delimiter: Delimiter,
+    ): String =
+        record.joinToString(separator = delimiter.value.toString()) { cell ->
+            cell
+                .replace("\n", "\\n")
+                .let { v ->
+                    if (delimiter.value == '\t') {
+                        v.replace("\t", "\\t")
+                    } else {
+                        v.replace(delimiter.value.toString(), "\\${delimiter.value}")
+                    }
+                }
+        }
 }
 
 enum class Delimiter(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/response/CsvWriterTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/response/CsvWriterTest.kt
@@ -21,7 +21,7 @@ class CsvWriterTest {
     }
 
     @Test
-    fun `GIVEN data with nulls and special chars THEN output quotes fields`() {
+    fun `GIVEN data with nulls and special chars WHEN using the CsvWriter THEN output quotes fields`() {
         val data = TestRecordCollection(
             headers = listOf("col1", "col2"),
             records = listOf(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/response/CsvWriterTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/response/CsvWriterTest.kt
@@ -1,0 +1,74 @@
+package org.genspectrum.lapis.response
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import java.io.StringWriter
+import java.util.stream.Stream
+
+class CsvWriterTest {
+    private val csvWriter = CsvWriter()
+    private val ianaTsvWriter = IanaTsvWriter()
+
+    // Dummy RecordCollection for testing
+    private class TestRecordCollection(
+        private val headers: List<String>,
+        override val records: Stream<List<String?>>,
+    ) : RecordCollection<List<String?>> {
+        override fun getHeader(): List<String> = headers
+
+        override fun mapToCsvValuesList(value: List<String?>): List<String?> = value
+    }
+
+    @Test
+    fun `GIVEN data with nulls and special chars THEN output quotes fields`() {
+        val data = TestRecordCollection(
+            headers = listOf("col1", "col2"),
+            records = listOf(
+                listOf("val1", null),
+                listOf("hello\nworld", "tab\tchar"),
+            ).stream(),
+        )
+        val out = StringWriter()
+
+        csvWriter.write(
+            appendable = out,
+            includeHeaders = true,
+            data = data,
+            delimiter = Delimiter.TAB,
+        )
+
+        val expected = buildString {
+            appendLine("col1\tcol2")
+            appendLine("val1\t")
+            appendLine("\"hello\nworld\"\t\"tab\tchar\"")
+        }
+        assertThat(out.toString(), `is`(expected))
+    }
+
+    @Test
+    fun `GIVEN data with nulls and special chars WHEN using the IanaTsvWriter THEN special chars are escaped`() {
+        val data = TestRecordCollection(
+            headers = listOf("col1", "col2"),
+            records = listOf(
+                listOf("val1", null),
+                listOf("hello\nworld", "tab\tchar"),
+            ).stream(),
+        )
+        val out = StringWriter()
+
+        ianaTsvWriter.write(
+            appendable = out,
+            includeHeaders = true,
+            data = data,
+            delimiter = Delimiter.TAB,
+        )
+
+        val expected = buildString {
+            appendLine("col1\tcol2")
+            appendLine("val1\t")
+            appendLine("hello\\nworld\ttab\\tchar")
+        }
+        assertThat(out.toString(), `is`(expected))
+    }
+}


### PR DESCRIPTION
resolves #1283 

Adds a new `IanaTsvWriter`, which escapes new lines and delimiters in cell values, and doesn't do any quoting. Configuring the `CsvPrinter` used in the `CsvWriter` - instead of creating a new class - didn't work: Setting the `QuoteMode`, to `NONE` quotes newlines and delimiters, but the tab was quoted as `\\\t`, which isn't right. I tried working around this, but in the end decided it was cleaner to write a quick implementation of the IANA spec from scratch, instead of trying to get the Apache lib to work with the format which it wasn't designed to support.

I've called the new type "TSV-ESCAPED". The RFC4180 already calls the quote-mechanism escaping, but I'd argue that's not escaping, that's quoting. Instead the new behaviour is escaping. This is now a new datatype, like CSV without headers, to keep things simple. In theory we could have 3 separate settings: TSV/CSV; headers/no headers; quoting/escaping.

## Testing
- I've added a test for the writer itself, to check that it escapes things
- I've added a test to check that the endpoint returns things correctly
- I didn't check it against any data manually, because I don't think the covid data has any cells with newlines, and I'm not sure how to set things up locally with test data.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test.
