### PR TITLE
chore(lapis-e2e): bump openapi-generator-cli to 7.17.0

### DIFF
--- a/lapis-e2e/openapitools.json
+++ b/lapis-e2e/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.12.0"
+    "version": "7.17.0"
   }
 }


### PR DESCRIPTION
This actually includes a bugfix I need, from version 7.13.0.