### PR TITLE
feat(lapis): fetch data from SILO in the Apache Arrow format

### DIFF
--- a/.idea/runConfigurations/LapisMultiSegmented.xml
+++ b/.idea/runConfigurations/LapisMultiSegmented.xml
@@ -3,6 +3,7 @@
     <module name="lapis.main" />
     <option name="PROGRAM_PARAMETERS" value="--silo.url=http://localhost:8093 --lapis.databaseConfig.path=lapis-e2e/testData/multiSegmented/testDatabaseConfig.yaml --referenceGenomeFilename=lapis-e2e/testData/multiSegmented/reference_genomes.json --server.port=8094" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.genspectrum.lapis.LapisApplicationKt" />
+    <option name="VM_PARAMETERS" value="-Dio.netty.tryReflectionSetAccessible=true --add-opens=java.base/java.nio=ALL-UNNAMED" />
     <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.idea/runConfigurations/LapisOpen.xml
+++ b/.idea/runConfigurations/LapisOpen.xml
@@ -4,6 +4,7 @@
     <module name="lapis.main" />
     <option name="PROGRAM_PARAMETERS" value="--silo.url=http://localhost:8091 --lapis.databaseConfig.path=lapis-e2e/testData/singleSegmented/testDatabaseConfig.yaml --referenceGenomeFilename=lapis-e2e/testData/singleSegmented/reference_genomes.json --server.port=8090" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="org.genspectrum.lapis.LapisApplicationKt" />
+    <option name="VM_PARAMETERS" value="-Dio.netty.tryReflectionSetAccessible=true --add-opens=java.base/java.nio=ALL-UNNAMED" />
     <option name="WORKING_DIRECTORY" value="file://$PROJECT_DIR$" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/lapis/README.md
+++ b/lapis/README.md
@@ -36,6 +36,13 @@ Optionally, you can pass:
 * `lapis.docs.url` to make the "Documentation" link on the landing page (`/`) point to your self-hosted [lapis docs](../lapis-docs/README.md).
   If `lapis.docs.url` is not set or empty, then the "Documentation" link will not be shown.
 
+Additionally, Apache Arrow requires these flags to be set on the JVM:
+```
+-Dio.netty.tryReflectionSetAccessible=true --add-opens=java.base/java.nio=ALL-UNNAMED
+```
+(see [Arrow docs](https://github.com/apache/arrow-java/?tab=readme-ov-file#java-properties)).
+We already set the flags in Docker and when starting LAPIS via the Gradle `bootRun` command.
+
 ### Operating LAPIS behind a proxy
 
 When running LAPIS behind a proxy, the proxy needs to set X-Forwarded headers:

--- a/lapis/build.gradle
+++ b/lapis/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'org.apache.commons:commons-csv:1.14.1'
     implementation 'com.github.luben:zstd-jni:1.5.7-7'
     implementation 'org.apache.arrow:arrow-vector:19.0.0'
-    implementation 'org.apache.arrow:arrow-memory-unsafe:19.0.0'
+    implementation 'org.apache.arrow:arrow-memory-netty:19.0.0'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.2.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat'
 
@@ -88,7 +88,7 @@ tasks.named('test') {
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
     }
-    maxHeapSize = '1g'
+    maxHeapSize = '2g'
     // Required by Apache Arrow to access DirectByteBuffer internals on Java 9+
     jvmArgs(
         '--add-opens=java.base/java.nio=ALL-UNNAMED',

--- a/lapis/build.gradle
+++ b/lapis/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.antlr:antlr4-runtime:4.13.2'
     implementation 'org.apache.commons:commons-csv:1.14.1'
     implementation 'com.github.luben:zstd-jni:1.5.7-7'
+    implementation 'org.apache.arrow:arrow-vector:19.0.0'
+    implementation 'org.apache.arrow:arrow-memory-unsafe:19.0.0'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.2.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat'
 
@@ -86,6 +88,12 @@ tasks.named('test') {
         exceptionFormat = TestExceptionFormat.FULL
         showExceptions = true
     }
+    maxHeapSize = '1g'
+    // Required by Apache Arrow to access DirectByteBuffer internals on Java 9+
+    jvmArgs(
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+    )
 }
 
 // taken from https://github.com/JLLeitschuh/ktlint-gradle/issues/809#issuecomment-2515514826

--- a/lapis/build.gradle
+++ b/lapis/build.gradle
@@ -62,6 +62,13 @@ dependencies {
 }
 
 
+// Required by Apache Arrow (Netty memory backend) to access DirectByteBuffer on Java 9+
+// See https://github.com/apache/arrow-java/?tab=readme-ov-file#java-properties
+def ARROW_JVM_ARGS = [
+    '-Dio.netty.tryReflectionSetAccessible=true',
+    '--add-opens=java.base/java.nio=ALL-UNNAMED',
+]
+
 compileKotlin {
     dependsOn generateGrammarSource
 }
@@ -89,11 +96,11 @@ tasks.named('test') {
         showExceptions = true
     }
     maxHeapSize = '2g'
-    // Required by Apache Arrow to access DirectByteBuffer internals on Java 9+
-    jvmArgs(
-        '--add-opens=java.base/java.nio=ALL-UNNAMED',
-        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
-    )
+    jvmArgs(ARROW_JVM_ARGS)
+}
+
+tasks.named('bootRun') {
+    jvmArgs(ARROW_JVM_ARGS)
 }
 
 // taken from https://github.com/JLLeitschuh/ktlint-gradle/issues/809#issuecomment-2515514826

--- a/lapis/entrypoint.sh
+++ b/lapis/entrypoint.sh
@@ -3,7 +3,11 @@
 JVM_OPTS=${JVM_OPTS:-}
 ARGS="${*}"
 
-GENERAL_OPTS="-jar app.jar \
+# Required by Apache Arrow (Netty memory backend) to access DirectByteBuffer on Java 9+
+# See https://github.com/apache/arrow-java/?tab=readme-ov-file#java-properties
+ARROW_OPTS="-Dio.netty.tryReflectionSetAccessible=true --add-opens=java.base/java.nio=ALL-UNNAMED"
+
+GENERAL_OPTS="$ARROW_OPTS -jar app.jar \
     --spring.profiles.active=docker \
     --referenceGenomeFilename=./reference_genomes.json \
     $ARGS"

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.parameters.HeaderParameter
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import mu.KotlinLogging
+import org.apache.arrow.memory.RootAllocator
 import org.genspectrum.lapis.auth.DataOpennessAuthorizationFilterFactory
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.DatabaseConfigValidator
@@ -51,6 +52,9 @@ private const val VERSION_FILE = "version.txt"
 @EnableScheduling
 @EnableCaching
 class LapisSpringConfig {
+    @Bean
+    fun rootAllocator() = RootAllocator()
+
     @Bean
     fun openAPI(
         sequenceFilterFields: SequenceFilterFields,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.parameters.HeaderParameter
 import io.swagger.v3.oas.models.security.SecurityRequirement
+import jakarta.annotation.PreDestroy
 import mu.KotlinLogging
 import org.apache.arrow.memory.RootAllocator
 import org.genspectrum.lapis.auth.DataOpennessAuthorizationFilterFactory
@@ -52,8 +53,15 @@ private const val VERSION_FILE = "version.txt"
 @EnableScheduling
 @EnableCaching
 class LapisSpringConfig {
+    private val rootAllocator = RootAllocator()
+
     @Bean
-    fun rootAllocator() = RootAllocator()
+    fun rootAllocator() = rootAllocator
+
+    @PreDestroy
+    fun closeRootAllocator() {
+        rootAllocator.close()
+    }
 
     @Bean
     fun openAPI(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -1231,7 +1231,7 @@ class LapisController(
     ): String {
         val treeResponse = siloQueryModel.getNewick(sequenceFilters = request)
         response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion)
-        return treeResponse.toList().first().subtreeNewick
+        return treeResponse.use { it.toList() }.first().subtreeNewick
     }
 
     @GetMapping(DETAILS_ROUTE, produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -353,7 +353,7 @@ class QueriesOverTimeModel(
                 ),
             ),
             setRequestDataVersion = false,
-        ).map { it.toList() }
+        ).map { stream -> stream.use { it.toList() } }
 
     /**
      * Builds a result row for one particular mutation.

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -63,12 +63,12 @@ data class MutationsOverTimeResult(
 
 data class MutationsOverTimeCell(
     @param:Schema(description = "Number of sequences with the mutation in the date range")
-    var count: Int,
+    var count: Long,
     @param:Schema(
         description = "Number of sequences with coverage (i.e., having a non-ambiguous symbol) at the position in" +
             "the date range. Confirmed deletions (i.e., \"-\") are included.",
     )
-    var coverage: Int,
+    var coverage: Long,
 )
 
 @Schema(
@@ -112,13 +112,13 @@ data class QueriesOverTimeResult(
 
 data class QueryOverTimeCell(
     @param:Schema(description = "Number of sequences that match the 'countQuery' in the date range")
-    var count: Int,
+    var count: Long,
     @param:Schema(
         description = "Number of sequences that match the 'coverageQuery' in the date range. " +
             "The query should be picked such that this number is the count of sequences that have a non-ambiguous " +
             "symbol at the positions of interest.",
     )
-    var coverage: Int,
+    var coverage: Long,
 )
 
 @Component
@@ -387,7 +387,7 @@ class QueriesOverTimeModel(
         dateField: String,
         dateRanges: List<DateRange>,
     ): List<Number> {
-        val result = Array(dateRanges.size) { 0 }
+        val result = Array(dateRanges.size) { 0L }
 
         counts.forEach { dateCount ->
             val index = findDateRangeIndex(dateCount, dateField, dateRanges)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -800,7 +800,7 @@ private fun getAggregatedResponseProperties(filterProperties: Map<SequenceFilter
                 "The response is stratified by this field.",
         )
     } + mapOf(
-        COUNT_PROPERTY to IntegerSchema().description("The number of sequences matching the filters."),
+        COUNT_PROPERTY to IntegerSchema().format("int64").description("The number of sequences matching the filters."),
     )
 
 private fun nucleotideMutationProportionSchema() =

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/CsvWriter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/CsvWriter.kt
@@ -11,7 +11,7 @@ interface RecordCollection<T> {
 
     fun getHeader(): List<String>
 
-    fun getCsvRecords(): Stream<List<String?>> = records.use { stream -> stream.map { mapToCsvValuesList(it) } }
+    fun getCsvRecords(): Stream<List<String?>> = records.map { mapToCsvValuesList(it) }
 
     /**
      * Csv values - must be in the same order as the header.

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/CsvWriter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/CsvWriter.kt
@@ -11,7 +11,7 @@ interface RecordCollection<T> {
 
     fun getHeader(): List<String>
 
-    fun getCsvRecords(): Stream<List<String?>> = records.map { mapToCsvValuesList(it) }
+    fun getCsvRecords(): Stream<List<String?>> = records.use { stream -> stream.map { mapToCsvValuesList(it) } }
 
     /**
      * Csv values - must be in the same order as the header.

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -1,17 +1,10 @@
 package org.genspectrum.lapis.response
 
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.node.ObjectNode
 import io.swagger.v3.oas.annotations.media.Schema
-import org.genspectrum.lapis.config.DatabaseConfig
-import org.genspectrum.lapis.util.UNALIGNED_PREFIX
 import org.springframework.boot.jackson.JsonComponent
 
 const val COUNT_PROPERTY = "count"

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.jackson.JsonComponent
 const val COUNT_PROPERTY = "count"
 
 data class AggregationData(
-    val count: Int,
+    val count: Long,
     @param:Schema(hidden = true) val fields: Map<String, JsonNode>,
 )
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -26,14 +26,6 @@ data class DetailsData(
 ) : Map<String, JsonNode> by map
 
 @JsonComponent
-class DetailsDataDeserializer : JsonDeserializer<DetailsData>() {
-    override fun deserialize(
-        p: JsonParser,
-        ctxt: DeserializationContext,
-    ): DetailsData = DetailsData(p.readValueAs(object : TypeReference<Map<String, JsonNode>>() {}))
-}
-
-@JsonComponent
 class AggregationDataSerializer : JsonSerializer<AggregationData>() {
     override fun serialize(
         value: AggregationData,
@@ -44,19 +36,6 @@ class AggregationDataSerializer : JsonSerializer<AggregationData>() {
         gen.writeNumberField(COUNT_PROPERTY, value.count)
         value.fields.forEach { (key, value) -> gen.writeObjectField(key, value) }
         gen.writeEndObject()
-    }
-}
-
-@JsonComponent
-class AggregationDataDeserializer : JsonDeserializer<AggregationData>() {
-    override fun deserialize(
-        p: JsonParser,
-        ctxt: DeserializationContext,
-    ): AggregationData {
-        val node = p.readValueAsTree<JsonNode>()
-        val count = node.get(COUNT_PROPERTY).asInt()
-        val fields = node.properties().asSequence().filter { it.key != COUNT_PROPERTY }.associate { it.key to it.value }
-        return AggregationData(count, fields)
     }
 }
 
@@ -99,19 +78,3 @@ data class InfoData(
     val dataVersion: String,
     val siloVersion: String?,
 )
-
-@JsonComponent
-class SequenceDataDeserializer(
-    val databaseConfig: DatabaseConfig,
-) : JsonDeserializer<SequenceData>() {
-    override fun deserialize(
-        p: JsonParser,
-        ctxt: DeserializationContext,
-    ): SequenceData {
-        val node = p.readValueAsTree<ObjectNode>()
-
-        return SequenceData(
-            node.properties().associate { (key, value) -> key.removePrefix(UNALIGNED_PREFIX) to value },
-        )
-    }
-}

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -25,11 +25,15 @@ import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
 import org.genspectrum.lapis.util.UNALIGNED_PREFIX
 
-/** Converts one row at `rowIndex` from an Arrow [org.apache.arrow.vector.VectorSchemaRoot] to a typed Kotlin object. */
+/**
+ * Converts one row at `rowIndex` from an Arrow [org.apache.arrow.vector.VectorSchemaRoot] to a typed Kotlin object.
+ *
+ * See https://github.com/GenSpectrum/LAPIS-SILO/blob/main/documentation/query_documentation.md#action for the SILO response schema
+ */
 typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
 
 val AGGREGATION_DATA_ARROW_CONVERTER: ArrowRowConverter<AggregationData> = { root, rowIndex ->
-    val count = root.getLong(COUNT_PROPERTY, rowIndex).toInt()
+    val count = root.getLong(COUNT_PROPERTY, rowIndex)
     val fields = root.schema.fields
         .mapIndexedNotNull { colIdx, field ->
             if (field.name == COUNT_PROPERTY) {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -1,0 +1,159 @@
+package org.genspectrum.lapis.silo
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.BooleanNode
+import com.fasterxml.jackson.databind.node.DoubleNode
+import com.fasterxml.jackson.databind.node.FloatNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.LongNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.BitVector
+import org.apache.arrow.vector.Float4Vector
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.genspectrum.lapis.response.AggregationData
+import org.genspectrum.lapis.response.COUNT_PROPERTY
+import org.genspectrum.lapis.response.DetailsData
+import org.genspectrum.lapis.response.InsertionData
+import org.genspectrum.lapis.response.MostCommonAncestorData
+import org.genspectrum.lapis.response.MutationData
+import org.genspectrum.lapis.response.PhyloSubtreeData
+import org.genspectrum.lapis.response.SequenceData
+import org.genspectrum.lapis.util.UNALIGNED_PREFIX
+
+/** Converts one row at `rowIndex` from an Arrow [org.apache.arrow.vector.VectorSchemaRoot] to a typed Kotlin object. */
+typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
+
+val AGGREGATION_DATA_ARROW_CONVERTER: ArrowRowConverter<AggregationData> = { root, rowIndex ->
+    val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
+    val fields = root.schema.fields
+        .filter { it.name != COUNT_PROPERTY }
+        .mapIndexed { _, field ->
+            val actualColIdx = root.schema.fields.indexOfFirst { it.name == field.name }
+            field.name to root.fieldValueAsJsonNode(actualColIdx, rowIndex)
+        }
+        .toMap()
+    AggregationData(count, fields)
+}
+
+val DETAILS_DATA_ARROW_CONVERTER: ArrowRowConverter<DetailsData> = { root, rowIndex ->
+    DetailsData(
+        root.schema.fields
+            .mapIndexed { colIdx, field -> field.name to root.fieldValueAsJsonNode(colIdx, rowIndex) }
+            .toMap(),
+    )
+}
+
+val MOST_COMMON_ANCESTOR_DATA_ARROW_CONVERTER: ArrowRowConverter<MostCommonAncestorData> = { root, rowIndex ->
+    MostCommonAncestorData(
+        mrcaNode = root.getString("mrcaNode", rowIndex),
+        missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
+        missingFromTree = root.getString("missingFromTree", rowIndex),
+    )
+}
+
+val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, rowIndex ->
+    MutationData(
+        mutation = root.getString("mutation", rowIndex),
+        count = root.getInt("count", rowIndex),
+        proportion = root.getDouble("proportion", rowIndex),
+        sequenceName = root.getString("sequenceName", rowIndex),
+        mutationFrom = root.getString("mutationFrom", rowIndex),
+        mutationTo = root.getString("mutationTo", rowIndex),
+        position = root.getInt("position", rowIndex),
+        coverage = root.getInt("coverage", rowIndex),
+    )
+}
+
+val INSERTION_DATA_ARROW_CONVERTER: ArrowRowConverter<InsertionData> = { root, rowIndex ->
+    InsertionData(
+        count = root.getInt("count", rowIndex) ?: 0,
+        insertion = root.getString("insertion", rowIndex) ?: "",
+        insertedSymbols = root.getString("insertedSymbols", rowIndex) ?: "",
+        position = root.getInt("position", rowIndex) ?: 0,
+        sequenceName = root.getString("sequenceName", rowIndex) ?: "",
+    )
+}
+
+val PHYLO_SUBTREE_DATA_ARROW_CONVERTER: ArrowRowConverter<PhyloSubtreeData> = { root, rowIndex ->
+    PhyloSubtreeData(
+        subtreeNewick = root.getString("subtreeNewick", rowIndex) ?: "",
+        missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
+        missingFromTree = root.getString("missingFromTree", rowIndex),
+    )
+}
+
+val SEQUENCE_DATA_ARROW_CONVERTER: ArrowRowConverter<SequenceData> = { root, rowIndex ->
+    SequenceData(
+        root.schema.fields
+            .mapIndexed { colIdx, field ->
+                field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
+            }
+            .toMap(),
+    )
+}
+
+private fun VectorSchemaRoot.getString(
+    name: String,
+    rowIndex: Int,
+): String? {
+    val vector = getVector(name) as? VarCharVector ?: return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
+    return String(vector.get(rowIndex))
+}
+
+private fun VectorSchemaRoot.getInt(
+    name: String,
+    rowIndex: Int,
+): Int? {
+    val vector = getVector(name) as? IntVector ?: return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.getLong(
+    name: String,
+    rowIndex: Int,
+): Long? {
+    val vector = getVector(name) as? BigIntVector ?: return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.getDouble(
+    name: String,
+    rowIndex: Int,
+): Double? {
+    val vector = getVector(name) as? Float8Vector ?: return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.fieldValueAsJsonNode(
+    columnIndex: Int,
+    rowIndex: Int,
+): JsonNode {
+    val vector = fieldVectors[columnIndex]
+    if (vector.isNull(rowIndex)) return NullNode.instance
+    return when (vector) {
+        is VarCharVector -> TextNode(String(vector.get(rowIndex)))
+        is IntVector -> IntNode(vector.get(rowIndex))
+        is BigIntVector -> LongNode(vector.get(rowIndex))
+        is Float8Vector -> DoubleNode(vector.get(rowIndex))
+        is Float4Vector -> FloatNode(vector.get(rowIndex))
+        is BitVector -> BooleanNode.valueOf(vector.get(rowIndex) != 0)
+        else -> TextNode(vector.getObject(rowIndex)?.toString() ?: "")
+    }
+}

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -120,8 +120,9 @@ private fun VectorSchemaRoot.getString(
     name: String,
     rowIndex: Int,
 ): String {
-    val vector = getVector(name) as? VarCharVector
-        ?: error("Expected VarCharVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
+    val rawVector = getVector(name)
+    val vector = rawVector as? VarCharVector
+        ?: error("Expected VarCharVector for column '$name' but got ${rawVector?.javaClass?.simpleName}")
     check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
     return String(vector.get(rowIndex), Charsets.UTF_8)
 }
@@ -143,8 +144,9 @@ private fun VectorSchemaRoot.getInt(
     name: String,
     rowIndex: Int,
 ): Int {
-    val vector = getVector(name) as? IntVector
-        ?: error("Expected IntVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
+    val rawVector = getVector(name)
+    val vector = rawVector as? IntVector
+        ?: error("Expected IntVector for column '$name' but got ${rawVector?.javaClass?.simpleName}")
     check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
     return vector.get(rowIndex)
 }
@@ -153,8 +155,9 @@ private fun VectorSchemaRoot.getLong(
     name: String,
     rowIndex: Int,
 ): Long {
-    val vector = getVector(name) as? BigIntVector
-        ?: error("Expected BigIntVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
+    val rawVector = getVector(name)
+    val vector = rawVector as? BigIntVector
+        ?: error("Expected BigIntVector for column '$name' but got ${rawVector?.javaClass?.simpleName}")
     check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
     return vector.get(rowIndex)
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -29,7 +29,7 @@ import org.genspectrum.lapis.util.UNALIGNED_PREFIX
 typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
 
 val AGGREGATION_DATA_ARROW_CONVERTER: ArrowRowConverter<AggregationData> = { root, rowIndex ->
-    val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
+    val count = root.getLong(COUNT_PROPERTY, rowIndex).toInt()
     val fields = root.schema.fields
         .filter { it.name != COUNT_PROPERTY }
         .mapIndexed { _, field ->
@@ -50,40 +50,40 @@ val DETAILS_DATA_ARROW_CONVERTER: ArrowRowConverter<DetailsData> = { root, rowIn
 
 val MOST_COMMON_ANCESTOR_DATA_ARROW_CONVERTER: ArrowRowConverter<MostCommonAncestorData> = { root, rowIndex ->
     MostCommonAncestorData(
-        mrcaNode = root.getString("mrcaNode", rowIndex),
-        missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
-        missingFromTree = root.getString("missingFromTree", rowIndex),
+        mrcaNode = root.getOptionalString("mrcaNode", rowIndex),
+        missingNodeCount = root.getInt("missingNodeCount", rowIndex),
+        missingFromTree = root.getOptionalString("missingFromTree", rowIndex),
     )
 }
 
 val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, rowIndex ->
     MutationData(
-        mutation = root.getString("mutation", rowIndex),
-        count = root.getInt("count", rowIndex),
-        proportion = root.getDouble("proportion", rowIndex),
-        sequenceName = root.getString("sequenceName", rowIndex),
-        mutationFrom = root.getString("mutationFrom", rowIndex),
-        mutationTo = root.getString("mutationTo", rowIndex),
-        position = root.getInt("position", rowIndex),
-        coverage = root.getInt("coverage", rowIndex),
+        mutation = root.getOptionalString("mutation", rowIndex),
+        count = root.getOptionalInt("count", rowIndex),
+        proportion = root.getOptionalDouble("proportion", rowIndex),
+        sequenceName = root.getOptionalString("sequenceName", rowIndex),
+        mutationFrom = root.getOptionalString("mutationFrom", rowIndex),
+        mutationTo = root.getOptionalString("mutationTo", rowIndex),
+        position = root.getOptionalInt("position", rowIndex),
+        coverage = root.getOptionalInt("coverage", rowIndex),
     )
 }
 
 val INSERTION_DATA_ARROW_CONVERTER: ArrowRowConverter<InsertionData> = { root, rowIndex ->
     InsertionData(
-        count = root.getInt("count", rowIndex) ?: 0,
-        insertion = root.getString("insertion", rowIndex) ?: "",
-        insertedSymbols = root.getString("insertedSymbols", rowIndex) ?: "",
-        position = root.getInt("position", rowIndex) ?: 0,
-        sequenceName = root.getString("sequenceName", rowIndex) ?: "",
+        count = root.getInt("count", rowIndex),
+        insertion = root.getString("insertion", rowIndex),
+        insertedSymbols = root.getString("insertedSymbols", rowIndex),
+        position = root.getInt("position", rowIndex),
+        sequenceName = root.getString("sequenceName", rowIndex),
     )
 }
 
 val PHYLO_SUBTREE_DATA_ARROW_CONVERTER: ArrowRowConverter<PhyloSubtreeData> = { root, rowIndex ->
     PhyloSubtreeData(
-        subtreeNewick = root.getString("subtreeNewick", rowIndex) ?: "",
-        missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
-        missingFromTree = root.getString("missingFromTree", rowIndex),
+        subtreeNewick = root.getString("subtreeNewick", rowIndex),
+        missingNodeCount = root.getInt("missingNodeCount", rowIndex),
+        missingFromTree = root.getOptionalString("missingFromTree", rowIndex),
     )
 }
 
@@ -97,7 +97,7 @@ val SEQUENCE_DATA_ARROW_CONVERTER: ArrowRowConverter<SequenceData> = { root, row
     )
 }
 
-private fun VectorSchemaRoot.getString(
+private fun VectorSchemaRoot.getOptionalString(
     name: String,
     rowIndex: Int,
 ): String? {
@@ -108,7 +108,17 @@ private fun VectorSchemaRoot.getString(
     return String(vector.get(rowIndex))
 }
 
-private fun VectorSchemaRoot.getInt(
+private fun VectorSchemaRoot.getString(
+    name: String,
+    rowIndex: Int,
+): String {
+    val vector = getVector(name) as? VarCharVector
+        ?: error("Expected VarCharVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
+    check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
+    return String(vector.get(rowIndex))
+}
+
+private fun VectorSchemaRoot.getOptionalInt(
     name: String,
     rowIndex: Int,
 ): Int? {
@@ -119,18 +129,27 @@ private fun VectorSchemaRoot.getInt(
     return vector.get(rowIndex)
 }
 
-private fun VectorSchemaRoot.getLong(
+private fun VectorSchemaRoot.getInt(
     name: String,
     rowIndex: Int,
-): Long? {
-    val vector = getVector(name) as? BigIntVector ?: return null
-    if (vector.isNull(rowIndex)) {
-        return null
-    }
+): Int {
+    val vector = getVector(name) as? IntVector
+        ?: error("Expected IntVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
+    check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
     return vector.get(rowIndex)
 }
 
-private fun VectorSchemaRoot.getDouble(
+private fun VectorSchemaRoot.getLong(
+    name: String,
+    rowIndex: Int,
+): Long {
+    val vector = getVector(name) as? BigIntVector
+        ?: error("Expected BigIntVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
+    check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.getOptionalDouble(
     name: String,
     rowIndex: Int,
 ): Double? {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -31,10 +31,12 @@ typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
 val AGGREGATION_DATA_ARROW_CONVERTER: ArrowRowConverter<AggregationData> = { root, rowIndex ->
     val count = root.getLong(COUNT_PROPERTY, rowIndex).toInt()
     val fields = root.schema.fields
-        .filter { it.name != COUNT_PROPERTY }
-        .mapIndexed { _, field ->
-            val actualColIdx = root.schema.fields.indexOfFirst { it.name == field.name }
-            field.name to root.fieldValueAsJsonNode(actualColIdx, rowIndex)
+        .mapIndexedNotNull { colIdx, field ->
+            if (field.name == COUNT_PROPERTY) {
+                null
+            } else {
+                field.name to root.fieldValueAsJsonNode(colIdx, rowIndex)
+            }
         }
         .toMap()
     AggregationData(count, fields)
@@ -105,7 +107,7 @@ private fun VectorSchemaRoot.getOptionalString(
     if (vector.isNull(rowIndex)) {
         return null
     }
-    return String(vector.get(rowIndex))
+    return String(vector.get(rowIndex), Charsets.UTF_8)
 }
 
 private fun VectorSchemaRoot.getString(
@@ -115,7 +117,7 @@ private fun VectorSchemaRoot.getString(
     val vector = getVector(name) as? VarCharVector
         ?: error("Expected VarCharVector for column '$name' but got ${getVector(name)?.javaClass?.simpleName}")
     check(!vector.isNull(rowIndex)) { "Unexpected null value in non-nullable column '$name' at row $rowIndex" }
-    return String(vector.get(rowIndex))
+    return String(vector.get(rowIndex), Charsets.UTF_8)
 }
 
 private fun VectorSchemaRoot.getOptionalInt(
@@ -167,7 +169,7 @@ private fun VectorSchemaRoot.fieldValueAsJsonNode(
     val vector = fieldVectors[columnIndex]
     if (vector.isNull(rowIndex)) return NullNode.instance
     return when (vector) {
-        is VarCharVector -> TextNode(String(vector.get(rowIndex)))
+        is VarCharVector -> TextNode(String(vector.get(rowIndex), Charsets.UTF_8))
         is IntVector -> IntNode(vector.get(rowIndex))
         is BigIntVector -> LongNode(vector.get(rowIndex))
         is Float8Vector -> DoubleNode(vector.get(rowIndex))

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -103,7 +103,9 @@ private fun VectorSchemaRoot.getOptionalString(
     name: String,
     rowIndex: Int,
 ): String? {
-    val vector = getVector(name) as? VarCharVector ?: return null
+    val rawVector = getVector(name) ?: return null
+    val vector = rawVector as? VarCharVector
+        ?: error("Expected VarCharVector for column '$name' but got ${rawVector.javaClass.simpleName}")
     if (vector.isNull(rowIndex)) {
         return null
     }
@@ -124,7 +126,9 @@ private fun VectorSchemaRoot.getOptionalInt(
     name: String,
     rowIndex: Int,
 ): Int? {
-    val vector = getVector(name) as? IntVector ?: return null
+    val rawVector = getVector(name) ?: return null
+    val vector = rawVector as? IntVector
+        ?: error("Expected IntVector for column '$name' but got ${rawVector.javaClass.simpleName}")
     if (vector.isNull(rowIndex)) {
         return null
     }
@@ -155,7 +159,9 @@ private fun VectorSchemaRoot.getOptionalDouble(
     name: String,
     rowIndex: Int,
 ): Double? {
-    val vector = getVector(name) as? Float8Vector ?: return null
+    val rawVector = getVector(name) ?: return null
+    val vector = rawVector as? Float8Vector
+        ?: error("Expected Float8Vector for column '$name' but got ${rawVector.javaClass.simpleName}")
     if (vector.isNull(rowIndex)) {
         return null
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -3,6 +3,8 @@ package org.genspectrum.lapis.silo
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.ipc.ArrowStreamReader
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.controller.LapisHeaders.REQUEST_ID
 import org.genspectrum.lapis.log
@@ -17,6 +19,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.context.request.RequestContextHolder
 import java.io.IOException
+import java.io.InputStream
 import java.net.ConnectException
 import java.net.URI
 import java.net.http.HttpClient
@@ -26,6 +29,7 @@ import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.stream.Stream
+import java.util.stream.StreamSupport
 
 @Component
 class SiloClient(
@@ -77,6 +81,7 @@ class SiloClient(
 }
 
 const val SILO_QUERY_CACHE_NAME = "siloQueryCache"
+const val ARROW_STREAM_MEDIA_TYPE = "application/vnd.apache.arrow.stream"
 
 @Component
 open class CachedSiloClient(
@@ -116,27 +121,46 @@ open class CachedSiloClient(
 
         val response = send(
             uri = siloUris.query,
-            bodyHandler = BodyHandlers.ofLines(),
-            tryToReadSiloErrorFromBody = { tryToReadSiloErrorFromString(it.findFirst().orElse("")) },
+            bodyHandler = BodyHandlers.ofInputStream(),
+            tryToReadSiloErrorFromBody = { tryToReadSiloErrorFromString(it.readBytes().toString(Charsets.UTF_8)) },
         ) {
             it.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.ACCEPT, ARROW_STREAM_MEDIA_TYPE)
                 .POST(HttpRequest.BodyPublishers.ofString(queryJson))
         }
 
         return WithDataVersion(
-            queryResult = response.body()
-                .filter { it.isNotBlank() }
-                .map {
-                    try {
-                        objectMapper.readValue(it, query.action.typeReference)
-                    } catch (exception: Exception) {
-                        val message = "Could not parse response from silo: " +
-                            exception::class.toString() + " " + exception.message + " - NDJSON line: " + it
-                        throw RuntimeException(message, exception)
-                    }
-                },
+            queryResult = parseArrowStream(response.body(), query.action.arrowConverter),
             dataVersion = getDataVersion(response),
         )
+    }
+
+    private fun <ResponseType> parseArrowStream(
+        inputStream: InputStream,
+        converter: ArrowRowConverter<ResponseType>,
+    ): Stream<ResponseType> {
+        val allocator = RootAllocator()
+        val reader = ArrowStreamReader(inputStream, allocator)
+
+        val batches = generateSequence {
+            try {
+                if (reader.loadNextBatch()) reader.vectorSchemaRoot else null
+            } catch (exception: Exception) {
+                val message = "Could not parse Arrow IPC response from SILO: " +
+                    exception::class.toString() + " " + exception.message
+                throw RuntimeException(message, exception)
+            }
+        }
+
+        val rowSequence = batches.flatMap { root ->
+            (0 until root.rowCount).asSequence().map { rowIndex -> converter(root, rowIndex) }
+        }
+
+        return StreamSupport.stream(rowSequence.asIterable().spliterator(), false)
+            .onClose {
+                reader.close()
+                allocator.close()
+            }
     }
 
     fun callInfo(): InfoData {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -123,7 +123,11 @@ open class CachedSiloClient(
         val response = send(
             uri = siloUris.query,
             bodyHandler = BodyHandlers.ofInputStream(),
-            tryToReadSiloErrorFromBody = { tryToReadSiloErrorFromString(it.readBytes().toString(Charsets.UTF_8)) },
+            tryToReadSiloErrorFromBody = { body ->
+                body.use {
+                    tryToReadSiloErrorFromString(it.readBytes().toString(Charsets.UTF_8))
+                }
+            },
         ) {
             it.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.ACCEPT, ARROW_STREAM_MEDIA_TYPE)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -130,30 +130,30 @@ open class CachedSiloClient(
                 .POST(HttpRequest.BodyPublishers.ofString(queryJson))
         }
 
-        val childAllocator = rootAllocator.newChildAllocator(
-            "query-${query.action.javaClass.simpleName}",
-            0,
-            Long.MAX_VALUE,
-        )
         return WithDataVersion(
-            queryResult = parseArrowStream(response.body(), query.action.arrowConverter, childAllocator),
+            queryResult = parseArrowStream(response.body(), query.action),
             dataVersion = getDataVersion(response),
         )
     }
 
     private fun <ResponseType> parseArrowStream(
         inputStream: InputStream,
-        converter: ArrowRowConverter<ResponseType>,
-        allocator: BufferAllocator,
-    ): Stream<ResponseType> =
-        allocator.use { alloc ->
+        action: SiloAction<ResponseType>,
+    ): Stream<ResponseType> {
+        val allocator = rootAllocator.newChildAllocator(
+            "query-${action.javaClass.simpleName}",
+            0,
+            Long.MAX_VALUE,
+        )
+
+        return allocator.use { alloc ->
             ArrowStreamReader(inputStream, alloc).use { reader ->
                 val rows = mutableListOf<ResponseType>()
                 try {
                     while (reader.loadNextBatch()) {
                         val root = reader.vectorSchemaRoot
                         for (rowIndex in 0 until root.rowCount) {
-                            rows.add(converter(root, rowIndex))
+                            rows.add(action.arrowConverter(root, rowIndex))
                         }
                     }
                 } catch (exception: Exception) {
@@ -164,6 +164,7 @@ open class CachedSiloClient(
                 rows.stream()
             }
         }
+    }
 
     fun callInfo(): InfoData {
         val response = send(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -30,6 +30,7 @@ import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.stream.Stream
+import java.util.stream.StreamSupport
 
 @Component
 class SiloClient(
@@ -109,7 +110,7 @@ open class CachedSiloClient(
     )
     open fun <ResponseType> sendCachedQuery(query: SiloQuery<ResponseType>): WithDataVersion<List<ResponseType>> =
         sendQuery(query)
-            .let { WithDataVersion(it.dataVersion, it.queryResult.toList()) }
+            .let { WithDataVersion(it.dataVersion, it.queryResult.use { stream -> stream.toList() }) }
 
     fun <ResponseType> sendQuery(query: SiloQuery<ResponseType>): WithDataVersion<Stream<ResponseType>> {
         if (RequestContextHolder.getRequestAttributes() != null) {
@@ -140,30 +141,29 @@ open class CachedSiloClient(
         inputStream: InputStream,
         action: SiloAction<ResponseType>,
     ): Stream<ResponseType> {
-        val allocator = rootAllocator.newChildAllocator(
-            "query-${action.javaClass.simpleName}",
-            0,
-            Long.MAX_VALUE,
-        )
+        val allocator = rootAllocator.newChildAllocator("query-${action.javaClass.simpleName}", 0, Long.MAX_VALUE)
+        val reader = ArrowStreamReader(inputStream, allocator)
 
-        return allocator.use { alloc ->
-            ArrowStreamReader(inputStream, alloc).use { reader ->
-                val rows = mutableListOf<ResponseType>()
-                try {
-                    while (reader.loadNextBatch()) {
-                        val root = reader.vectorSchemaRoot
-                        for (rowIndex in 0 until root.rowCount) {
-                            rows.add(action.arrowConverter(root, rowIndex))
-                        }
+        val rowSequence = sequence {
+            try {
+                while (reader.loadNextBatch()) {
+                    val root = reader.vectorSchemaRoot
+                    for (rowIndex in 0 until root.rowCount) {
+                        yield(action.arrowConverter(root, rowIndex))
                     }
-                } catch (exception: Exception) {
-                    val message = "Could not parse Arrow IPC response from SILO: " +
-                        exception::class.toString() + " " + exception.message
-                    throw RuntimeException(message, exception)
                 }
-                rows.stream()
+            } catch (exception: Exception) {
+                val message = "Could not parse Arrow IPC response from SILO: " +
+                    exception::class.toString() + " " + exception.message
+                throw RuntimeException(message, exception)
             }
         }
+
+        return StreamSupport.stream(rowSequence.asIterable().spliterator(), false)
+            .onClose {
+                reader.close()
+                allocator.close()
+            }
     }
 
     fun callInfo(): InfoData {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -3,6 +3,7 @@ package org.genspectrum.lapis.silo
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.ipc.ArrowStreamReader
 import org.genspectrum.lapis.config.DatabaseConfig
@@ -29,7 +30,6 @@ import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.stream.Stream
-import java.util.stream.StreamSupport
 
 @Component
 class SiloClient(
@@ -91,6 +91,7 @@ open class CachedSiloClient(
     private val requestIdContext: RequestIdContext,
     private val requestContext: RequestContext,
     private val config: DatabaseConfig,
+    private val rootAllocator: RootAllocator,
 ) {
     private val httpClient = HttpClient.newBuilder()
         // Create our own thread pool explicitly to not use the ForkJoinPool.commonPool()
@@ -129,8 +130,13 @@ open class CachedSiloClient(
                 .POST(HttpRequest.BodyPublishers.ofString(queryJson))
         }
 
+        val childAllocator = rootAllocator.newChildAllocator(
+            "query-${query.action.javaClass.simpleName}",
+            0,
+            Long.MAX_VALUE,
+        )
         return WithDataVersion(
-            queryResult = parseArrowStream(response.body(), query.action.arrowConverter),
+            queryResult = parseArrowStream(response.body(), query.action.arrowConverter, childAllocator),
             dataVersion = getDataVersion(response),
         )
     }
@@ -138,30 +144,26 @@ open class CachedSiloClient(
     private fun <ResponseType> parseArrowStream(
         inputStream: InputStream,
         converter: ArrowRowConverter<ResponseType>,
-    ): Stream<ResponseType> {
-        val allocator = RootAllocator()
-        val reader = ArrowStreamReader(inputStream, allocator)
-
-        val batches = generateSequence {
-            try {
-                if (reader.loadNextBatch()) reader.vectorSchemaRoot else null
-            } catch (exception: Exception) {
-                val message = "Could not parse Arrow IPC response from SILO: " +
-                    exception::class.toString() + " " + exception.message
-                throw RuntimeException(message, exception)
+        allocator: BufferAllocator,
+    ): Stream<ResponseType> =
+        allocator.use { alloc ->
+            ArrowStreamReader(inputStream, alloc).use { reader ->
+                val rows = mutableListOf<ResponseType>()
+                try {
+                    while (reader.loadNextBatch()) {
+                        val root = reader.vectorSchemaRoot
+                        for (rowIndex in 0 until root.rowCount) {
+                            rows.add(converter(root, rowIndex))
+                        }
+                    }
+                } catch (exception: Exception) {
+                    val message = "Could not parse Arrow IPC response from SILO: " +
+                        exception::class.toString() + " " + exception.message
+                    throw RuntimeException(message, exception)
+                }
+                rows.stream()
             }
         }
-
-        val rowSequence = batches.flatMap { root ->
-            (0 until root.rowCount).asSequence().map { rowIndex -> converter(root, rowIndex) }
-        }
-
-        return StreamSupport.stream(rowSequence.asIterable().spliterator(), false)
-            .onClose {
-                reader.close()
-                allocator.close()
-            }
-    }
 
     fun callInfo(): InfoData {
         val response = send(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -3,7 +3,6 @@ package org.genspectrum.lapis.silo
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.apache.arrow.memory.BufferAllocator
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.ipc.ArrowStreamReader
 import org.genspectrum.lapis.config.DatabaseConfig

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -148,6 +148,7 @@ open class CachedSiloClient(
                 while (reader.loadNextBatch()) {
                     val root = reader.vectorSchemaRoot
                     for (rowIndex in 0 until root.rowCount) {
+                        // make sure that this is lazy and doesn't load the whole response into memory at once
                         yield(action.arrowConverter(root, rowIndex))
                     }
                 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -4,105 +4,24 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.FloatNode
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.LongNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
-import org.apache.arrow.vector.BigIntVector
-import org.apache.arrow.vector.BitVector
-import org.apache.arrow.vector.Float4Vector
-import org.apache.arrow.vector.Float8Vector
-import org.apache.arrow.vector.IntVector
-import org.apache.arrow.vector.VarCharVector
-import org.apache.arrow.vector.VectorSchemaRoot
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
 import org.genspectrum.lapis.response.AggregationData
-import org.genspectrum.lapis.response.COUNT_PROPERTY
 import org.genspectrum.lapis.response.DetailsData
 import org.genspectrum.lapis.response.InsertionData
 import org.genspectrum.lapis.response.MostCommonAncestorData
 import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
-import org.genspectrum.lapis.util.UNALIGNED_PREFIX
 import java.time.LocalDate
 
 data class SiloQuery<ResponseType>(
     val action: SiloAction<ResponseType>,
     val filterExpression: SiloFilterExpression,
 )
-
-/** Converts one row at `rowIndex` from an Arrow [VectorSchemaRoot] to a typed Kotlin object. */
-typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
-
-private fun VectorSchemaRoot.getString(
-    name: String,
-    rowIndex: Int,
-): String? {
-    val vector = getVector(name) as? VarCharVector ?: return null
-    if (vector.isNull(rowIndex)) {
-        return null
-    }
-    return String(vector.get(rowIndex))
-}
-
-private fun VectorSchemaRoot.getInt(
-    name: String,
-    rowIndex: Int,
-): Int? {
-    val vector = getVector(name) as? IntVector ?: return null
-    if (vector.isNull(rowIndex)) {
-        return null
-    }
-    return vector.get(rowIndex)
-}
-
-private fun VectorSchemaRoot.getLong(
-    name: String,
-    rowIndex: Int,
-): Long? {
-    val vector = getVector(name) as? BigIntVector ?: return null
-    if (vector.isNull(rowIndex)) {
-        return null
-    }
-    return vector.get(rowIndex)
-}
-
-private fun VectorSchemaRoot.getDouble(
-    name: String,
-    rowIndex: Int,
-): Double? {
-    val vector = getVector(name) as? Float8Vector ?: return null
-    if (vector.isNull(rowIndex)) {
-        return null
-    }
-    return vector.get(rowIndex)
-}
-
-private fun VectorSchemaRoot.fieldValueAsJsonNode(
-    columnIndex: Int,
-    rowIndex: Int,
-): JsonNode {
-    val vector = fieldVectors[columnIndex]
-    if (vector.isNull(rowIndex)) return NullNode.instance
-    return when (vector) {
-        is VarCharVector -> TextNode(String(vector.get(rowIndex)))
-        is IntVector -> IntNode(vector.get(rowIndex))
-        is BigIntVector -> LongNode(vector.get(rowIndex))
-        is Float8Vector -> DoubleNode(vector.get(rowIndex))
-        is Float4Vector -> FloatNode(vector.get(rowIndex))
-        is BitVector -> BooleanNode.valueOf(vector.get(rowIndex) != 0)
-        else -> TextNode(vector.getObject(rowIndex)?.toString() ?: "")
-    }
-}
 
 interface CommonActionFields {
     val orderByFields: List<OrderByField>
@@ -114,8 +33,8 @@ interface CommonActionFields {
 const val ORDER_BY_RANDOM_FIELD_NAME = "random"
 
 sealed class SiloAction<ResponseType>(
-    @JsonIgnore val cacheable: Boolean,
     @JsonIgnore val arrowConverter: ArrowRowConverter<ResponseType>,
+    @JsonIgnore val cacheable: Boolean,
 ) : CommonActionFields {
     companion object {
         fun aggregated(
@@ -265,18 +184,8 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<AggregationData>(
+            arrowConverter = AGGREGATION_DATA_ARROW_CONVERTER,
             cacheable = true,
-            arrowConverter = { root, rowIndex ->
-                val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
-                val fields = root.schema.fields
-                    .filter { it.name != COUNT_PROPERTY }
-                    .mapIndexed { colIdx, field ->
-                        val actualColIdx = root.schema.fields.indexOfFirst { it.name == field.name }
-                        field.name to root.fieldValueAsJsonNode(actualColIdx, rowIndex)
-                    }
-                    .toMap()
-                AggregationData(count, fields)
-            },
         ) {
         val type: String = "Aggregated"
     }
@@ -290,8 +199,8 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
     ) : SiloAction<MutationData>(
-            cacheable = true,
             arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
+            cacheable = true,
         ) {
         val type: String = "Mutations"
     }
@@ -305,8 +214,8 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
     ) : SiloAction<MutationData>(
-            cacheable = true,
             arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
+            cacheable = true,
         ) {
         val type: String = "AminoAcidMutations"
     }
@@ -319,14 +228,8 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<DetailsData>(
+            arrowConverter = DETAILS_DATA_ARROW_CONVERTER,
             cacheable = false,
-            arrowConverter = { root, rowIndex ->
-                DetailsData(
-                    root.schema.fields.mapIndexed { colIdx, field ->
-                        field.name to root.fieldValueAsJsonNode(colIdx, rowIndex)
-                    }.toMap(),
-                )
-            },
         ) {
         val type: String = "Details"
     }
@@ -338,8 +241,8 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<InsertionData>(
-            cacheable = true,
             arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
+            cacheable = true,
         ) {
         val type: String = "Insertions"
     }
@@ -353,14 +256,8 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
     ) : SiloAction<MostCommonAncestorData>(
+            arrowConverter = MOST_COMMON_ANCESTOR_DATA_ARROW_CONVERTER,
             cacheable = true,
-            arrowConverter = { root, rowIndex ->
-                MostCommonAncestorData(
-                    mrcaNode = root.getString("mrcaNode", rowIndex),
-                    missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
-                    missingFromTree = root.getString("missingFromTree", rowIndex),
-                )
-            },
         ) {
         val type: String = "MostRecentCommonAncestor"
     }
@@ -374,14 +271,8 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
     ) : SiloAction<PhyloSubtreeData>(
+            arrowConverter = PHYLO_SUBTREE_DATA_ARROW_CONVERTER,
             cacheable = true,
-            arrowConverter = { root, rowIndex ->
-                PhyloSubtreeData(
-                    subtreeNewick = root.getString("subtreeNewick", rowIndex) ?: "",
-                    missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
-                    missingFromTree = root.getString("missingFromTree", rowIndex),
-                )
-            },
         ) {
         val type: String = "PhyloSubtree"
     }
@@ -393,8 +284,8 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<InsertionData>(
-            cacheable = true,
             arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
+            cacheable = true,
         ) {
         val type: String = "AminoAcidInsertions"
     }
@@ -409,40 +300,9 @@ sealed class SiloAction<ResponseType>(
         val sequenceNames: List<String>,
         val additionalFields: List<String> = emptyList(),
     ) : SiloAction<SequenceData>(
+            arrowConverter = SEQUENCE_DATA_ARROW_CONVERTER,
             cacheable = false,
-            arrowConverter = { root, rowIndex ->
-                SequenceData(
-                    root.schema.fields
-                        .mapIndexed { colIdx, field ->
-                            field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
-                        }
-                        .toMap(),
-                )
-            },
         )
-}
-
-private val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, rowIndex ->
-    MutationData(
-        mutation = root.getString("mutation", rowIndex),
-        count = root.getInt("count", rowIndex),
-        proportion = root.getDouble("proportion", rowIndex),
-        sequenceName = root.getString("sequenceName", rowIndex),
-        mutationFrom = root.getString("mutationFrom", rowIndex),
-        mutationTo = root.getString("mutationTo", rowIndex),
-        position = root.getInt("position", rowIndex),
-        coverage = root.getInt("coverage", rowIndex),
-    )
-}
-
-private val INSERTION_DATA_ARROW_CONVERTER: ArrowRowConverter<InsertionData> = { root, rowIndex ->
-    InsertionData(
-        count = root.getInt("count", rowIndex) ?: 0,
-        insertion = root.getString("insertion", rowIndex) ?: "",
-        insertedSymbols = root.getString("insertedSymbols", rowIndex) ?: "",
-        position = root.getInt("position", rowIndex) ?: 0,
-        sequenceName = root.getString("sequenceName", rowIndex) ?: "",
-    )
 }
 
 sealed class SiloFilterExpression(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -41,7 +41,7 @@ data class SiloQuery<ResponseType>(
     val filterExpression: SiloFilterExpression,
 )
 
-/** Converts one row at [rowIndex] from an Arrow [VectorSchemaRoot] to a typed Kotlin object. */
+/** Converts one row at `rowIndex` from an Arrow [VectorSchemaRoot] to a typed Kotlin object. */
 typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
 
 private fun VectorSchemaRoot.getString(
@@ -49,7 +49,9 @@ private fun VectorSchemaRoot.getString(
     rowIndex: Int,
 ): String? {
     val vector = getVector(name) as? VarCharVector ?: return null
-    if (vector.isNull(rowIndex)) return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
     return String(vector.get(rowIndex))
 }
 
@@ -58,7 +60,9 @@ private fun VectorSchemaRoot.getInt(
     rowIndex: Int,
 ): Int? {
     val vector = getVector(name) as? IntVector ?: return null
-    if (vector.isNull(rowIndex)) return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
     return vector.get(rowIndex)
 }
 
@@ -67,7 +71,9 @@ private fun VectorSchemaRoot.getLong(
     rowIndex: Int,
 ): Long? {
     val vector = getVector(name) as? BigIntVector ?: return null
-    if (vector.isNull(rowIndex)) return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
     return vector.get(rowIndex)
 }
 
@@ -76,7 +82,9 @@ private fun VectorSchemaRoot.getDouble(
     rowIndex: Int,
 ): Double? {
     val vector = getVector(name) as? Float8Vector ?: return null
-    if (vector.isNull(rowIndex)) return null
+    if (vector.isNull(rowIndex)) {
+        return null
+    }
     return vector.get(rowIndex)
 }
 
@@ -84,7 +92,7 @@ private fun VectorSchemaRoot.fieldValueAsJsonNode(
     columnIndex: Int,
     rowIndex: Int,
 ): JsonNode {
-    val vector = getFieldVectors()[columnIndex]
+    val vector = fieldVectors[columnIndex]
     if (vector.isNull(rowIndex)) return NullNode.instance
     return when (vector) {
         is VarCharVector -> TextNode(String(vector.get(rowIndex)))

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -5,24 +5,82 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.node.BooleanNode
+import com.fasterxml.jackson.databind.node.DoubleNode
+import com.fasterxml.jackson.databind.node.FloatNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.LongNode
+import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.BitVector
+import org.apache.arrow.vector.Float4Vector
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.VectorSchemaRoot
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
 import org.genspectrum.lapis.response.AggregationData
+import org.genspectrum.lapis.response.COUNT_PROPERTY
 import org.genspectrum.lapis.response.DetailsData
 import org.genspectrum.lapis.response.InsertionData
 import org.genspectrum.lapis.response.MostCommonAncestorData
 import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
+import org.genspectrum.lapis.util.UNALIGNED_PREFIX
 import java.time.LocalDate
 
 data class SiloQuery<ResponseType>(
     val action: SiloAction<ResponseType>,
     val filterExpression: SiloFilterExpression,
 )
+
+/** Converts one row at [rowIndex] from an Arrow [VectorSchemaRoot] to a typed Kotlin object. */
+typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
+
+private fun VectorSchemaRoot.getString(name: String, rowIndex: Int): String? {
+    val vector = getVector(name) as? VarCharVector ?: return null
+    if (vector.isNull(rowIndex)) return null
+    return String(vector.get(rowIndex))
+}
+
+private fun VectorSchemaRoot.getInt(name: String, rowIndex: Int): Int? {
+    val vector = getVector(name) as? IntVector ?: return null
+    if (vector.isNull(rowIndex)) return null
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.getLong(name: String, rowIndex: Int): Long? {
+    val vector = getVector(name) as? BigIntVector ?: return null
+    if (vector.isNull(rowIndex)) return null
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.getDouble(name: String, rowIndex: Int): Double? {
+    val vector = getVector(name) as? Float8Vector ?: return null
+    if (vector.isNull(rowIndex)) return null
+    return vector.get(rowIndex)
+}
+
+private fun VectorSchemaRoot.fieldValueAsJsonNode(columnIndex: Int, rowIndex: Int): JsonNode {
+    val vector = getFieldVectors()[columnIndex]
+    if (vector.isNull(rowIndex)) return NullNode.instance
+    return when (vector) {
+        is VarCharVector -> TextNode(String(vector.get(rowIndex)))
+        is IntVector -> IntNode(vector.get(rowIndex))
+        is BigIntVector -> LongNode(vector.get(rowIndex))
+        is Float8Vector -> DoubleNode(vector.get(rowIndex))
+        is Float4Vector -> FloatNode(vector.get(rowIndex))
+        is BitVector -> BooleanNode.valueOf(vector.get(rowIndex) != 0)
+        else -> TextNode(vector.getObject(rowIndex)?.toString() ?: "")
+    }
+}
 
 class AggregationDataTypeReference : TypeReference<AggregationData>()
 
@@ -52,6 +110,7 @@ const val ORDER_BY_RANDOM_FIELD_NAME = "random"
 sealed class SiloAction<ResponseType>(
     @JsonIgnore val typeReference: TypeReference<ResponseType>,
     @JsonIgnore val cacheable: Boolean,
+    @JsonIgnore val arrowConverter: ArrowRowConverter<ResponseType>,
 ) : CommonActionFields {
     companion object {
         fun aggregated(
@@ -196,7 +255,21 @@ sealed class SiloAction<ResponseType>(
         override val randomize: RandomizeConfig? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-    ) : SiloAction<AggregationData>(AggregationDataTypeReference(), cacheable = true) {
+    ) : SiloAction<AggregationData>(
+        typeReference = AggregationDataTypeReference(),
+        cacheable = true,
+        arrowConverter = { root, rowIndex ->
+            val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
+            val fields = root.schema.fields
+                .filter { it.name != COUNT_PROPERTY }
+                .mapIndexed { colIdx, field ->
+                    val actualColIdx = root.schema.fields.indexOfFirst { it.name == field.name }
+                    field.name to root.fieldValueAsJsonNode(actualColIdx, rowIndex)
+                }
+                .toMap()
+            AggregationData(count, fields)
+        },
+    ) {
         val type: String = "Aggregated"
     }
 
@@ -208,7 +281,11 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
-    ) : SiloAction<MutationData>(MutationDataTypeReference(), cacheable = true) {
+    ) : SiloAction<MutationData>(
+        typeReference = MutationDataTypeReference(),
+        cacheable = true,
+        arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
+    ) {
         val type: String = "Mutations"
     }
 
@@ -220,7 +297,11 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
-    ) : SiloAction<MutationData>(AminoAcidMutationDataTypeReference(), cacheable = true) {
+    ) : SiloAction<MutationData>(
+        typeReference = AminoAcidMutationDataTypeReference(),
+        cacheable = true,
+        arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
+    ) {
         val type: String = "AminoAcidMutations"
     }
 
@@ -231,7 +312,17 @@ sealed class SiloAction<ResponseType>(
         override val randomize: RandomizeConfig? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-    ) : SiloAction<DetailsData>(DetailsDataTypeReference(), cacheable = false) {
+    ) : SiloAction<DetailsData>(
+        typeReference = DetailsDataTypeReference(),
+        cacheable = false,
+        arrowConverter = { root, rowIndex ->
+            DetailsData(
+                root.schema.fields.mapIndexed { colIdx, field ->
+                    field.name to root.fieldValueAsJsonNode(colIdx, rowIndex)
+                }.toMap(),
+            )
+        },
+    ) {
         val type: String = "Details"
     }
 
@@ -241,7 +332,11 @@ sealed class SiloAction<ResponseType>(
         override val randomize: RandomizeConfig? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-    ) : SiloAction<InsertionData>(InsertionDataTypeReference(), cacheable = true) {
+    ) : SiloAction<InsertionData>(
+        typeReference = InsertionDataTypeReference(),
+        cacheable = true,
+        arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
+    ) {
         val type: String = "Insertions"
     }
 
@@ -253,7 +348,17 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
-    ) : SiloAction<MostCommonAncestorData>(MostCommonAncestorDataTypeReference(), cacheable = true) {
+    ) : SiloAction<MostCommonAncestorData>(
+        typeReference = MostCommonAncestorDataTypeReference(),
+        cacheable = true,
+        arrowConverter = { root, rowIndex ->
+            MostCommonAncestorData(
+                mrcaNode = root.getString("mrcaNode", rowIndex),
+                missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
+                missingFromTree = root.getString("missingFromTree", rowIndex),
+            )
+        },
+    ) {
         val type: String = "MostRecentCommonAncestor"
     }
 
@@ -265,7 +370,17 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
-    ) : SiloAction<PhyloSubtreeData>(PhyloSubtreeDataTypeReference(), cacheable = true) {
+    ) : SiloAction<PhyloSubtreeData>(
+        typeReference = PhyloSubtreeDataTypeReference(),
+        cacheable = true,
+        arrowConverter = { root, rowIndex ->
+            PhyloSubtreeData(
+                subtreeNewick = root.getString("subtreeNewick", rowIndex) ?: "",
+                missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
+                missingFromTree = root.getString("missingFromTree", rowIndex),
+            )
+        },
+    ) {
         val type: String = "PhyloSubtree"
     }
 
@@ -275,7 +390,11 @@ sealed class SiloAction<ResponseType>(
         override val randomize: RandomizeConfig? = null,
         override val limit: Int? = null,
         override val offset: Int? = null,
-    ) : SiloAction<InsertionData>(InsertionDataTypeReference(), cacheable = true) {
+    ) : SiloAction<InsertionData>(
+        typeReference = InsertionDataTypeReference(),
+        cacheable = true,
+        arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
+    ) {
         val type: String = "AminoAcidInsertions"
     }
 
@@ -288,7 +407,40 @@ sealed class SiloAction<ResponseType>(
         val type: SequenceType,
         val sequenceNames: List<String>,
         val additionalFields: List<String> = emptyList(),
-    ) : SiloAction<SequenceData>(SequenceDataTypeReference(), cacheable = false)
+    ) : SiloAction<SequenceData>(
+        typeReference = SequenceDataTypeReference(),
+        cacheable = false,
+        arrowConverter = { root, rowIndex ->
+            SequenceData(
+                root.schema.fields.mapIndexed { colIdx, field ->
+                    field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
+                }.toMap(),
+            )
+        },
+    )
+}
+
+private val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, rowIndex ->
+    MutationData(
+        mutation = root.getString("mutation", rowIndex),
+        count = root.getInt("count", rowIndex),
+        proportion = root.getDouble("proportion", rowIndex),
+        sequenceName = root.getString("sequenceName", rowIndex),
+        mutationFrom = root.getString("mutationFrom", rowIndex),
+        mutationTo = root.getString("mutationTo", rowIndex),
+        position = root.getInt("position", rowIndex),
+        coverage = root.getInt("coverage", rowIndex),
+    )
+}
+
+private val INSERTION_DATA_ARROW_CONVERTER: ArrowRowConverter<InsertionData> = { root, rowIndex ->
+    InsertionData(
+        count = root.getInt("count", rowIndex) ?: 0,
+        insertion = root.getString("insertion", rowIndex) ?: "",
+        insertedSymbols = root.getString("insertedSymbols", rowIndex) ?: "",
+        position = root.getInt("position", rowIndex) ?: 0,
+        sequenceName = root.getString("sequenceName", rowIndex) ?: "",
+    )
 }
 
 sealed class SiloFilterExpression(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
@@ -105,22 +104,6 @@ private fun VectorSchemaRoot.fieldValueAsJsonNode(
     }
 }
 
-class AggregationDataTypeReference : TypeReference<AggregationData>()
-
-class MutationDataTypeReference : TypeReference<MutationData>()
-
-class AminoAcidMutationDataTypeReference : TypeReference<MutationData>()
-
-class DetailsDataTypeReference : TypeReference<DetailsData>()
-
-class InsertionDataTypeReference : TypeReference<InsertionData>()
-
-class SequenceDataTypeReference : TypeReference<SequenceData>()
-
-class MostCommonAncestorDataTypeReference : TypeReference<MostCommonAncestorData>()
-
-class PhyloSubtreeDataTypeReference : TypeReference<PhyloSubtreeData>()
-
 interface CommonActionFields {
     val orderByFields: List<OrderByField>
     val limit: Int?
@@ -131,7 +114,6 @@ interface CommonActionFields {
 const val ORDER_BY_RANDOM_FIELD_NAME = "random"
 
 sealed class SiloAction<ResponseType>(
-    @JsonIgnore val typeReference: TypeReference<ResponseType>,
     @JsonIgnore val cacheable: Boolean,
     @JsonIgnore val arrowConverter: ArrowRowConverter<ResponseType>,
 ) : CommonActionFields {
@@ -258,10 +240,14 @@ sealed class SiloAction<ResponseType>(
 
         private fun getRandomize(orderByFields: OrderBySpec): RandomizeConfig =
             when (orderByFields) {
-                is OrderBySpec.ByFields -> RandomizeConfig.Disabled
-                is OrderBySpec.Random ->
+                is OrderBySpec.ByFields -> {
+                    RandomizeConfig.Disabled
+                }
+
+                is OrderBySpec.Random -> {
                     orderByFields.seed?.let { RandomizeConfig.WithSeed(it) }
                         ?: RandomizeConfig.Enabled
+                }
             }
 
         private fun getOrderByFieldsList(orderByFields: OrderBySpec): List<OrderByField> =
@@ -279,7 +265,6 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<AggregationData>(
-            typeReference = AggregationDataTypeReference(),
             cacheable = true,
             arrowConverter = { root, rowIndex ->
                 val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
@@ -305,7 +290,6 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
     ) : SiloAction<MutationData>(
-            typeReference = MutationDataTypeReference(),
             cacheable = true,
             arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
         ) {
@@ -321,7 +305,6 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
     ) : SiloAction<MutationData>(
-            typeReference = AminoAcidMutationDataTypeReference(),
             cacheable = true,
             arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
         ) {
@@ -336,7 +319,6 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<DetailsData>(
-            typeReference = DetailsDataTypeReference(),
             cacheable = false,
             arrowConverter = { root, rowIndex ->
                 DetailsData(
@@ -356,7 +338,6 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<InsertionData>(
-            typeReference = InsertionDataTypeReference(),
             cacheable = true,
             arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
         ) {
@@ -372,7 +353,6 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
     ) : SiloAction<MostCommonAncestorData>(
-            typeReference = MostCommonAncestorDataTypeReference(),
             cacheable = true,
             arrowConverter = { root, rowIndex ->
                 MostCommonAncestorData(
@@ -394,7 +374,6 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
     ) : SiloAction<PhyloSubtreeData>(
-            typeReference = PhyloSubtreeDataTypeReference(),
             cacheable = true,
             arrowConverter = { root, rowIndex ->
                 PhyloSubtreeData(
@@ -414,7 +393,6 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<InsertionData>(
-            typeReference = InsertionDataTypeReference(),
             cacheable = true,
             arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
         ) {
@@ -431,13 +409,14 @@ sealed class SiloAction<ResponseType>(
         val sequenceNames: List<String>,
         val additionalFields: List<String> = emptyList(),
     ) : SiloAction<SequenceData>(
-            typeReference = SequenceDataTypeReference(),
             cacheable = false,
             arrowConverter = { root, rowIndex ->
                 SequenceData(
-                    root.schema.fields.mapIndexed { colIdx, field ->
-                        field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
-                    }.toMap(),
+                    root.schema.fields
+                        .mapIndexed { colIdx, field ->
+                            field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
+                        }
+                        .toMap(),
                 )
             },
         )
@@ -625,8 +604,14 @@ class RandomizeConfigSerializer : JsonSerializer<RandomizeConfig>() {
         serializers: SerializerProvider,
     ) {
         when (value) {
-            is RandomizeConfig.Enabled -> gen.writeBoolean(true)
-            is RandomizeConfig.Disabled -> gen.writeBoolean(false)
+            is RandomizeConfig.Enabled -> {
+                gen.writeBoolean(true)
+            }
+
+            is RandomizeConfig.Disabled -> {
+                gen.writeBoolean(false)
+            }
+
             is RandomizeConfig.WithSeed -> {
                 gen.writeStartObject()
                 gen.writeNumberField("seed", value.seed)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -44,31 +44,46 @@ data class SiloQuery<ResponseType>(
 /** Converts one row at [rowIndex] from an Arrow [VectorSchemaRoot] to a typed Kotlin object. */
 typealias ArrowRowConverter<T> = (root: VectorSchemaRoot, rowIndex: Int) -> T
 
-private fun VectorSchemaRoot.getString(name: String, rowIndex: Int): String? {
+private fun VectorSchemaRoot.getString(
+    name: String,
+    rowIndex: Int,
+): String? {
     val vector = getVector(name) as? VarCharVector ?: return null
     if (vector.isNull(rowIndex)) return null
     return String(vector.get(rowIndex))
 }
 
-private fun VectorSchemaRoot.getInt(name: String, rowIndex: Int): Int? {
+private fun VectorSchemaRoot.getInt(
+    name: String,
+    rowIndex: Int,
+): Int? {
     val vector = getVector(name) as? IntVector ?: return null
     if (vector.isNull(rowIndex)) return null
     return vector.get(rowIndex)
 }
 
-private fun VectorSchemaRoot.getLong(name: String, rowIndex: Int): Long? {
+private fun VectorSchemaRoot.getLong(
+    name: String,
+    rowIndex: Int,
+): Long? {
     val vector = getVector(name) as? BigIntVector ?: return null
     if (vector.isNull(rowIndex)) return null
     return vector.get(rowIndex)
 }
 
-private fun VectorSchemaRoot.getDouble(name: String, rowIndex: Int): Double? {
+private fun VectorSchemaRoot.getDouble(
+    name: String,
+    rowIndex: Int,
+): Double? {
     val vector = getVector(name) as? Float8Vector ?: return null
     if (vector.isNull(rowIndex)) return null
     return vector.get(rowIndex)
 }
 
-private fun VectorSchemaRoot.fieldValueAsJsonNode(columnIndex: Int, rowIndex: Int): JsonNode {
+private fun VectorSchemaRoot.fieldValueAsJsonNode(
+    columnIndex: Int,
+    rowIndex: Int,
+): JsonNode {
     val vector = getFieldVectors()[columnIndex]
     if (vector.isNull(rowIndex)) return NullNode.instance
     return when (vector) {
@@ -256,20 +271,20 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<AggregationData>(
-        typeReference = AggregationDataTypeReference(),
-        cacheable = true,
-        arrowConverter = { root, rowIndex ->
-            val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
-            val fields = root.schema.fields
-                .filter { it.name != COUNT_PROPERTY }
-                .mapIndexed { colIdx, field ->
-                    val actualColIdx = root.schema.fields.indexOfFirst { it.name == field.name }
-                    field.name to root.fieldValueAsJsonNode(actualColIdx, rowIndex)
-                }
-                .toMap()
-            AggregationData(count, fields)
-        },
-    ) {
+            typeReference = AggregationDataTypeReference(),
+            cacheable = true,
+            arrowConverter = { root, rowIndex ->
+                val count = root.getLong(COUNT_PROPERTY, rowIndex)?.toInt() ?: 0
+                val fields = root.schema.fields
+                    .filter { it.name != COUNT_PROPERTY }
+                    .mapIndexed { colIdx, field ->
+                        val actualColIdx = root.schema.fields.indexOfFirst { it.name == field.name }
+                        field.name to root.fieldValueAsJsonNode(actualColIdx, rowIndex)
+                    }
+                    .toMap()
+                AggregationData(count, fields)
+            },
+        ) {
         val type: String = "Aggregated"
     }
 
@@ -282,10 +297,10 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
     ) : SiloAction<MutationData>(
-        typeReference = MutationDataTypeReference(),
-        cacheable = true,
-        arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
-    ) {
+            typeReference = MutationDataTypeReference(),
+            cacheable = true,
+            arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
+        ) {
         val type: String = "Mutations"
     }
 
@@ -298,10 +313,10 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         val fields: List<String> = emptyList(),
     ) : SiloAction<MutationData>(
-        typeReference = AminoAcidMutationDataTypeReference(),
-        cacheable = true,
-        arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
-    ) {
+            typeReference = AminoAcidMutationDataTypeReference(),
+            cacheable = true,
+            arrowConverter = MUTATION_DATA_ARROW_CONVERTER,
+        ) {
         val type: String = "AminoAcidMutations"
     }
 
@@ -313,16 +328,16 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<DetailsData>(
-        typeReference = DetailsDataTypeReference(),
-        cacheable = false,
-        arrowConverter = { root, rowIndex ->
-            DetailsData(
-                root.schema.fields.mapIndexed { colIdx, field ->
-                    field.name to root.fieldValueAsJsonNode(colIdx, rowIndex)
-                }.toMap(),
-            )
-        },
-    ) {
+            typeReference = DetailsDataTypeReference(),
+            cacheable = false,
+            arrowConverter = { root, rowIndex ->
+                DetailsData(
+                    root.schema.fields.mapIndexed { colIdx, field ->
+                        field.name to root.fieldValueAsJsonNode(colIdx, rowIndex)
+                    }.toMap(),
+                )
+            },
+        ) {
         val type: String = "Details"
     }
 
@@ -333,10 +348,10 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<InsertionData>(
-        typeReference = InsertionDataTypeReference(),
-        cacheable = true,
-        arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
-    ) {
+            typeReference = InsertionDataTypeReference(),
+            cacheable = true,
+            arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
+        ) {
         val type: String = "Insertions"
     }
 
@@ -349,16 +364,16 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
     ) : SiloAction<MostCommonAncestorData>(
-        typeReference = MostCommonAncestorDataTypeReference(),
-        cacheable = true,
-        arrowConverter = { root, rowIndex ->
-            MostCommonAncestorData(
-                mrcaNode = root.getString("mrcaNode", rowIndex),
-                missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
-                missingFromTree = root.getString("missingFromTree", rowIndex),
-            )
-        },
-    ) {
+            typeReference = MostCommonAncestorDataTypeReference(),
+            cacheable = true,
+            arrowConverter = { root, rowIndex ->
+                MostCommonAncestorData(
+                    mrcaNode = root.getString("mrcaNode", rowIndex),
+                    missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
+                    missingFromTree = root.getString("missingFromTree", rowIndex),
+                )
+            },
+        ) {
         val type: String = "MostRecentCommonAncestor"
     }
 
@@ -371,16 +386,16 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
         override val randomize: RandomizeConfig? = null,
     ) : SiloAction<PhyloSubtreeData>(
-        typeReference = PhyloSubtreeDataTypeReference(),
-        cacheable = true,
-        arrowConverter = { root, rowIndex ->
-            PhyloSubtreeData(
-                subtreeNewick = root.getString("subtreeNewick", rowIndex) ?: "",
-                missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
-                missingFromTree = root.getString("missingFromTree", rowIndex),
-            )
-        },
-    ) {
+            typeReference = PhyloSubtreeDataTypeReference(),
+            cacheable = true,
+            arrowConverter = { root, rowIndex ->
+                PhyloSubtreeData(
+                    subtreeNewick = root.getString("subtreeNewick", rowIndex) ?: "",
+                    missingNodeCount = root.getInt("missingNodeCount", rowIndex) ?: 0,
+                    missingFromTree = root.getString("missingFromTree", rowIndex),
+                )
+            },
+        ) {
         val type: String = "PhyloSubtree"
     }
 
@@ -391,10 +406,10 @@ sealed class SiloAction<ResponseType>(
         override val limit: Int? = null,
         override val offset: Int? = null,
     ) : SiloAction<InsertionData>(
-        typeReference = InsertionDataTypeReference(),
-        cacheable = true,
-        arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
-    ) {
+            typeReference = InsertionDataTypeReference(),
+            cacheable = true,
+            arrowConverter = INSERTION_DATA_ARROW_CONVERTER,
+        ) {
         val type: String = "AminoAcidInsertions"
     }
 
@@ -408,16 +423,16 @@ sealed class SiloAction<ResponseType>(
         val sequenceNames: List<String>,
         val additionalFields: List<String> = emptyList(),
     ) : SiloAction<SequenceData>(
-        typeReference = SequenceDataTypeReference(),
-        cacheable = false,
-        arrowConverter = { root, rowIndex ->
-            SequenceData(
-                root.schema.fields.mapIndexed { colIdx, field ->
-                    field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
-                }.toMap(),
-            )
-        },
-    )
+            typeReference = SequenceDataTypeReference(),
+            cacheable = false,
+            arrowConverter = { root, rowIndex ->
+                SequenceData(
+                    root.schema.fields.mapIndexed { colIdx, field ->
+                        field.name.removePrefix(UNALIGNED_PREFIX) to root.fieldValueAsJsonNode(colIdx, rowIndex)
+                    }.toMap(),
+                )
+            },
+        )
 }
 
 private val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, rowIndex ->

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
@@ -186,7 +186,7 @@ AminoAcidMutationsOverTimeModelTest {
         )
         assertThat(
             result.totalCountsByDateRange,
-            equalTo(listOf(10, 23)),
+            equalTo(listOf(10L, 23L)),
         )
         assertThat(dataVersion.dataVersion, notNullValue())
     }
@@ -235,7 +235,7 @@ AminoAcidMutationsOverTimeModelTest {
                 ),
             ),
         )
-        assertThat(result.totalCountsByDateRange, equalTo(listOf(0, 0)))
+        assertThat(result.totalCountsByDateRange, equalTo(listOf(0L, 0L)))
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -185,7 +185,7 @@ class NucleotideMutationsOverTimeModelTest {
         )
         assertThat(
             result.totalCountsByDateRange,
-            equalTo(listOf(10, 23)),
+            equalTo(listOf(10L, 23L)),
         )
         assertThat(dataVersion.dataVersion, notNullValue())
     }
@@ -236,7 +236,7 @@ class NucleotideMutationsOverTimeModelTest {
         )
         assertThat(
             result.totalCountsByDateRange,
-            equalTo(listOf(0, 0)),
+            equalTo(listOf(0L, 0L)),
         )
     }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModelTest.kt
@@ -211,7 +211,7 @@ class QueriesOverTimeModelTest {
         )
         assertThat(
             result.totalCountsByDateRange,
-            equalTo(listOf(10, 23)),
+            equalTo(listOf(10L, 23L)),
         )
         assertThat(dataVersion.dataVersion, notNullValue())
     }
@@ -267,7 +267,7 @@ class QueriesOverTimeModelTest {
         )
         assertThat(
             result.totalCountsByDateRange,
-            equalTo(listOf(0, 0)),
+            equalTo(listOf(0L, 0L)),
         )
     }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
@@ -1,0 +1,100 @@
+package org.genspectrum.lapis.silo
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.BigIntVector
+import org.apache.arrow.vector.BitVector
+import org.apache.arrow.vector.Float8Vector
+import org.apache.arrow.vector.IntVector
+import org.apache.arrow.vector.VarCharVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.arrow.vector.types.pojo.Field
+import org.apache.arrow.vector.types.pojo.FieldType
+import org.apache.arrow.vector.types.pojo.Schema
+import java.io.ByteArrayOutputStream
+import java.nio.channels.Channels
+
+/**
+ * Builds an Arrow IPC stream byte array from [rows] using the given [schemaAndRows] builder.
+ *
+ * Usage:
+ * ```
+ * buildArrowIpcStream(
+ *     listOf(mapOf("count" to 6L, "division" to "Aargau"))
+ * )
+ * ```
+ * Each row is a map of column name to value. All rows must have the same keys.
+ * Supported value types: Long (int64), Int (int32), Double (float64), String, Boolean, null.
+ */
+fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
+    if (rows.isEmpty()) {
+        return buildEmptyArrowIpcStream()
+    }
+
+    val sampleRow = rows.first()
+    val allocator = RootAllocator()
+
+    val fields = sampleRow.entries.map { (name, value) ->
+        when (value) {
+            is Long -> Field(name, FieldType.nullable(ArrowType.Int(64, true)), null)
+            is Int -> Field(name, FieldType.nullable(ArrowType.Int(32, true)), null)
+            is Double -> Field(name, FieldType.nullable(ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE)), null)
+            is Boolean -> Field(name, FieldType.nullable(ArrowType.Bool()), null)
+            else -> Field(name, FieldType.nullable(ArrowType.Utf8()), null)
+        }
+    }
+
+    val schema = Schema(fields)
+    val root = VectorSchemaRoot.create(schema, allocator)
+
+    root.allocateNew()
+    root.rowCount = rows.size
+
+    rows.forEachIndexed { rowIdx, row ->
+        sampleRow.keys.forEachIndexed { colIdx, colName ->
+            val value = row[colName]
+            when (val vector = root.getVector(colIdx)) {
+                is BigIntVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Long)
+                is IntVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Int)
+                is Float8Vector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Double)
+                is BitVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, if (value as Boolean) 1 else 0)
+                is VarCharVector ->
+                    if (value == null) {
+                        vector.setNull(rowIdx)
+                    } else {
+                        vector.setSafe(rowIdx, (value as String).toByteArray())
+                    }
+            }
+        }
+    }
+
+    root.setRowCount(rows.size)
+
+    val outputStream = ByteArrayOutputStream()
+    val writer = ArrowStreamWriter(root, null, Channels.newChannel(outputStream))
+    writer.start()
+    writer.writeBatch()
+    writer.end()
+    writer.close()
+    root.close()
+    allocator.close()
+
+    return outputStream.toByteArray()
+}
+
+private fun buildEmptyArrowIpcStream(): ByteArray {
+    val allocator = RootAllocator()
+    val schema = Schema(emptyList())
+    val root = VectorSchemaRoot.create(schema, allocator)
+
+    val outputStream = ByteArrayOutputStream()
+    val writer = ArrowStreamWriter(root, null, Channels.newChannel(outputStream))
+    writer.start()
+    writer.end()
+    writer.close()
+    root.close()
+    allocator.close()
+
+    return outputStream.toByteArray()
+}

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
@@ -108,8 +108,6 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
         }
     }
 
-    root.setRowCount(rows.size)
-
     val outputStream = ByteArrayOutputStream()
     val writer = ArrowStreamWriter(root, null, Channels.newChannel(outputStream))
     writer.start()

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
@@ -39,7 +39,13 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
         when (value) {
             is Long -> Field(name, FieldType.nullable(ArrowType.Int(64, true)), null)
             is Int -> Field(name, FieldType.nullable(ArrowType.Int(32, true)), null)
-            is Double -> Field(name, FieldType.nullable(ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE)), null)
+            is Double -> Field(
+                name,
+                FieldType.nullable(
+                    ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE),
+                ),
+                null,
+            )
             is Boolean -> Field(name, FieldType.nullable(ArrowType.Bool()), null)
             else -> Field(name, FieldType.nullable(ArrowType.Utf8()), null)
         }
@@ -58,7 +64,13 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
                 is BigIntVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Long)
                 is IntVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Int)
                 is Float8Vector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Double)
-                is BitVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, if (value as Boolean) 1 else 0)
+                is BitVector -> if (value ==
+                    null
+                ) {
+                    vector.setNull(rowIdx)
+                } else {
+                    vector.set(rowIdx, if (value as Boolean) 1 else 0)
+                }
                 is VarCharVector ->
                     if (value == null) {
                         vector.setNull(rowIdx)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
@@ -51,6 +51,10 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
 
             is Boolean -> Field(name, FieldType.nullable(ArrowType.Bool()), null)
 
+            // Note: null values (and any unrecognized types) are typed as Utf8.
+            // If the first row has null for a column that later rows fill with a typed value (e.g. Int, Long),
+            // the column will be inferred as Utf8 and the converter will throw a cast error at runtime.
+            // Avoid this in tests by ensuring the first row contains non-null values for all typed columns.
             else -> Field(name, FieldType.nullable(ArrowType.Utf8()), null)
         }
     }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
@@ -16,7 +16,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.channels.Channels
 
 /**
- * Builds an Arrow IPC stream byte array from [rows] using the given [schemaAndRows] builder.
+ * Builds an Arrow IPC stream byte array from [rows] using the given builder.
  *
  * Usage:
  * ```
@@ -38,7 +38,9 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
     val fields = sampleRow.entries.map { (name, value) ->
         when (value) {
             is Long -> Field(name, FieldType.nullable(ArrowType.Int(64, true)), null)
+
             is Int -> Field(name, FieldType.nullable(ArrowType.Int(32, true)), null)
+
             is Double -> Field(
                 name,
                 FieldType.nullable(
@@ -46,7 +48,9 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
                 ),
                 null,
             )
+
             is Boolean -> Field(name, FieldType.nullable(ArrowType.Bool()), null)
+
             else -> Field(name, FieldType.nullable(ArrowType.Utf8()), null)
         }
     }
@@ -61,22 +65,45 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
         sampleRow.keys.forEachIndexed { colIdx, colName ->
             val value = row[colName]
             when (val vector = root.getVector(colIdx)) {
-                is BigIntVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Long)
-                is IntVector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Int)
-                is Float8Vector -> if (value == null) vector.setNull(rowIdx) else vector.set(rowIdx, value as Double)
-                is BitVector -> if (value ==
-                    null
-                ) {
-                    vector.setNull(rowIdx)
-                } else {
-                    vector.set(rowIdx, if (value as Boolean) 1 else 0)
+                is BigIntVector -> {
+                    if (value == null) {
+                        vector.setNull(rowIdx)
+                    } else {
+                        vector.set(rowIdx, value as Long)
+                    }
                 }
-                is VarCharVector ->
+
+                is IntVector -> {
+                    if (value == null) {
+                        vector.setNull(rowIdx)
+                    } else {
+                        vector.set(rowIdx, value as Int)
+                    }
+                }
+
+                is Float8Vector -> {
+                    if (value == null) {
+                        vector.setNull(rowIdx)
+                    } else {
+                        vector.set(rowIdx, value as Double)
+                    }
+                }
+
+                is BitVector -> {
+                    if (value == null) {
+                        vector.setNull(rowIdx)
+                    } else {
+                        vector.set(rowIdx, if (value as Boolean) 1 else 0)
+                    }
+                }
+
+                is VarCharVector -> {
                     if (value == null) {
                         vector.setNull(rowIdx)
                     } else {
                         vector.setSafe(rowIdx, (value as String).toByteArray())
                     }
+                }
             }
         }
     }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/ArrowTestHelper.kt
@@ -101,7 +101,7 @@ fun buildArrowIpcStream(rows: List<Map<String, Any?>>): ByteArray {
                     if (value == null) {
                         vector.setNull(rowIdx)
                     } else {
-                        vector.setSafe(rowIdx, (value as String).toByteArray())
+                        vector.setSafe(rowIdx, (value as String).toByteArray(Charsets.UTF_8))
                     }
                 }
             }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -37,6 +37,7 @@ import org.mockserver.model.HttpRequest.request
 import org.mockserver.model.HttpResponse
 import org.mockserver.model.HttpResponse.response
 import org.mockserver.model.MediaType
+import org.mockserver.model.MediaType.parse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 
@@ -81,12 +82,14 @@ class SiloClientTest(
     fun `GIVEN server returns aggregated response THEN response can be deserialized`() {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-                        {"count": 6,"division": "Aargau"}
-                        {"count": 8,"division": "Basel-Land"}
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf("count" to 6L, "division" to "Aargau"),
+                            mapOf("count" to 8L, "division" to "Basel-Land"),
+                        ),
+                    ),
                 ),
         )
 
@@ -109,12 +112,32 @@ class SiloClientTest(
     fun `GIVEN server returns mutations response THEN response can be deserialized`(action: SiloAction<MutationData>) {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-{"count": 51,"mutation": "C3037T","mutationFrom": "C","mutationTo": "T","position": 3037,"proportion": 1,"sequenceName": "main","coverage":100}
-{"count": 52,"mutation": "C14408T","mutationFrom": "C","mutationTo": "T","position": 14408,"proportion": 1,"sequenceName": "main","coverage":101}
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf(
+                                "mutation" to "C3037T",
+                                "mutationFrom" to "C",
+                                "mutationTo" to "T",
+                                "sequenceName" to "main",
+                                "position" to 3037,
+                                "proportion" to 1.0,
+                                "coverage" to 100,
+                                "count" to 51,
+                            ),
+                            mapOf(
+                                "mutation" to "C14408T",
+                                "mutationFrom" to "C",
+                                "mutationTo" to "T",
+                                "sequenceName" to "main",
+                                "position" to 14408,
+                                "proportion" to 1.0,
+                                "coverage" to 101,
+                                "count" to 52,
+                            ),
+                        ),
+                    ),
                 ),
         )
 
@@ -153,13 +176,15 @@ class SiloClientTest(
     fun `GIVEN server returns sequence data THEN response can be deserialized`() {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-                        {"primaryKey": "key1","someSequenceName": "ABCD"}
-                        {"primaryKey": "key2","someSequenceName": "DEFG"}
-                        {"primaryKey": "key3","someSequenceName": null}
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf("primaryKey" to "key1", "someSequenceName" to "ABCD"),
+                            mapOf("primaryKey" to "key2", "someSequenceName" to "DEFG"),
+                            mapOf("primaryKey" to "key3", "someSequenceName" to null),
+                        ),
+                    ),
                 ),
         )
 
@@ -184,18 +209,20 @@ class SiloClientTest(
     fun `GIVEN server returns unaligned sequence data THEN response can be deserialized`() {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-                        {"primaryKey": "key1","unaligned_someSequenceName": "ABCD"}
-                        {"primaryKey": "key2","unaligned_someSequenceName": "DEFG"}
-                        {"primaryKey": "key3","unaligned_someSequenceName": null}
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf("primaryKey" to "key1", "unaligned_someSequenceName" to "ABCD"),
+                            mapOf("primaryKey" to "key2", "unaligned_someSequenceName" to "DEFG"),
+                            mapOf("primaryKey" to "key3", "unaligned_someSequenceName" to null),
+                        ),
+                    ),
                 ),
         )
 
         val query = SiloQuery(
-            SiloAction.genomicSequence(SequenceType.ALIGNED, listOf("someSequenceName")),
+            SiloAction.genomicSequence(SequenceType.UNALIGNED, listOf("unaligned_someSequenceName")),
             StringEquals("theColumn", "theValue"),
         )
         val result = underTest.sendQuery(query).toList()
@@ -215,12 +242,26 @@ class SiloClientTest(
     fun `GIVEN server returns details response THEN response can be deserialized`() {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-{ "age": 50, "country": "Switzerland", "date": "2021-02-23", "pango_lineage": "B.1.1.7", "qc_value": 0.95 }
-{ "age": 54, "country": "Switzerland", "date": "2021-03-19", "pango_lineage": "B.1.1.7", "qc_value": 0.94 }
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf(
+                                "age" to 50,
+                                "country" to "Switzerland",
+                                "date" to "2021-02-23",
+                                "pango_lineage" to "B.1.1.7",
+                                "qc_value" to 0.95,
+                            ),
+                            mapOf(
+                                "age" to 54,
+                                "country" to "Switzerland",
+                                "date" to "2021-03-19",
+                                "pango_lineage" to "B.1.1.7",
+                                "qc_value" to 0.94,
+                            ),
+                        ),
+                    ),
                 ),
         )
 
@@ -257,11 +298,17 @@ class SiloClientTest(
     fun `GIVEN server returns most recent common ancestor response THEN response can be deserialized`() {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-{ "mrcaNode": "node", "missingNodeCount": 5, "missingFromTree": "node1,node2,node3,node4,node5" }
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf(
+                                "mrcaNode" to "node",
+                                "missingNodeCount" to 5,
+                                "missingFromTree" to "node1,node2,node3,node4,node5",
+                            ),
+                        ),
+                    ),
                 ),
         )
 
@@ -294,12 +341,26 @@ class SiloClientTest(
     ) {
         expectQueryRequestAndRespondWith(
             response()
-                .withContentType(MediaType.APPLICATION_JSON_UTF_8)
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
                 .withBody(
-                    """
-{ "count": 1, "insertedSymbols": "SGE", "position": 143, "insertion": "ins_S:247:SGE", "sequenceName": "S" }
-{ "count": 2, "insertedSymbols": "EPE", "position": 214, "insertion": "ins_S:214:EPE", "sequenceName": "S" }
-                    """,
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf(
+                                "count" to 1,
+                                "insertedSymbols" to "SGE",
+                                "position" to 143,
+                                "insertion" to "ins_S:247:SGE",
+                                "sequenceName" to "S",
+                            ),
+                            mapOf(
+                                "count" to 2,
+                                "insertedSymbols" to "EPE",
+                                "position" to 214,
+                                "insertion" to "ins_S:214:EPE",
+                                "sequenceName" to "S",
+                            ),
+                        ),
+                    ),
                 ),
         )
 
@@ -370,7 +431,7 @@ class SiloClientTest(
         )
 
         val exception = assertThrows<RuntimeException> { underTest.sendQuery(someQuery).toList() }
-        assertThat(exception.message, containsString("Could not parse response from silo"))
+        assertThat(exception.message, containsString("Could not parse Arrow IPC response from SILO"))
     }
 
     @Test
@@ -415,9 +476,7 @@ class SiloClientTest(
         val errorMessage = "make this fail so that we see a difference on the second call"
 
         expectQueryRequestAndRespondWith(
-            response()
-                .withStatusCode(200)
-                .withBody(""),
+            emptyArrowResponse(),
             Times.exactly(1),
         )
         expectQueryRequestAndRespondWith(
@@ -439,9 +498,7 @@ class SiloClientTest(
         query: SiloQuery<*>,
     ) {
         expectQueryRequestAndRespondWith(
-            response()
-                .withStatusCode(200)
-                .withBody(""),
+            emptyArrowResponse(),
             Times.once(),
         )
 
@@ -460,10 +517,8 @@ class SiloClientTest(
         )
 
         expectQueryRequestAndRespondWith(
-            response()
-                .withStatusCode(200)
-                .withHeader(DATA_VERSION_HEADER, dataVersionValue)
-                .withBody(""),
+            emptyArrowResponse()
+                .withHeader(DATA_VERSION_HEADER, dataVersionValue),
             Times.once(),
         )
 
@@ -482,9 +537,7 @@ class SiloClientTest(
     fun `GIVEN a cacheable action with randomize=true THEN is not cached`() {
         val errorMessage = "This error should appear"
         expectQueryRequestAndRespondWith(
-            response()
-                .withStatusCode(200)
-                .withBody(""),
+            emptyArrowResponse(),
             Times.once(),
         )
         expectQueryRequestAndRespondWith(
@@ -511,9 +564,7 @@ class SiloClientTest(
     @Test
     fun `GIVEN a cacheable action with randomize with seed THEN is cached`() {
         expectQueryRequestAndRespondWith(
-            response()
-                .withStatusCode(200)
-                .withBody(""),
+            emptyArrowResponse(),
             Times.once(),
         )
 
@@ -687,10 +738,8 @@ class SiloClientAndCacheInvalidatorTest(
 
     private fun assertThatResultIsCachedOnSecondRequest() {
         expectQueryRequestAndRespondWith(
-            response()
-                .withStatusCode(200)
-                .withHeader(DATA_VERSION_HEADER, firstDataVersion)
-                .withBody(""),
+            emptyArrowResponse()
+                .withHeader(DATA_VERSION_HEADER, firstDataVersion),
             Times.once(),
         )
 
@@ -739,11 +788,18 @@ private fun expectQueryRequestAndRespondWith(
                 .withMethod("POST")
                 .withPath("/query")
                 .withContentType(MediaType.APPLICATION_JSON)
-                .withHeader("X-Request-Id", REQUEST_ID_VALUE),
+                .withHeader("X-Request-Id", REQUEST_ID_VALUE)
+                .withHeader("Accept", ARROW_STREAM_MEDIA_TYPE),
             times,
         )
         .respond(httpResponse)
 }
+
+private fun emptyArrowResponse() =
+    response()
+        .withStatusCode(200)
+        .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
+        .withBody(buildArrowIpcStream(emptyList()))
 
 private fun expectInfoCallAndReturnDataVersion(
     dataVersion: String,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -745,8 +745,8 @@ class SiloClientAndCacheInvalidatorTest(
             Times.once(),
         )
 
-        siloClient.sendQuery(someQuery).toList()
-        siloClient.sendQuery(someQuery).toList()
+        siloClient.sendQuery(someQuery).use { it.toList() }
+        siloClient.sendQuery(someQuery).use { it.toList() }
         assertThat(dataVersion.dataVersion, `is`(firstDataVersion))
     }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -15,6 +15,7 @@ import org.genspectrum.lapis.response.DetailsData
 import org.genspectrum.lapis.response.InsertionData
 import org.genspectrum.lapis.response.MostCommonAncestorData
 import org.genspectrum.lapis.response.MutationData
+import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
 import org.genspectrum.lapis.scheduler.DataVersionCacheInvalidator
 import org.hamcrest.MatcherAssert.assertThat
@@ -329,6 +330,46 @@ class SiloClientTest(
                     mrcaNode = "node",
                     missingNodeCount = 5,
                     missingFromTree = "node1,node2,node3,node4,node5",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN server returns phylo subtree response THEN response can be deserialized`() {
+        expectQueryRequestAndRespondWith(
+            response()
+                .withContentType(parse(ARROW_STREAM_MEDIA_TYPE))
+                .withBody(
+                    buildArrowIpcStream(
+                        listOf(
+                            mapOf(
+                                "subtreeNewick" to "(A,B);",
+                                "missingNodeCount" to 2,
+                                "missingFromTree" to "node1,node2",
+                            ),
+                        ),
+                    ),
+                ),
+        )
+
+        val query = SiloQuery(
+            SiloAction.phyloSubtree(
+                phyloTreeField = "phyloTreeField",
+                printNodesNotInTree = true,
+            ),
+            StringEquals("theColumn", "theValue"),
+        )
+        val result = sendQuery(query)
+
+        assertThat(result, hasSize(1))
+        assertThat(
+            result[0],
+            `is`(
+                PhyloSubtreeData(
+                    subtreeNewick = "(A,B);",
+                    missingNodeCount = 2,
+                    missingFromTree = "node1,node2",
                 ),
             ),
         )

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -94,7 +94,7 @@ class SiloClientTest(
         )
 
         val query = SiloQuery(SiloAction.aggregated(), StringEquals("theColumn", "theValue"))
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(
             result,
@@ -142,7 +142,7 @@ class SiloClientTest(
         )
 
         val query = SiloQuery(action, StringEquals("theColumn", "theValue"))
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(result, hasSize(2))
         assertThat(
@@ -192,7 +192,7 @@ class SiloClientTest(
             SiloAction.genomicSequence(SequenceType.ALIGNED, listOf("someSequenceName")),
             StringEquals("theColumn", "theValue"),
         )
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(result, hasSize(3))
         assertThat(
@@ -225,7 +225,7 @@ class SiloClientTest(
             SiloAction.genomicSequence(SequenceType.UNALIGNED, listOf("unaligned_someSequenceName")),
             StringEquals("theColumn", "theValue"),
         )
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(result, hasSize(3))
         assertThat(
@@ -266,7 +266,7 @@ class SiloClientTest(
         )
 
         val query = SiloQuery(SiloAction.details(), StringEquals("theColumn", "theValue"))
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(result, hasSize(2))
         assertThat(
@@ -319,7 +319,7 @@ class SiloClientTest(
             ),
             StringEquals("theColumn", "theValue"),
         )
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(result, hasSize(1))
         assertThat(
@@ -365,7 +365,7 @@ class SiloClientTest(
         )
 
         val query = SiloQuery(action, True)
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
 
         assertThat(result, hasSize(2))
         assertThat(
@@ -398,7 +398,7 @@ class SiloClientTest(
                 .withBody("""{"unexpectedKey":  "some unexpected message"}"""),
         )
 
-        val exception = assertThrows<SiloException> { underTest.sendQuery(someQuery).toList() }
+        val exception = assertThrows<SiloException> { sendQuery(someQuery) }
 
         assertThat(exception.statusCode, equalTo(500))
         assertThat(
@@ -416,7 +416,7 @@ class SiloClientTest(
                 .withBody("""{"error":  "Test Error", "message": "test message with details"}"""),
         )
 
-        val exception = assertThrows<SiloException> { underTest.sendQuery(someQuery).toList() }
+        val exception = assertThrows<SiloException> { sendQuery(someQuery) }
         assertThat(exception.statusCode, equalTo(432))
         assertThat(exception.message, equalTo("Error from SILO: test message with details"))
     }
@@ -430,7 +430,7 @@ class SiloClientTest(
                 .withBody("""{"unexpectedField":  "some message"}"""),
         )
 
-        val exception = assertThrows<RuntimeException> { underTest.sendQuery(someQuery).toList() }
+        val exception = assertThrows<RuntimeException> { sendQuery(someQuery) }
         assertThat(exception.message, containsString("Could not parse Arrow IPC response from SILO"))
     }
 
@@ -446,7 +446,7 @@ class SiloClientTest(
                 .withBody("""{"error":  "Test Error", "message": "$errorMessage"}"""),
         )
 
-        val exception = assertThrows<SiloUnavailableException> { underTest.sendQuery(someQuery).toList() }
+        val exception = assertThrows<SiloUnavailableException> { sendQuery(someQuery) }
 
         assertThat(exception.message, `is`("SILO is currently unavailable: $errorMessage"))
         assertThat(exception.retryAfter, `is`(retryAfterValue))
@@ -462,7 +462,7 @@ class SiloClientTest(
                 .withBody("""{"error":  "Test Error", "message": "$errorMessage"}"""),
         )
 
-        val exception = assertThrows<SiloUnavailableException> { underTest.sendQuery(someQuery).toList() }
+        val exception = assertThrows<SiloUnavailableException> { sendQuery(someQuery) }
 
         assertThat(exception.message, `is`("SILO is currently unavailable: $errorMessage"))
         assertThat(exception.retryAfter, `is`(nullValue()))
@@ -486,9 +486,9 @@ class SiloClientTest(
             Times.exactly(1),
         )
 
-        underTest.sendQuery(query).toList()
+        sendQuery(query)
 
-        val exception = assertThrows<SiloException> { underTest.sendQuery(query).toList() }
+        val exception = assertThrows<SiloException> { sendQuery(query) }
         assertThat(exception.message, containsString(errorMessage))
     }
 
@@ -502,8 +502,8 @@ class SiloClientTest(
             Times.once(),
         )
 
-        val result1 = underTest.sendQuery(query).toList()
-        val result2 = underTest.sendQuery(query).toList()
+        val result1 = sendQuery(query)
+        val result2 = sendQuery(query)
 
         assertThat(result1, `is`(result2))
     }
@@ -525,11 +525,11 @@ class SiloClientTest(
         val query = queriesThatShouldBeCached[0]
 
         assertThat(dataVersion.dataVersion, `is`(nullValue()))
-        underTest.sendQuery(query).toList()
+        sendQuery(query)
         assertThat(dataVersion.dataVersion, `is`(dataVersionValue))
 
         dataVersion.dataVersion = null
-        underTest.sendQuery(query).toList()
+        sendQuery(query)
         assertThat(dataVersion.dataVersion, `is`(dataVersionValue))
     }
 
@@ -554,10 +554,10 @@ class SiloClientTest(
         val query = SiloQuery(SiloAction.mutations(orderByFields = listOf(orderByRandom).toOrderBySpec()), True)
         assertThat(query.action.cacheable, `is`(true))
 
-        val result = underTest.sendQuery(query).toList()
+        val result = sendQuery(query)
         assertThat(result, hasSize(0))
 
-        val exception = assertThrows<SiloException> { underTest.sendQuery(query).toList() }
+        val exception = assertThrows<SiloException> { sendQuery(query) }
         assertThat(exception.message, containsString(errorMessage))
     }
 
@@ -571,8 +571,8 @@ class SiloClientTest(
         val query = SiloQuery(SiloAction.mutations(orderByFields = OrderBySpec.Random(123)), True)
         assertThat(query.action.cacheable, `is`(true))
 
-        val result1 = underTest.sendQuery(query).toList()
-        val result2 = underTest.sendQuery(query).toList()
+        val result1 = sendQuery(query)
+        val result2 = sendQuery(query)
 
         assertThat(result1, `is`(result2))
     }
@@ -638,6 +638,8 @@ class SiloClientTest(
                     .withBody(lineageDefinition),
             )
     }
+
+    private fun <R> sendQuery(query: SiloQuery<R>): List<R> = underTest.sendQuery(query).use { it.toList() }
 
     companion object {
         @JvmStatic


### PR DESCRIPTION
resolves #1547

SILO supports returning query responses as [Apache Arrow IPC streams](https://arrow.apache.org/docs/format/Columnar.html#format-ipc) (`application/vnd.apache.arrow.stream`), which is more efficient to parse than NDJSON. This PR switches LAPIS to request and consume Arrow IPC responses from SILO for all query types.

**For reviewers:**
- `SiloClient.kt`: sends `Accept: application/vnd.apache.arrow.stream`, reads the response as a lazy `Stream` via `ArrowStreamReader`. A shared `RootAllocator` bean (Netty-backed) is used application-wide; a child allocator is created per query and closed when the stream is consumed.
- `SiloQuery.kt`: each `SiloAction` subclass now carries an `arrowConverter` reference instead of a Jackson `TypeReference`.
- The JVM flags `-Dio.netty.tryReflectionSetAccessible=true` and `--add-opens=java.base/java.nio=ALL-UNNAMED` are required and added to `bootRun`, `test`, and `entrypoint.sh`.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] All necessary changes are explained in the `llms.txt`.~~
- [x] The implemented feature is covered by an appropriate test.