### PR TITLE
fix(lapis): also don't log the stack trace when SILO says that it's not available yet

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -82,7 +82,7 @@ class ExceptionHandler(
     @ExceptionHandler(SiloUnavailableException::class)
     @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
     fun handleSiloUnavailableException(e: SiloUnavailableException): ErrorResponse {
-        log.warn(e) { "Caught SiloUnavailableException: ${e.message}" }
+        log.warn { "Caught SiloUnavailableException: ${e.message}" } // don't log stack trace for this common case
 
         return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message) { header(RETRY_AFTER, e.retryAfter) }
     }


### PR DESCRIPTION


We know where those are coming from, there is no point in cluttering the logs with stack traces

Similar to #1373 


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
