### PR TITLE
feat(lapis): mutationsOverTime endpoint: return total sequence count per dateRange

### DIFF
--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MutationsOverTimeControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MutationsOverTimeControllerTest.kt
@@ -62,6 +62,7 @@ class NucleotideMutationsOverTimeControllerTest(
                 listOf(MutationsOverTimeCell(count = 10, coverage = 100)),
                 listOf(MutationsOverTimeCell(count = 5, coverage = 50)),
             ),
+            totalCountsByDateRange = listOf(300),
         )
 
         val mutationsSlot = slot<List<NucleotideMutation>>()
@@ -99,6 +100,7 @@ class NucleotideMutationsOverTimeControllerTest(
             .andExpect(jsonPath("$.data.mutations[1]").value("A456G"))
             .andExpect(jsonPath("$.data.dateRanges[0].dateFrom").value("2025-01-01"))
             .andExpect(jsonPath("$.data.dateRanges[0].dateTo").value("2025-01-31"))
+            .andExpect(jsonPath("$.data.totalCountsByDateRange[0]").value("300"))
             .andExpect(jsonPath("$.data.data[0][0].count").value(10))
             .andExpect(jsonPath("$.data.data[0][0].coverage").value(100))
             .andExpect(jsonPath("$.data.data[1][0].count").value(5))
@@ -126,6 +128,7 @@ class NucleotideMutationsOverTimeControllerTest(
             mutations = listOf("123T"),
             dateRanges = listOf(DateRange(LocalDate.parse("2025-01-01"), LocalDate.parse("2025-01-31"))),
             data = listOf(listOf(MutationsOverTimeCell(count = 1, coverage = 2))),
+            totalCountsByDateRange = listOf(300),
         )
 
         val mvcResult = mockMvc.perform(
@@ -234,6 +237,7 @@ class AminoAcidMutationsOverTimeControllerTest(
                 listOf(MutationsOverTimeCell(count = 10, coverage = 100)),
                 listOf(MutationsOverTimeCell(count = 5, coverage = 50)),
             ),
+            totalCountsByDateRange = listOf(300),
         )
 
         val mutationsSlot = slot<List<AminoAcidMutation>>()
@@ -271,6 +275,7 @@ class AminoAcidMutationsOverTimeControllerTest(
             .andExpect(jsonPath("$.data.mutations[1]").value("gene1:A456G"))
             .andExpect(jsonPath("$.data.dateRanges[0].dateFrom").value("2025-01-01"))
             .andExpect(jsonPath("$.data.dateRanges[0].dateTo").value("2025-01-31"))
+            .andExpect(jsonPath("$.data.totalCountsByDateRange[0]").value("300"))
             .andExpect(jsonPath("$.data.data[0][0].count").value(10))
             .andExpect(jsonPath("$.data.data[0][0].coverage").value(100))
             .andExpect(jsonPath("$.data.data[1][0].count").value(5))
@@ -298,6 +303,7 @@ class AminoAcidMutationsOverTimeControllerTest(
             mutations = listOf("123T"),
             dateRanges = listOf(DateRange(LocalDate.parse("2025-01-01"), LocalDate.parse("2025-01-31"))),
             data = listOf(listOf(MutationsOverTimeCell(count = 1, coverage = 2))),
+            totalCountsByDateRange = listOf(3),
         )
 
         val mvcResult = mockMvc.perform(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
@@ -67,6 +67,7 @@ class AminoAcidMutationsOverTimeModelTest {
         assertThat(result.mutations, equalTo(emptyList()))
         assertThat(result.data, equalTo(emptyList()))
         assertThat(result.dateRanges, equalTo(dateRanges))
+        assertThat(result.totalCountsByDateRange, equalTo(emptyList()))
     }
 
     @Test
@@ -83,6 +84,7 @@ class AminoAcidMutationsOverTimeModelTest {
         assertThat(result.mutations, equalTo(mutations.map { it.toString(referenceGenome) }))
         assertThat(result.data, equalTo(emptyList()))
         assertThat(result.dateRanges, equalTo(emptyList()))
+        assertThat(result.totalCountsByDateRange, equalTo(emptyList()))
     }
 
     private fun commonSetup() {
@@ -126,6 +128,15 @@ class AminoAcidMutationsOverTimeModelTest {
                 AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
             ),
         )
+        mockSiloTotalCountQuery(
+            siloQueryClient,
+            DUMMY_DATE_BETWEEN_ALL,
+            Stream.of(
+                AggregationData(10, fields = mapOf("date" to TextNode("2021-06-01"))),
+                AggregationData(11, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(12, fields = mapOf("date" to TextNode("2022-07-01"))),
+            ),
+        )
     }
 
     @Test
@@ -153,6 +164,10 @@ class AminoAcidMutationsOverTimeModelTest {
                 ),
             ),
         )
+        assertThat(
+            result.totalCountsByDateRange,
+            equalTo(listOf(10, 23)),
+        )
     }
 
     @Test
@@ -177,6 +192,7 @@ class AminoAcidMutationsOverTimeModelTest {
     fun `given a list of mutations and date ranges and no data for a mutation, then it returns zero`() {
         mockSiloCountQuery(siloQueryClient, DUMMY_MUTATION_EQUALS1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
         mockSiloAminoAcidCoverageQuery(siloQueryClient, "S", 1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
+        mockSiloTotalCountQuery(siloQueryClient, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
 
         val mutations = listOf(DUMMY_MUTATION1)
         val dateRanges = listOf(DUMMY_DATE_RANGE1, DUMMY_DATE_RANGE2)
@@ -198,6 +214,7 @@ class AminoAcidMutationsOverTimeModelTest {
                 ),
             ),
         )
+        assertThat(result.totalCountsByDateRange, equalTo(listOf(0, 0)))
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/Helpers.kt
@@ -19,6 +19,7 @@ import org.genspectrum.lapis.silo.Or
 import org.genspectrum.lapis.silo.SiloAction
 import org.genspectrum.lapis.silo.SiloClient
 import org.genspectrum.lapis.silo.SiloFilterExpression
+import org.genspectrum.lapis.silo.True
 import org.genspectrum.lapis.silo.WithDataVersion
 import java.time.LocalDate
 import java.util.stream.Stream
@@ -58,6 +59,7 @@ fun mockSiloCountQuery(
             match { query ->
                 query.action == AGGREGATED_SILO_ACTION &&
                     query.filterExpression is And &&
+                    query.filterExpression.children.count() == 3 &&
                     query.filterExpression.children.contains(mutationFilter) &&
                     query.filterExpression.children.contains(dateBetweenFilter)
             },
@@ -115,11 +117,33 @@ private fun mockSiloCoverageQuery(
             match { query ->
                 query.action == AGGREGATED_SILO_ACTION &&
                     query.filterExpression is And &&
+                    query.filterExpression.children.count() == 3 &&
                     query.filterExpression.children.any {
                         it is Or &&
                             (it).children.all(mutationFilterExpressionFn)
                     } &&
                     query.filterExpression.children.contains(dateBetween)
+            },
+            false,
+        )
+    } answers {
+        WithDataVersion(DUMMY_DATA_VERSION, queryResult)
+    }
+}
+
+fun mockSiloTotalCountQuery(
+    siloClient: SiloClient,
+    dateBetweenFilter: DateBetween,
+    queryResult: Stream<AggregationData>,
+) {
+    every {
+        siloClient.sendQueryAndGetDataVersion<AggregationData>(
+            match { query ->
+                query.action == AGGREGATED_SILO_ACTION &&
+                    query.filterExpression is And &&
+                    query.filterExpression.children.count() == 2 &&
+                    query.filterExpression.children.contains(True) &&
+                    query.filterExpression.children.contains(dateBetweenFilter)
             },
             false,
         )

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -65,6 +65,7 @@ class NucleotideMutationsOverTimeModelTest {
         assertThat(result.mutations, equalTo(emptyList()))
         assertThat(result.data, equalTo(emptyList()))
         assertThat(result.dateRanges, equalTo(dateRanges))
+        assertThat(result.totalCountsByDateRange, equalTo(emptyList()))
     }
 
     @Test
@@ -81,6 +82,7 @@ class NucleotideMutationsOverTimeModelTest {
         assertThat(result.mutations, equalTo(mutations.map { it.toString(referenceGenome) }))
         assertThat(result.data, equalTo(emptyList()))
         assertThat(result.dateRanges, equalTo(emptyList()))
+        assertThat(result.totalCountsByDateRange, equalTo(emptyList()))
     }
 
     private fun commonSetup() {
@@ -124,6 +126,15 @@ class NucleotideMutationsOverTimeModelTest {
                 AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
             ),
         )
+        mockSiloTotalCountQuery(
+            siloQueryClient,
+            DUMMY_DATE_BETWEEN_ALL,
+            queryResult = Stream.of(
+                AggregationData(10, fields = mapOf("date" to TextNode("2021-06-01"))),
+                AggregationData(11, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(12, fields = mapOf("date" to TextNode("2022-07-01"))),
+            ),
+        )
     }
 
     @Test
@@ -151,6 +162,10 @@ class NucleotideMutationsOverTimeModelTest {
                 ),
             ),
         )
+        assertThat(
+            result.totalCountsByDateRange,
+            equalTo(listOf(10, 23)),
+        )
     }
 
     @Test
@@ -175,6 +190,7 @@ class NucleotideMutationsOverTimeModelTest {
     fun `given a list of mutations and date ranges and no data for a mutation, then it returns zero`() {
         mockSiloCountQuery(siloQueryClient, DUMMY_MUTATION_EQUALS1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
         mockSiloNucleotideCoverageQuery(siloQueryClient, null, 1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
+        mockSiloTotalCountQuery(siloQueryClient, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
 
         val mutations = listOf(DUMMY_MUTATION1)
         val dateRanges = listOf(DUMMY_DATE_RANGE1, DUMMY_DATE_RANGE2)
@@ -195,6 +211,10 @@ class NucleotideMutationsOverTimeModelTest {
                     listOf(MutationsOverTimeCell(0, 0), MutationsOverTimeCell(0, 0)),
                 ),
             ),
+        )
+        assertThat(
+            result.totalCountsByDateRange,
+            equalTo(listOf(0, 0)),
         )
     }
 


### PR DESCRIPTION
resolves #1308 

This PR modifies the `mutationsOverTime` response to also include the totalCount for the dateRange for every cell. This information is needed for the component, and with this information in the response, less queries are needed in the frontend.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] The implemented feature is covered by an appropriate test. - tests have been adapted
