### PR TITLE
fix(lapis): send `isNull` to SILO on `isNull(date)` advanced query

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -27,6 +27,7 @@ import org.genspectrum.lapis.silo.HasAminoAcidMutation
 import org.genspectrum.lapis.silo.HasNucleotideMutation
 import org.genspectrum.lapis.silo.IntBetween
 import org.genspectrum.lapis.silo.IntEquals
+import org.genspectrum.lapis.silo.IsNull
 import org.genspectrum.lapis.silo.LineageEquals
 import org.genspectrum.lapis.silo.Maybe
 import org.genspectrum.lapis.silo.NOf
@@ -268,7 +269,7 @@ class AdvancedQueryCustomListener(
             }
 
             MetadataType.DATE -> {
-                expressionStack.addLast(Not(DateBetween(field.name, to = null, from = null)))
+                expressionStack.addLast(IsNull(field.name))
             }
 
             MetadataType.FLOAT -> {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
@@ -16,6 +16,7 @@ import org.genspectrum.lapis.silo.HasAminoAcidMutation
 import org.genspectrum.lapis.silo.HasNucleotideMutation
 import org.genspectrum.lapis.silo.IntBetween
 import org.genspectrum.lapis.silo.IntEquals
+import org.genspectrum.lapis.silo.IsNull
 import org.genspectrum.lapis.silo.LineageEquals
 import org.genspectrum.lapis.silo.Maybe
 import org.genspectrum.lapis.silo.NOf
@@ -374,7 +375,7 @@ class AdvancedQueryFacadeTest {
                 ValidTestCase(
                     "date metadata with isNull",
                     "isNull(date)",
-                    Not(DateBetween("date", null, null)),
+                    IsNull("date"),
                 ),
                 ValidTestCase(
                     "int metadata with isNull",


### PR DESCRIPTION
Noticed while implementing #1682. Not wrong yet, but it will be with SaneQL. Since we have the separate `isNull` filter now, we should use it.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] All necessary changes are explained in the `llms.txt`.~~
- [x] The implemented feature is covered by an appropriate test.
