### PR TITLE
fix(lapis): mutations over time need only aggregatedDataAccessKey

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
@@ -10,10 +10,12 @@ import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.OpennessLevel
 import org.genspectrum.lapis.controller.AGGREGATED_ROUTE
 import org.genspectrum.lapis.controller.AMINO_ACID_INSERTIONS_ROUTE
+import org.genspectrum.lapis.controller.AMINO_ACID_MUTATIONS_OVER_TIME_ROUTE
 import org.genspectrum.lapis.controller.AMINO_ACID_MUTATIONS_ROUTE
 import org.genspectrum.lapis.controller.DATABASE_CONFIG_ROUTE
 import org.genspectrum.lapis.controller.INFO_ROUTE
 import org.genspectrum.lapis.controller.NUCLEOTIDE_INSERTIONS_ROUTE
+import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATIONS_OVER_TIME_ROUTE
 import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATIONS_ROUTE
 import org.genspectrum.lapis.controller.REFERENCE_GENOME_ROUTE
 import org.genspectrum.lapis.controller.middleware.DATA_OPENNESS_AUTHORIZATION_FILTER_ORDER
@@ -137,7 +139,10 @@ private class ProtectedDataAuthorizationFilter(
             NUCLEOTIDE_INSERTIONS_ROUTE,
             AMINO_ACID_INSERTIONS_ROUTE,
             INFO_ROUTE,
-        ).map { "/sample$it" }
+        ).map { "/sample$it" } + listOf(
+            NUCLEOTIDE_MUTATIONS_OVER_TIME_ROUTE,
+            AMINO_ACID_MUTATIONS_OVER_TIME_ROUTE,
+        ).map { "/component$it" }
     }
 
     override fun isAuthorizedForEndpoint(request: CachedBodyHttpServletRequest): AuthorizationResult {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/MutationsOverTimeController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/MutationsOverTimeController.kt
@@ -19,6 +19,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+const val NUCLEOTIDE_MUTATIONS_OVER_TIME_ROUTE = "/nucleotideMutationsOverTime"
+const val AMINO_ACID_MUTATIONS_OVER_TIME_ROUTE = "/aminoAcidMutationsOverTime"
+
 @RestController
 @RequestMapping("/component")
 class MutationsOverTimeController(
@@ -27,7 +30,7 @@ class MutationsOverTimeController(
     val dataVersion: DataVersion,
 ) {
     @PostMapping(
-        "/nucleotideMutationsOverTime",
+        NUCLEOTIDE_MUTATIONS_OVER_TIME_ROUTE,
         produces = [MediaType.APPLICATION_JSON_VALUE],
         consumes = [MediaType.APPLICATION_JSON_VALUE],
     )
@@ -47,7 +50,7 @@ class MutationsOverTimeController(
     }
 
     @PostMapping(
-        "/aminoAcidMutationsOverTime",
+        AMINO_ACID_MUTATIONS_OVER_TIME_ROUTE,
         produces = [MediaType.APPLICATION_JSON_VALUE],
         consumes = [MediaType.APPLICATION_JSON_VALUE],
     )


### PR DESCRIPTION
The mutations over time endpoints should only require `aggregatedDataAccessKeys` for non-open instances.

## PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by an appropriate test.~
