### PR TITLE
test(lapis-e2e): skip test that only fails in CI for now

### DIFF
--- a/lapis-e2e/test/common.spec.ts
+++ b/lapis-e2e/test/common.spec.ts
@@ -208,6 +208,8 @@ describe('All endpoints', () => {
         expectIsZstdEncoded(await response.arrayBuffer());
       });
 
+      // TODO - These tests are failing in CI, so we're excluding them for now.
+      // Issue for it: https://github.com/GenSpectrum/LAPIS/issues/1423
       it.skip('should return zstd compressed data when accepting compression in header', async () => {
         const urlParams = new URLSearchParams();
         if (route.pathSegment === '/mostRecentCommonAncestor' || route.pathSegment === '/phyloSubtree') {


### PR DESCRIPTION
We are tracking this in #1423

For now, we need to disable this test, because it's too noisy. we can re-enable it once we have fixed it.