### PR TITLE
feat(lapis): also allow multiple value in int, float and date filters (and concatenate them with `or`)

### DIFF
--- a/lapis-docs/src/components/FiltersTable/getFilters.tsx
+++ b/lapis-docs/src/components/FiltersTable/getFilters.tsx
@@ -17,7 +17,9 @@ export function getFilters(config: Config) {
                 {
                     name: metadata.name,
                     type: metadata.type,
-                    description: `Filters the "${metadata.name}" column" with exact match`,
+                    description:
+                        `Filters the "${metadata.name}" column with exact match. ` +
+                        `You can also supply an array of values - they will be combined with logical OR.`,
                 },
                 {
                     name: `${metadata.name}From`,
@@ -36,7 +38,9 @@ export function getFilters(config: Config) {
             const stringDescription = {
                 name: metadata.name,
                 type: metadata.type,
-                description: `Filters the "${metadata.name}" column" with exact match`,
+                description:
+                    `Filters the "${metadata.name}" column" with exact match. ` +
+                    `You can also supply an array of values - they will be combined with logical OR.`,
             };
 
             const allowRegexSearchDescription = {

--- a/lapis-docs/src/components/FiltersTable/getFilters.tsx
+++ b/lapis-docs/src/components/FiltersTable/getFilters.tsx
@@ -39,7 +39,7 @@ export function getFilters(config: Config) {
                 name: metadata.name,
                 type: metadata.type,
                 description:
-                    `Filters the "${metadata.name}" column" with exact match. ` +
+                    `Filters the "${metadata.name}" column with exact match. ` +
                     `You can also supply an array of values - they will be combined with logical OR.`,
             };
 

--- a/lapis-e2e/test/aggregatedQueries/dateEqualsMultiple.json
+++ b/lapis-e2e/test/aggregatedQueries/dateEqualsMultiple.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "date equals with multiple values",
+  "lapisRequest": {
+    "date": ["2021-05-08", "2021-01-20"]
+  },
+  "expected": [
+    {
+      "count": 6
+    }
+  ]
+}

--- a/lapis-e2e/test/aggregatedQueries/floatEqualsMultiple.json
+++ b/lapis-e2e/test/aggregatedQueries/floatEqualsMultiple.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "float equals with multiple values",
+  "lapisRequest": {
+    "qcValue": [0.97, 0.98]
+  },
+  "expected": [
+    {
+      "count": 20
+    }
+  ]
+}

--- a/lapis-e2e/test/aggregatedQueries/intEqualsMultiple.json
+++ b/lapis-e2e/test/aggregatedQueries/intEqualsMultiple.json
@@ -1,0 +1,11 @@
+{
+  "testCaseName": "int equals with multiple values",
+  "lapisRequest": {
+    "age": [51, 52]
+  },
+  "expected": [
+    {
+      "count": 15
+    }
+  ]
+}

--- a/lapis-e2e/test/aminoAcidSequence.spec.ts
+++ b/lapis-e2e/test/aminoAcidSequence.spec.ts
@@ -190,7 +190,7 @@ describe('The /alignedAminoAcidSequence endpoint', () => {
 
       const errorResponse = await response.json();
       expect(errorResponse.error.detail).to.match(
-        /Error from SILO: The table does not contain the SequenceColumn 'unknownGene'/
+        /Error from SILO: The table does not contain the field unknownGene/
       );
     });
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -298,10 +298,14 @@ class SiloFilterExpressionMapper(
         }
 
         if (exactDateFilters.isNotEmpty()) {
-            return when (val date = getAsDate(exactDateFilters[0])) {
-                null -> IsNull(column = siloColumnName)
-                else -> DateBetween(column = siloColumnName, from = date, to = date)
-            }
+            return Or(
+                exactDateFilters[0].values.map {
+                    when (val date = parseDate(it, exactDateFilters[0].originalKey)) {
+                        null -> IsNull(column = siloColumnName)
+                        else -> DateBetween(column = siloColumnName, from = date, to = date)
+                    }
+                },
+            )
         }
 
         return DateBetween(
@@ -321,7 +325,14 @@ class SiloFilterExpressionMapper(
     private fun getAsDate(sequenceFilterValue: SequenceFilterValue?): LocalDate? {
         val (_, values, originalKey) = sequenceFilterValue ?: return null
         val value = extractSingleFilterValue(values, originalKey) ?: return null
+        return parseDate(value, originalKey)
+    }
 
+    private fun parseDate(
+        value: String?,
+        originalKey: String,
+    ): LocalDate? {
+        value ?: return null
         try {
             return LocalDate.parse(value)
         } catch (exception: DateTimeParseException) {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -350,36 +350,44 @@ class SiloFilterExpressionMapper(
     private fun mapToIntEqualsFilter(
         siloColumnName: SequenceFilterFieldName,
         values: List<SequenceFilterValue>,
-    ): SiloFilterExpression {
-        val value = extractSingleFilterValue(values[0])
-            ?: return IsNull(column = siloColumnName)
+    ): SiloFilterExpression =
+        Or(
+            values[0].values.map {
+                when (it) {
+                    null -> IsNull(column = siloColumnName)
 
-        try {
-            return IntEquals(siloColumnName, value.toInt())
-        } catch (exception: NumberFormatException) {
-            throw BadRequestException(
-                "$siloColumnName '$value' is not a valid integer: ${exception.message}",
-                exception,
-            )
-        }
-    }
+                    else -> try {
+                        IntEquals(siloColumnName, it.toInt())
+                    } catch (exception: NumberFormatException) {
+                        throw BadRequestException(
+                            "$siloColumnName '$it' is not a valid integer: ${exception.message}",
+                            exception,
+                        )
+                    }
+                }
+            },
+        )
 
     private fun mapToFloatEqualsFilter(
         siloColumnName: SequenceFilterFieldName,
         values: List<SequenceFilterValue>,
-    ): SiloFilterExpression {
-        val value = extractSingleFilterValue(values[0])
-            ?: return IsNull(column = siloColumnName)
+    ): SiloFilterExpression =
+        Or(
+            values[0].values.map {
+                when (it) {
+                    null -> IsNull(column = siloColumnName)
 
-        try {
-            return FloatEquals(siloColumnName, value.toDouble())
-        } catch (exception: NumberFormatException) {
-            throw BadRequestException(
-                "$siloColumnName '$value' is not a valid float: ${exception.message}",
-                exception,
-            )
-        }
-    }
+                    else -> try {
+                        FloatEquals(siloColumnName, it.toDouble())
+                    } catch (exception: NumberFormatException) {
+                        throw BadRequestException(
+                            "$siloColumnName '$it' is not a valid float: ${exception.message}",
+                            exception,
+                        )
+                    }
+                }
+            },
+        )
 
     private fun mapToIntBetweenFilter(
         siloColumnName: SequenceFilterFieldName,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -508,16 +508,21 @@ private fun primitiveSequenceFilterFieldSchemas(sequenceFilterFields: SequenceFi
 
 private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
     when (fieldType) {
-        SequenceFilterFieldType.String ->
+        SequenceFilterFieldType.String -> {
+            val fieldSchema = stringSchema(fieldType.openApiType)
+                .description("A string or null")
             Schema<String>().anyOf(
                 listOf(
-                    stringSchema(fieldType.openApiType),
-                    logicalOrArraySchema(stringSchema(fieldType.openApiType)),
+                    fieldSchema,
+                    logicalOrArraySchema(fieldSchema),
                 ),
             )
+        }
 
         SequenceFilterFieldType.Int -> {
-            val fieldSchema = Schema<Int>().types(setOf(fieldType.openApiType))
+            val fieldSchema = Schema<Int>()
+                .types(setOf(fieldType.openApiType))
+                .description("An integer or null")
             Schema<Any>().anyOf(
                 listOf(
                     fieldSchema,
@@ -527,7 +532,9 @@ private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
         }
 
         SequenceFilterFieldType.Float -> {
-            val fieldSchema = Schema<Float>().types(setOf(fieldType.openApiType))
+            val fieldSchema = Schema<Float>()
+                .types(setOf(fieldType.openApiType))
+                .description("A float or null")
             Schema<Any>().anyOf(
                 listOf(
                     fieldSchema,
@@ -538,6 +545,7 @@ private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
 
         SequenceFilterFieldType.Date -> {
             val fieldSchema = stringSchema(fieldType.openApiType)
+                .description("A date string (YYYY-MM-DD) or null")
             Schema<String>().anyOf(
                 listOf(
                     fieldSchema,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -536,6 +536,16 @@ private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
             )
         }
 
+        SequenceFilterFieldType.Date -> {
+            val fieldSchema = stringSchema(fieldType.openApiType)
+            Schema<String>().anyOf(
+                listOf(
+                    fieldSchema,
+                    logicalOrArraySchema(fieldSchema),
+                ),
+            )
+        }
+
         SequenceFilterFieldType.Lineage -> {
             val fieldSchema = stringSchema(fieldType.openApiType)
                 .description(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -516,6 +516,26 @@ private fun filterFieldSchema(fieldType: SequenceFilterFieldType) =
                 ),
             )
 
+        SequenceFilterFieldType.Int -> {
+            val fieldSchema = Schema<Int>().types(setOf(fieldType.openApiType))
+            Schema<Any>().anyOf(
+                listOf(
+                    fieldSchema,
+                    logicalOrArraySchema(fieldSchema),
+                ),
+            )
+        }
+
+        SequenceFilterFieldType.Float -> {
+            val fieldSchema = Schema<Float>().types(setOf(fieldType.openApiType))
+            Schema<Any>().anyOf(
+                listOf(
+                    fieldSchema,
+                    logicalOrArraySchema(fieldSchema),
+                ),
+            )
+        }
+
         SequenceFilterFieldType.Lineage -> {
             val fieldSchema = stringSchema(fieldType.openApiType)
                 .description(

--- a/lapis/src/main/resources/templates/llms.txt
+++ b/lapis/src/main/resources/templates/llms.txt
@@ -28,11 +28,11 @@ You can use metadata fields as filter parameters in your queries. The filter syn
   You can also supply an array - the fields will be combined with logical OR.
   Examples: `"[(${stringField})]": "someValue"`, `"[(${stringField})].regex": "^startsWithThis*"`, `"[(${stringField})]": ["someValue", "orOtherValue"]`[/]
 [# th:if="${lineageField != null}"]- **Lineage fields**: For string fields that also have a lineage index, you can filter for exact matches (`"[(${lineageField})]": "lineage"`) or including sublineages (`"[(${lineageField})]": "lineage*"`).[/]
-[# th:if="${dateField != null}"]- **Date fields**: Use exact match, or `From`/`To` suffixes for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
+[# th:if="${dateField != null}"]- **Date fields**: Use exact match, or `From`/`To` suffixes for ranges. You can also supply an array for exact match - the values will be combined with logical OR, and may include `null`.
   Examples: `"[(${dateField})]": "2023-01-15"`, `"[(${dateField})]From": "2023-01-01", "[(${dateField})]To": "2023-12-31"`, `"[(${dateField})]": ["2023-01-15", "2023-02-20"]`[/]
-[# th:if="${intField != null}"]- **Integer fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
+[# th:if="${intField != null}"]- **Integer fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR, and may include `null`.
   Examples: `"[(${intField})]": 42`, `"[(${intField})]From": 10, "[(${intField})]To": 50`, `"[(${intField})]": [42, 43]`[/]
-[# th:if="${floatField != null}"]- **Float fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
+[# th:if="${floatField != null}"]- **Float fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR, and may include `null`.
   Examples: `"[(${floatField})]": 0.95`, `"[(${floatField})]From": 0.8, "[(${floatField})]To": 1.0`, `"[(${floatField})]": [0.95, 0.97]`[/]
 [# th:if="${booleanField != null}"]- **Boolean fields**: Use `true` or `false`. Example: `"[(${booleanField})]": true`[/]
 

--- a/lapis/src/main/resources/templates/llms.txt
+++ b/lapis/src/main/resources/templates/llms.txt
@@ -29,8 +29,10 @@ You can use metadata fields as filter parameters in your queries. The filter syn
   Examples: `"[(${stringField})]": "someValue"`, `"[(${stringField})].regex": "^startsWithThis*"`, `"[(${stringField})]": ["someValue", "orOtherValue"]`[/]
 [# th:if="${lineageField != null}"]- **Lineage fields**: For string fields that also have a lineage index, you can filter for exact matches (`"[(${lineageField})]": "lineage"`) or including sublineages (`"[(${lineageField})]": "lineage*"`).[/]
 [# th:if="${dateField != null}"]- **Date fields**: Use `From` and `To` suffixes for ranges. Example: `"[(${dateField})]From": "2023-01-01", "[(${dateField})]To": "2023-12-31"`[/]
-[# th:if="${intField != null}"]- **Integer fields**: Use exact match or `From`/`To` for ranges. Example: `"[(${intField})]": 42` or `"[(${intField})]From": 10, "[(${intField})]To": 50`[/]
-[# th:if="${floatField != null}"]- **Float fields**: Use exact match or `From`/`To` for ranges. Example: `"[(${floatField})]": 0.95` or `"[(${floatField})]From": 0.8, "[(${floatField})]To": 1.0`[/]
+[# th:if="${intField != null}"]- **Integer fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
+  Examples: `"[(${intField})]": 42`, `"[(${intField})]From": 10, "[(${intField})]To": 50`, `"[(${intField})]": [42, 43]`[/]
+[# th:if="${floatField != null}"]- **Float fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
+  Examples: `"[(${floatField})]": 0.95`, `"[(${floatField})]From": 0.8, "[(${floatField})]To": 1.0`, `"[(${floatField})]": [0.95, 0.97]`[/]
 [# th:if="${booleanField != null}"]- **Boolean fields**: Use `true` or `false`. Example: `"[(${booleanField})]": true`[/]
 
 You can combine multiple filters in a single query. All filters are combined with AND logic.

--- a/lapis/src/main/resources/templates/llms.txt
+++ b/lapis/src/main/resources/templates/llms.txt
@@ -28,7 +28,8 @@ You can use metadata fields as filter parameters in your queries. The filter syn
   You can also supply an array - the fields will be combined with logical OR.
   Examples: `"[(${stringField})]": "someValue"`, `"[(${stringField})].regex": "^startsWithThis*"`, `"[(${stringField})]": ["someValue", "orOtherValue"]`[/]
 [# th:if="${lineageField != null}"]- **Lineage fields**: For string fields that also have a lineage index, you can filter for exact matches (`"[(${lineageField})]": "lineage"`) or including sublineages (`"[(${lineageField})]": "lineage*"`).[/]
-[# th:if="${dateField != null}"]- **Date fields**: Use `From` and `To` suffixes for ranges. Example: `"[(${dateField})]From": "2023-01-01", "[(${dateField})]To": "2023-12-31"`[/]
+[# th:if="${dateField != null}"]- **Date fields**: Use exact match, or `From`/`To` suffixes for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
+  Examples: `"[(${dateField})]": "2023-01-15"`, `"[(${dateField})]From": "2023-01-01", "[(${dateField})]To": "2023-12-31"`, `"[(${dateField})]": ["2023-01-15", "2023-02-20"]`[/]
 [# th:if="${intField != null}"]- **Integer fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR.
   Examples: `"[(${intField})]": 42`, `"[(${intField})]From": 10, "[(${intField})]To": 50`, `"[(${intField})]": [42, 43]`[/]
 [# th:if="${floatField != null}"]- **Float fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR.

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -678,11 +678,6 @@ class SiloFilterExpressionMapperTest {
                 expectedErrorMessage = "Expected exactly one value for 'dateFrom' but got 2 values.",
             ),
             InvalidFilterScenario(
-                description = "multiple intField values",
-                filterParameters = DummySequenceFilters(mapOf("intField" to listOf("1", "2"))),
-                expectedErrorMessage = "Expected exactly one value for 'intField' but got 2 values.",
-            ),
-            InvalidFilterScenario(
                 description = "multiple intFieldTo values",
                 filterParameters = DummySequenceFilters(mapOf("intFieldTo" to listOf("1", "2"))),
                 expectedErrorMessage = "Expected exactly one value for 'intFieldTo' but got 2 values.",
@@ -691,11 +686,6 @@ class SiloFilterExpressionMapperTest {
                 description = "multiple intFieldFrom values",
                 filterParameters = DummySequenceFilters(mapOf("intFieldFrom" to listOf("1", "2"))),
                 expectedErrorMessage = "Expected exactly one value for 'intFieldFrom' but got 2 values.",
-            ),
-            InvalidFilterScenario(
-                description = "multiple floatField values",
-                filterParameters = DummySequenceFilters(mapOf("floatField" to listOf("0.1", "0.2"))),
-                expectedErrorMessage = "Expected exactly one value for 'floatField' but got 2 values.",
             ),
             InvalidFilterScenario(
                 description = "multiple floatFieldTo values",
@@ -849,13 +839,13 @@ class SiloFilterExpressionMapperTest {
                     mapOf(
                         "intField" to listOf("42"),
                     ),
-                    And(IntEquals("intField", 42)),
+                    And(Or(IntEquals("intField", 42))),
                 ),
                 Arguments.of(
                     mapOf(
                         "intField" to listOf(null),
                     ),
-                    And(IsNull(column = "intField")),
+                    And(Or(IsNull(column = "intField"))),
                 ),
                 Arguments.of(
                     mapOf(
@@ -885,13 +875,13 @@ class SiloFilterExpressionMapperTest {
                     mapOf(
                         "floatField" to listOf("42.45"),
                     ),
-                    And(FloatEquals("floatField", 42.45)),
+                    And(Or(FloatEquals("floatField", 42.45))),
                 ),
                 Arguments.of(
                     mapOf(
                         "floatField" to listOf(null),
                     ),
-                    And(IsNull("floatField")),
+                    And(Or(IsNull("floatField"))),
                 ),
                 Arguments.of(
                     mapOf(
@@ -916,6 +906,50 @@ class SiloFilterExpressionMapperTest {
                         "floatFieldTo" to listOf(null),
                     ),
                     And(FloatBetween("floatField", null, null)),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "intField" to listOf("1", "2"),
+                    ),
+                    And(
+                        Or(
+                            IntEquals("intField", 1),
+                            IntEquals("intField", 2),
+                        ),
+                    ),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "intField" to listOf("1", null),
+                    ),
+                    And(
+                        Or(
+                            IntEquals("intField", 1),
+                            IsNull(column = "intField"),
+                        ),
+                    ),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "floatField" to listOf("0.1", "0.2"),
+                    ),
+                    And(
+                        Or(
+                            FloatEquals("floatField", 0.1),
+                            FloatEquals("floatField", 0.2),
+                        ),
+                    ),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "floatField" to listOf("0.1", null),
+                    ),
+                    And(
+                        Or(
+                            FloatEquals("floatField", 0.1),
+                            IsNull(column = "floatField"),
+                        ),
+                    ),
                 ),
                 Arguments.of(
                     mapOf(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.model
 
-import org.genspectrum.lapis.DATE_FIELD
 import org.genspectrum.lapis.FIELD_WITH_UPPERCASE_LETTER
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.config.ReferenceSequenceSchema
@@ -663,11 +662,6 @@ class SiloFilterExpressionMapperTest {
 
         val filterParametersWithMultipleValues = listOf(
             InvalidFilterScenario(
-                description = "multiple $DATE_FIELD values",
-                filterParameters = DummySequenceFilters(mapOf(DATE_FIELD to listOf("2021-06-03", "2021-06-04"))),
-                expectedErrorMessage = "Expected exactly one value for '$DATE_FIELD' but got 2 values.",
-            ),
-            InvalidFilterScenario(
                 description = "multiple dateTo values",
                 filterParameters = DummySequenceFilters(mapOf("dateTo" to listOf("2021-06-03", "2021-06-04"))),
                 expectedErrorMessage = "Expected exactly one value for 'dateTo' but got 2 values.",
@@ -767,11 +761,11 @@ class SiloFilterExpressionMapperTest {
                     mapOf(
                         "date" to listOf("2021-06-03"),
                     ),
-                    And(DateBetween("date", from = LocalDate.of(2021, 6, 3), to = LocalDate.of(2021, 6, 3))),
+                    And(Or(DateBetween("date", from = LocalDate.of(2021, 6, 3), to = LocalDate.of(2021, 6, 3)))),
                 ),
                 Arguments.of(
                     mapOf("date" to listOf(null)),
-                    And(IsNull(column = "date")),
+                    And(Or(IsNull(column = "date"))),
                 ),
                 Arguments.of(
                     mapOf(
@@ -812,6 +806,28 @@ class SiloFilterExpressionMapperTest {
                     And(
                         DateBetween("date", from = null, to = LocalDate.of(2021, 6, 3)),
                         Or(StringEquals("some_metadata", "ABC")),
+                    ),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "date" to listOf("2021-06-03", "2021-06-04"),
+                    ),
+                    And(
+                        Or(
+                            DateBetween("date", from = LocalDate.of(2021, 6, 3), to = LocalDate.of(2021, 6, 3)),
+                            DateBetween("date", from = LocalDate.of(2021, 6, 4), to = LocalDate.of(2021, 6, 4)),
+                        ),
+                    ),
+                ),
+                Arguments.of(
+                    mapOf(
+                        "date" to listOf("2021-06-03", null),
+                    ),
+                    And(
+                        Or(
+                            DateBetween("date", from = LocalDate.of(2021, 6, 3), to = LocalDate.of(2021, 6, 3)),
+                            IsNull(column = "date"),
+                        ),
                     ),
                 ),
                 Arguments.of(


### PR DESCRIPTION
resolves #1595

`int`, `float`, and `date` exact-match filters now accept an array of values, combining them with logical OR — the same behaviour already supported for `string` fields.

```json
{ "age": [50, 51, 52] }
{ "qcValue": [0.95, 0.97, 0.8] }
{ "date": ["2021-05-08", "2021-01-20"] }
```

`null` is supported as an array element to filter for missing values. Range filters (`*From`/`*To`) are unchanged and still accept a single value only.


## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] All necessary changes are explained in the `llms.txt`.
- [x] The implemented feature is covered by an appropriate test.
