### PR TITLE
fix(lapis): also regard request parameters for non-GET requests

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/util/CachedBodyHttpServletRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/util/CachedBodyHttpServletRequest.kt
@@ -88,13 +88,15 @@ class CachedBodyHttpServletRequest private constructor(
     }
 
     fun getStringField(fieldName: String): String? {
-        if (method == HttpMethod.GET.name()) {
-            return parameterMap[fieldName]?.firstOrNull()
+        val parameterValue = parameterMap[fieldName]?.firstOrNull()
+        if (parameterValue != null) {
+            return parameterValue
         }
-
-        val fieldValue = parsedBody[fieldName]
-        if (fieldValue?.isTextual == true) {
-            return fieldValue.asText()
+        if (method != HttpMethod.GET.name()) {
+            val fieldValue = parsedBody[fieldName]
+            if (fieldValue?.isTextual == true) {
+                return fieldValue.asText()
+            }
         }
         return null
     }


### PR DESCRIPTION
This allows the usage of URL request parameters for some fields including `accessKey` for non-GET request (including OPTIONS requests which cannot have a body).

## PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] The implemented feature is covered by an appropriate test.~
