### PR TITLE
docs(lapis): fix Pango lineage banner

### DIFF
--- a/lapis-docs/src/config.ts
+++ b/lapis-docs/src/config.ts
@@ -14,7 +14,7 @@ export type MetadataType =
 export type Metadata = {
     name: string;
     type: MetadataType;
-    generateLineageIndex?: boolean;
+    generateLineageIndex?: string | null;
 };
 
 export type Feature = {
@@ -55,7 +55,8 @@ export function hasFeature(feature: string): boolean {
 export function hasPangoLineage(config: Config): boolean {
     return config.schema.metadata.some(
         (m) =>
-            m.generateLineageIndex === true &&
+            m.generateLineageIndex !== undefined &&
+            m.generateLineageIndex !== null &&
             (m.name.toLowerCase().includes('pangolineage') || m.name.toLowerCase().includes('pango_lineage')),
     );
 }

--- a/lapis-docs/src/content/docs/concepts/pango-lineage-query.mdx
+++ b/lapis-docs/src/content/docs/concepts/pango-lineage-query.mdx
@@ -9,7 +9,7 @@ import { getConfig, hasPangoLineage, hasFeature } from '../../../config.ts';
 {/* prettier-ignore */}
 <OnlyIf condition={!hasPangoLineage(getConfig())}>
 :::note
-This feature is not available in this LAPIS instance, because none of the fields seems to be a Pango lineage field.
+This feature is not available in this LAPIS instance.
 :::
 </OnlyIf>
 


### PR DESCRIPTION
The SARS-CoV-2 LAPIS instance of CoV-Spectrum ( is showing the following banner (https://lapis.cov-spectrum.org/open/v2/docs/concepts/pango-lineage-query) which is wrong as it has Pango lineages:

<img width="995" height="207" alt="image" src="https://github.com/user-attachments/assets/afcf1768-d833-45b5-84fb-a9ab46d9bbbc" />

This PR fixes the bug.

## PR Checklist
- ~[ ] All necessary documentation has been adapted.~
- ~[ ] All necessary changes are explained in the `llms.txt`.~
- ~[ ] The implemented feature is covered by an appropriate test.~
