### PR TITLE
fix(lapis): truncate error details if they are too long

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -118,11 +118,21 @@ class ExceptionHandler(
                 LapisErrorResponse(
                     error = ProblemDetail.forStatus(httpStatus).also {
                         it.title = title
-                        it.detail = detail
+                        it.detail = truncate(detail, maxLength = 100_000)
                     },
                     info = lapisInfoFactory.create(),
                 ),
             )
+
+    private fun truncate(
+        value: String?,
+        maxLength: Int,
+    ): String? {
+        if (value == null || value.length <= maxLength) {
+            return value
+        }
+        return value.substring(0, maxLength) + "..."
+    }
 }
 
 @Component


### PR DESCRIPTION
The request mentioned in #1324 had a gigantic error message because it contained the whole newick tree that was too large for Jackson to parse. 100k chars should still be enough for any reasonable error message.

This is the current error message (the part that fits on a screenshot):
<img width="2200" height="1026" alt="image" src="https://github.com/user-attachments/assets/b2ebe635-20c0-4697-9c73-7c9db78f98d9" />


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
