### PR TITLE
feat(lapis): ensure order preservation for muts and dateRanges in mutationsOverTime

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
@@ -55,7 +55,7 @@ const val ALL_UNALIGNED_MULTI_SEGMENTED_NUCLEOTIDE_SEQUENCE_ENDPOINT_DESCRIPTION
     """"Returns the unaligned nucleotide sequences of all requested segments that match the given filter criteria."""
 const val MUTATIONS_OVER_TIME_ENDPOINT_DESCRIPTION =
     """Returns the number of sequences containing the specified mutations within the requested date ranges, along 
-    with the corresponding coverage."""
+    with the corresponding coverage. The order of the mutations and date ranges is preserved."""
 
 const val AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION =
     """The fields to stratify by.

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
@@ -26,8 +26,10 @@ import java.util.stream.Stream
 
 private val DUMMY_MUTATION1 = AminoAcidMutation("S", 1, "R")
 private val DUMMY_MUTATION2 = AminoAcidMutation("S", 2, "N")
+private val DUMMY_MUTATION3 = AminoAcidMutation("A", 1, "B")
 private val DUMMY_MUTATION_EQUALS1 = AminoAcidSymbolEquals("S", 1, "R")
 private val DUMMY_MUTATION_EQUALS2 = AminoAcidSymbolEquals("S", 2, "N")
+private val DUMMY_MUTATION_EQUALS3 = AminoAcidSymbolEquals("A", 1, "B")
 
 @SpringBootTest
 class AminoAcidMutationsOverTimeModelTest {
@@ -83,8 +85,7 @@ class AminoAcidMutationsOverTimeModelTest {
         assertThat(result.dateRanges, equalTo(emptyList()))
     }
 
-    @Test
-    fun `given a list of mutations and date ranges, then it returns the count and coverage data`() {
+    private fun commonSetup() {
         mockSiloCountQuery(
             siloQueryClient,
             DUMMY_MUTATION_EQUALS1,
@@ -125,6 +126,11 @@ class AminoAcidMutationsOverTimeModelTest {
                 AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
             ),
         )
+    }
+
+    @Test
+    fun `given a list of mutations and date ranges, then it returns the count and coverage data`() {
+        commonSetup()
 
         val mutations = listOf(DUMMY_MUTATION1, DUMMY_MUTATION2)
         val dateRanges = listOf(DUMMY_DATE_RANGE1, DUMMY_DATE_RANGE2)
@@ -147,6 +153,24 @@ class AminoAcidMutationsOverTimeModelTest {
                 ),
             ),
         )
+    }
+
+    @Test
+    fun `given a list of mutations and date ranges in reverse order, then order is preserved as well`() {
+        commonSetup()
+
+        val mutationsReversed = listOf(DUMMY_MUTATION2, DUMMY_MUTATION1)
+        val dateRangesReversed = listOf(DUMMY_DATE_RANGE2, DUMMY_DATE_RANGE1)
+
+        val result = underTest.evaluateAminoAcidMutations(
+            mutations = mutationsReversed,
+            lapisFilter = DUMMY_LAPIS_FILTER,
+            dateField = DUMMY_DATE_FIELD,
+            dateRanges = dateRangesReversed,
+        )
+
+        assertThat(result.mutations, equalTo(mutationsReversed.map { it.toString(referenceGenome) }))
+        assertThat(result.dateRanges, equalTo(dateRangesReversed))
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -83,8 +83,7 @@ class NucleotideMutationsOverTimeModelTest {
         assertThat(result.dateRanges, equalTo(emptyList()))
     }
 
-    @Test
-    fun `given a list of mutations and date ranges, then it returns the count and coverage data`() {
+    private fun commonSetup() {
         mockSiloCountQuery(
             siloQueryClient,
             DUMMY_MUTATION_EQUALS1,
@@ -125,6 +124,11 @@ class NucleotideMutationsOverTimeModelTest {
                 AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
             ),
         )
+    }
+
+    @Test
+    fun `given a list of mutations and date ranges, then it returns the count and coverage data`() {
+        commonSetup()
 
         val mutations = listOf(DUMMY_MUTATION1, DUMMY_MUTATION2)
         val dateRanges = listOf(DUMMY_DATE_RANGE1, DUMMY_DATE_RANGE2)
@@ -147,6 +151,24 @@ class NucleotideMutationsOverTimeModelTest {
                 ),
             ),
         )
+    }
+
+    @Test
+    fun `given a list of mutations and date ranges in reverse order, then the order is preserved`() {
+        commonSetup()
+
+        val mutationsReversed = listOf(DUMMY_MUTATION2, DUMMY_MUTATION1)
+        val dateRangesReversed = listOf(DUMMY_DATE_RANGE2, DUMMY_DATE_RANGE1)
+
+        val result = underTest.evaluateNucleotideMutations(
+            mutations = mutationsReversed,
+            lapisFilter = DUMMY_LAPIS_FILTER,
+            dateField = DUMMY_DATE_FIELD,
+            dateRanges = dateRangesReversed,
+        )
+
+        assertThat(result.mutations, equalTo(mutationsReversed.map { it.toString(referenceGenome) }))
+        assertThat(result.dateRanges, equalTo(dateRangesReversed))
     }
 
     @Test


### PR DESCRIPTION
resolves #1309

The order is already preserved, I just added some docs and a test for it.

## PR Checklist
- [x] All necessary documentation has been adapted. -> I adapted the endpoint description; is there more?
- [x] The implemented feature is covered by an appropriate test.
