### PR TITLE
feat(lapis): improve health endpoint

### DIFF
--- a/lapis-e2e/test/common.ts
+++ b/lapis-e2e/test/common.ts
@@ -1,4 +1,5 @@
 import {
+  ActuatorApi,
   Configuration,
   InfoControllerApi,
   LapisControllerApi,
@@ -46,6 +47,7 @@ export const lapisClient = new LapisControllerApi(new Configuration({ basePath }
 export const lapisInfoClient = new InfoControllerApi(new Configuration({ basePath })).withMiddleware(
   middleware
 );
+export const actuatorClient = new ActuatorApi(new Configuration({ basePath })).withMiddleware(middleware);
 export const mutOverTimeClient = new MutationsOverTimeControllerApi(
   new Configuration({ basePath })
 ).withMiddleware(middleware);

--- a/lapis-e2e/test/health.spec.ts
+++ b/lapis-e2e/test/health.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { actuatorClient } from './common';
+
+describe('The /actuator/health endpoint', () => {
+  it('should return health status with silo component', async () => {
+    const health = await actuatorClient.health();
+
+    expect(health).to.have.property('status');
+    expect(health.status).to.equal('UP');
+
+    expect(health).to.have.property('components');
+    expect(health.components).to.have.property('silo');
+
+    const siloComponent = health.components.silo;
+    expect(siloComponent).to.have.property('status');
+    expect(siloComponent.status).to.equal('UP');
+
+    expect(siloComponent).to.have.property('details');
+    expect(siloComponent.details).to.have.property('dataVersion');
+    expect(siloComponent.details.dataVersion).to.match(/\d+/);
+    expect(siloComponent.details).to.have.property('siloVersion');
+    expect(siloComponent.details.siloVersion).to.be.a('string').and.not.be.empty;
+  });
+});

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
@@ -1,0 +1,45 @@
+package org.genspectrum.lapis.health
+
+import org.genspectrum.lapis.silo.CachedSiloClient
+import org.genspectrum.lapis.silo.SiloNotReachableException
+import org.genspectrum.lapis.silo.SiloUnavailableException
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+
+@Component
+class SiloHealthIndicator(
+    private val cachedSiloClient: CachedSiloClient,
+) : HealthIndicator {
+    override fun health(): Health =
+        try {
+            val info = cachedSiloClient.callInfo()
+            Health
+                .up()
+                .withDetail("dataVersion", info.dataVersion)
+                .withDetail("siloVersion", info.siloVersion ?: "unknown")
+                .build()
+        } catch (e: SiloNotReachableException) {
+            Health
+                .down()
+                .withDetail("error", "SILO not reachable")
+                .withDetail("message", e.message)
+                .withException(e)
+                .build()
+        } catch (e: SiloUnavailableException) {
+            Health
+                .down()
+                .withDetail("error", "SILO unavailable (HTTP 503)")
+                .withDetail("message", e.message)
+                .withDetail("retryAfter", e.retryAfter)
+                .withException(e)
+                .build()
+        } catch (e: Exception) {
+            Health
+                .down()
+                .withDetail("error", "Unexpected error checking SILO")
+                .withDetail("message", e.message)
+                .withException(e)
+                .build()
+        }
+}

--- a/lapis/src/main/resources/application.properties
+++ b/lapis/src/main/resources/application.properties
@@ -10,8 +10,16 @@ server.error.whitelabel.enabled=false
 server.error.include-message=always
 
 springdoc.show-actuator=true
+# what to expose and CORS config
 management.endpoints.enabled-by-default=false
+management.endpoints.web.exposure.include=health,caches,metrics
+management.endpoints.web.cors.allowed-origins=*
+management.endpoints.web.cors.allowed-methods=GET,OPTIONS
+# show health endpoint without default details (disk usage etc.) but with SILO
 management.endpoint.health.enabled=true
+management.endpoint.health.show-details=always
+management.endpoint.health.show-components=always
+management.health.defaults.enabled=false
+# cache and metrics
 management.endpoint.caches.enabled=true
 management.endpoint.metrics.enabled=true
-management.endpoints.web.exposure.include=health,caches,metrics


### PR DESCRIPTION
**Current state**

The health endpoint isn't accessible in the browser because of CORS config, and it only shows UP/DOWN.

**This PR**

Updates the CORS config so the endpoint is accessible, following [this](https://stackoverflow.com/a/37077677) advice.

Also adds a new health check for SILO, so we get dedicated silo info as well. example:

```json
{
  "status": "UP",
  "components": {
    "silo": {
      "status": "UP",
      "details": {
        "dataVersion": "1762432588",
        "siloVersion": "928d36991a802dcf83fa7f34f8ac7420d8a6bc84"
      }
    }
  }
}
```

## PR Checklist
- ~~All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
