### PR TITLE
fix(lapis): logs in the query parse endpoint

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
@@ -33,6 +33,8 @@ class QueryParseModel(
         doFullValidation: Boolean,
     ): ParsedQueryResult =
         try {
+            log.info { "Parsing query: $query" }
+
             val filter = try {
                 advancedQueryFacade.map(query)
             } catch (e: BadRequestException) {
@@ -51,7 +53,8 @@ class QueryParseModel(
             }
 
             ParsedQueryResult.Success(filter = filter)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            log.error(e) { "Unexpected error parsing query: $query" }
             ParsedQueryResult.Failure(error = "Unexpected error parsing query.")
         }
 


### PR DESCRIPTION
While implementing https://github.com/GenSpectrum/dashboards/issues/1156, I got an error from LAPIS:

<img width="670" height="268" alt="grafik" src="https://github.com/user-attachments/assets/092a8778-5b6a-4475-a6fd-6c1bcf8ccba4" />

The logs only show:
```
$ grep a5af1238-a6dd-4010-adcc-ad598cdab350 LAPIS.log 
2026-04-27 09:36:46,054 DEBUG [http-nio-8080-exec-85] [a5af1238-a6dd-4010-adcc-ad598cdab350] org.springframework.web.filter.CommonsRequestLoggingFilter: Before request [POST /open/v2/query/parse]
2026-04-27 09:36:46,055 INFO [http-nio-8080-exec-85] [a5af1238-a6dd-4010-adcc-ad598cdab350] org.genspectrum.lapis.silo.SiloClient: Calling SILO info
2026-04-27 09:36:46,057 DEBUG [http-nio-8080-exec-85] [a5af1238-a6dd-4010-adcc-ad598cdab350] org.springframework.web.filter.CommonsRequestLoggingFilter: After request [POST /open/v2/query/parse]
2026-04-27 09:36:46,058 INFO [http-nio-8080-exec-85] [a5af1238-a6dd-4010-adcc-ad598cdab350] org.genspectrum.lapis.logging.RequestContextLogger: {"unixTimestamp":1777282606054,"responseTimeInMilliSeconds":4,"endpoint":"/open/v2/query/parse","responseCode":200}
```
which isn't really helpful. We should at least log the error and actually it's also helpful to know which query is being processed.


## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] All necessary changes are explained in the `llms.txt`.~~
~~- [ ] The implemented feature is covered by an appropriate test.~~
