### PR TITLE
fix(lapis): fix 500 server error in *mutationsOverTime endpoints

### DIFF
--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.node.TextNode
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenome
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.model.SiloFilterExpressionMapper
@@ -47,10 +48,14 @@ class AminoAcidMutationsOverTimeModelTest {
 
     private lateinit var underTest: MutationsOverTimeModel
 
+    @Autowired
+    private lateinit var config: DatabaseConfig
+
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
-        underTest = MutationsOverTimeModel(siloQueryClient, siloFilterExpressionMapper, referenceGenome, dataVersion)
+        underTest =
+            MutationsOverTimeModel(siloQueryClient, siloFilterExpressionMapper, referenceGenome, dataVersion, config)
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.node.TextNode
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenome
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.model.SiloFilterExpressionMapper
@@ -45,10 +46,14 @@ class NucleotideMutationsOverTimeModelTest {
 
     private lateinit var underTest: MutationsOverTimeModel
 
+    @Autowired
+    private lateinit var config: DatabaseConfig
+
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
-        underTest = MutationsOverTimeModel(siloQueryClient, siloFilterExpressionMapper, referenceGenome, dataVersion)
+        underTest =
+            MutationsOverTimeModel(siloQueryClient, siloFilterExpressionMapper, referenceGenome, dataVersion, config)
     }
 
     @Test


### PR DESCRIPTION
In https://github.com/GenSpectrum/LAPIS/pull/1352 we made the thread count for the SILO client configurable, so we wouldn't get issues with creating too many threads and getting a RejectedExecutionException. But now we get the same issue, further up the call chain.

The `ForkJoinPool` used by the `parallelStream` will get blocked threads because of the `SiloClient`, and then creates compensation threads, eventually running into the thread limit, if there are a lot of mutations to query.

This PR removes the `parallelStream` in favor of a fixed size thread pool. It reuses the thread count from the SILO client, because that's the limiting factor anyways. The thread pool is created as a class property and maintained until the class is destroyed.

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- ~~The implemented feature is covered by an appropriate test.~~
