### PR TITLE
chore(lapis): remove explicit dependency on `kotlin-stdlib`

### DIFF
--- a/lapis/build.gradle
+++ b/lapis/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     }
     testImplementation 'com.ninja-squad:springmockk:5.0.1'
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib'
 }
 
 


### PR DESCRIPTION
It was added here: https://github.com/GenSpectrum/LAPIS/pull/228/changes#r1171203338
To me it seems like there is no real reason why we added it. LAPIS compiles without it, I don't see a reason why we should ned it.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
- [x] The implemented feature is covered by an appropriate test.
