### PR TITLE
fix(lapis): upgrade to Spring boot 4

### DIFF
--- a/lapis-e2e/test/auth.spec.ts
+++ b/lapis-e2e/test/auth.spec.ts
@@ -33,7 +33,9 @@ describe('LAPIS that requires authentication', () => {
         const result = await fetch(basePath + '/sample/aggregated');
 
         expect(result.status).to.equal(401);
-        expect(result.headers.get('www-authenticate')).to.equal('Bearer');
+        expect(result.headers.get('www-authenticate')).to.match(
+          /Bearer resource_metadata="http:\/\/localhost:\d+\/.well-known\/oauth-protected-resource"/
+        );
       });
 
       it('should reject call with invalid token', async () => {

--- a/lapis-e2e/test/badRequest.spec.ts
+++ b/lapis-e2e/test/badRequest.spec.ts
@@ -13,7 +13,6 @@ describe('Error handling: BadRequest', () => {
       instance: '/sample/aggregated',
       status: 400,
       title: 'Bad Request',
-      type: 'about:blank',
     });
   });
 });

--- a/lapis/build.gradle
+++ b/lapis/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '4.0.6'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.jetbrains.kotlin.jvm' version '2.3.21'
     id 'org.jetbrains.kotlin.plugin.spring' version '2.3.21'
@@ -28,15 +28,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
+    implementation 'tools.jackson.module:jackson-module-kotlin'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+    implementation 'tools.jackson.dataformat:jackson-dataformat-yaml'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
     implementation 'io.github.microutils:kotlin-logging-jvm:3.0.5'
     antlr 'org.antlr:antlr4:4.13.2'
     implementation 'org.antlr:antlr4-runtime:4.13.2'
@@ -47,10 +46,10 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine:3.2.4'
     implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-0.6.x-compat'
 
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+    implementation "org.springframework.boot:spring-boot-starter-security-oauth2-resource-server"
     implementation "org.springframework.boot:spring-boot-starter-security"
 
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+    testImplementation('org.springframework.boot:spring-boot-starter-webmvc-test') {
         exclude group: "org.mockito"
     }
     testImplementation 'com.ninja-squad:springmockk:5.0.1'

--- a/lapis/build.gradle
+++ b/lapis/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'tools.jackson.module:jackson-module-kotlin'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin' // needed by springdoc/swagger-core (still on Jackson 2)
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
     implementation 'tools.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
@@ -5,7 +5,7 @@ import org.genspectrum.lapis.controller.LapisHeaders.REQUEST_ID
 import org.genspectrum.lapis.controller.middleware.Compression
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.RETRY_AFTER
-import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.HttpMessageConverters
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -21,15 +21,17 @@ class CorsConfiguration : WebMvcConfigurer {
             .maxAge(3600)
     }
 
-    override fun extendMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
+    override fun configureMessageConverters(builder: HttpMessageConverters.ServerBuilder) {
         // Register compression media types with the Jackson JSON converter so that
         // error responses can be serialized even when the Content-Type is forced to
         // application/gzip or application/zstd by the CompressionFilter.
         val compressionMediaTypes = Compression.entries.map { it.contentType }
-        converters.filterIsInstance<JacksonJsonHttpMessageConverter>().forEach { converter ->
-            val supportedTypes = converter.supportedMediaTypes.toMutableList()
-            supportedTypes.addAll(compressionMediaTypes)
-            converter.supportedMediaTypes = supportedTypes
+        builder.configureMessageConverters { converter ->
+            if (converter is JacksonJsonHttpMessageConverter) {
+                val supportedTypes = converter.supportedMediaTypes.toMutableList()
+                supportedTypes.addAll(compressionMediaTypes)
+                converter.supportedMediaTypes = supportedTypes
+            }
         }
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/CorsConfiguration.kt
@@ -2,8 +2,11 @@ package org.genspectrum.lapis
 
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisHeaders.REQUEST_ID
+import org.genspectrum.lapis.controller.middleware.Compression
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.RETRY_AFTER
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
@@ -16,5 +19,17 @@ class CorsConfiguration : WebMvcConfigurer {
             .allowedHeaders("*")
             .exposedHeaders(LAPIS_DATA_VERSION, REQUEST_ID, RETRY_AFTER)
             .maxAge(3600)
+    }
+
+    override fun extendMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
+        // Register compression media types with the Jackson JSON converter so that
+        // error responses can be serialized even when the Content-Type is forced to
+        // application/gzip or application/zstd by the CompressionFilter.
+        val compressionMediaTypes = Compression.entries.map { it.contentType }
+        converters.filterIsInstance<JacksonJsonHttpMessageConverter>().forEach { converter ->
+            val supportedTypes = converter.supportedMediaTypes.toMutableList()
+            supportedTypes.addAll(compressionMediaTypes)
+            converter.supportedMediaTypes = supportedTypes
+        }
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -32,12 +32,14 @@ import org.genspectrum.lapis.util.TimeFactory
 import org.genspectrum.lapis.util.YamlObjectMapper
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.customizers.OperationCustomizer
+import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer
 import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.CommonsRequestLoggingFilter
@@ -53,6 +55,10 @@ private const val VERSION_FILE = "version.txt"
 @EnableScheduling
 @EnableCaching
 class LapisSpringConfig {
+    init {
+        SpringDocUtils.getConfig().addRequestWrapperToIgnore(HttpHeaders::class.java)
+    }
+
     private val rootAllocator = RootAllocator()
 
     @Bean

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -1,8 +1,5 @@
 package org.genspectrum.lapis
 
-import com.fasterxml.jackson.core.StreamReadConstraints
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
@@ -36,15 +33,18 @@ import org.genspectrum.lapis.util.YamlObjectMapper
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer
-import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.CommonsRequestLoggingFilter
+import tools.jackson.core.StreamReadConstraints
+import tools.jackson.core.json.JsonFactory
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.readValue
 import java.io.File
 
 private const val VERSION_FILE = "version.txt"
@@ -175,14 +175,16 @@ class LapisSpringConfig {
         }
 
     @Bean
-    fun streamConstraintsCustomizer(): Jackson2ObjectMapperBuilderCustomizer =
-        Jackson2ObjectMapperBuilderCustomizer { builder: Jackson2ObjectMapperBuilder ->
-            builder.postConfigurer { objectMapper: ObjectMapper ->
-                objectMapper.factory.setStreamReadConstraints(
-                    StreamReadConstraints.builder()
-                        .maxStringLength(200_000_000)
-                        .build(),
-                )
-            }
-        }
+    fun jsonMapperBuilder(customizers: List<JsonMapperBuilderCustomizer>): JsonMapper.Builder {
+        val factory = JsonFactory.builder()
+            .streamReadConstraints(
+                StreamReadConstraints.builder()
+                    .maxStringLength(200_000_000)
+                    .build(),
+            )
+            .build()
+        val builder = JsonMapper.builder(factory)
+        customizers.forEach { it.customize(builder) }
+        return builder
+    }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/LapisSpringConfig.kt
@@ -180,6 +180,8 @@ class LapisSpringConfig {
             LapisVersion("local")
         }
 
+    // We must call the customizers ourselves to preserve Boot's default Jackson configuration
+    // (Kotlin module registration, feature flags, date handling, etc.).
     @Bean
     fun jsonMapperBuilder(customizers: List<JsonMapperBuilderCustomizer>): JsonMapper.Builder {
         val factory = JsonFactory.builder()

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/OAuthConfig.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/OAuthConfig.kt
@@ -2,7 +2,7 @@ package org.genspectrum.lapis
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/auth/DataOpennessAuthorizationFilter.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.auth
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -16,6 +15,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+import tools.jackson.databind.ObjectMapper
 
 @Component
 class DataOpennessAuthorizationFilterFactory(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
@@ -1,8 +1,8 @@
 package org.genspectrum.lapis.config
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.io.File
 
 const val REFERENCE_GENOME_SEGMENTS_APPLICATION_ARG_PREFIX = "referenceGenome.segments"

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -3,6 +3,8 @@ package org.genspectrum.lapis.controller
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.genspectrum.lapis.config.DatabaseConfig
+import org.genspectrum.lapis.controller.middleware.CompressionSource
+import org.genspectrum.lapis.controller.middleware.RequestCompression
 import org.genspectrum.lapis.log
 import org.genspectrum.lapis.response.LapisErrorResponse
 import org.genspectrum.lapis.response.LapisInfoFactory
@@ -31,6 +33,7 @@ import org.springframework.web.servlet.View
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import java.net.URI
 
 private typealias ErrorResponse = ResponseEntity<LapisErrorResponse>
 
@@ -43,7 +46,7 @@ private typealias ErrorResponse = ResponseEntity<LapisErrorResponse>
 class ExceptionHandler(
     private val notFoundView: NotFoundView,
     private val lapisInfoFactory: LapisInfoFactory,
-    private val requestCompression: org.genspectrum.lapis.controller.middleware.RequestCompression,
+    private val requestCompression: RequestCompression,
 ) : ResponseEntityExceptionHandler() {
     @ExceptionHandler(Throwable::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -128,7 +131,7 @@ class ExceptionHandler(
     ): ErrorResponse {
         val compressionSource = requestCompression.compressionSource
         val addCompressionEncoding: BodyBuilder.() -> Unit = {
-            if (compressionSource is org.genspectrum.lapis.controller.middleware.CompressionSource.RequestProperty) {
+            if (compressionSource is CompressionSource.RequestProperty) {
                 header(HttpHeaders.CONTENT_ENCODING, compressionSource.compression.value)
             }
         }
@@ -141,7 +144,7 @@ class ExceptionHandler(
             .body(
                 LapisErrorResponse(
                     error = ProblemDetail.forStatus(httpStatus).also {
-                        it.type = java.net.URI.create("about:blank")
+                        it.type = URI.create("about:blank")
                         it.title = title
                         it.detail = truncate(detail, maxLength = 100_000)
                     },

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -45,28 +45,6 @@ class ExceptionHandler(
     private val lapisInfoFactory: LapisInfoFactory,
     private val requestCompression: org.genspectrum.lapis.controller.middleware.RequestCompression,
 ) : ResponseEntityExceptionHandler() {
-    override fun createProblemDetail(
-        ex: Exception,
-        status: HttpStatusCode,
-        defaultDetail: String,
-        detailMessageCode: String?,
-        detailMessageArguments: Array<out Any>?,
-        request: WebRequest,
-    ): ProblemDetail {
-        val problemDetail = super.createProblemDetail(
-            ex,
-            status,
-            defaultDetail,
-            detailMessageCode,
-            detailMessageArguments,
-            request,
-        )
-        if (problemDetail.type == null) {
-            problemDetail.type = java.net.URI.create("about:blank")
-        }
-        return problemDetail
-    }
-
     @ExceptionHandler(Throwable::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     fun handleUnexpectedException(e: Throwable): ErrorResponse {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -45,6 +45,28 @@ class ExceptionHandler(
     private val lapisInfoFactory: LapisInfoFactory,
     private val requestCompression: org.genspectrum.lapis.controller.middleware.RequestCompression,
 ) : ResponseEntityExceptionHandler() {
+    override fun createProblemDetail(
+        ex: Exception,
+        status: HttpStatusCode,
+        defaultDetail: String,
+        detailMessageCode: String?,
+        detailMessageArguments: Array<out Any>?,
+        request: WebRequest,
+    ): ProblemDetail {
+        val problemDetail = super.createProblemDetail(
+            ex,
+            status,
+            defaultDetail,
+            detailMessageCode,
+            detailMessageArguments,
+            request,
+        )
+        if (problemDetail.type == null) {
+            problemDetail.type = java.net.URI.create("about:blank")
+        }
+        return problemDetail
+    }
+
     @ExceptionHandler(Throwable::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     fun handleUnexpectedException(e: Throwable): ErrorResponse {
@@ -141,6 +163,7 @@ class ExceptionHandler(
             .body(
                 LapisErrorResponse(
                     error = ProblemDetail.forStatus(httpStatus).also {
+                        it.type = java.net.URI.create("about:blank")
                         it.title = title
                         it.detail = truncate(detail, maxLength = 100_000)
                     },

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -9,9 +9,9 @@ import org.genspectrum.lapis.response.LapisInfoFactory
 import org.genspectrum.lapis.silo.SiloException
 import org.genspectrum.lapis.silo.SiloNotReachableException
 import org.genspectrum.lapis.silo.SiloUnavailableException
-import org.springframework.boot.autoconfigure.web.ServerProperties
-import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController
-import org.springframework.boot.web.servlet.error.ErrorAttributes
+import org.springframework.boot.autoconfigure.web.WebProperties
+import org.springframework.boot.webmvc.autoconfigure.error.BasicErrorController
+import org.springframework.boot.webmvc.error.ErrorAttributes
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpHeaders.ACCEPT
 import org.springframework.http.HttpHeaders.RETRY_AFTER
@@ -43,6 +43,7 @@ private typealias ErrorResponse = ResponseEntity<LapisErrorResponse>
 class ExceptionHandler(
     private val notFoundView: NotFoundView,
     private val lapisInfoFactory: LapisInfoFactory,
+    private val requestCompression: org.genspectrum.lapis.controller.middleware.RequestCompression,
 ) : ResponseEntityExceptionHandler() {
     @ExceptionHandler(Throwable::class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -84,7 +85,9 @@ class ExceptionHandler(
     fun handleSiloUnavailableException(e: SiloUnavailableException): ErrorResponse {
         log.warn { "Caught SiloUnavailableException: ${e.message}" } // don't log stack trace for this common case
 
-        return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message) { header(RETRY_AFTER, e.retryAfter) }
+        return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message) {
+            e.retryAfter?.let { header(RETRY_AFTER, it) }
+        }
     }
 
     override fun handleNoResourceFoundException(
@@ -122,11 +125,19 @@ class ExceptionHandler(
         title: String,
         detail: String?,
         alsoDoOnBuilder: BodyBuilder.() -> Unit = {},
-    ): ErrorResponse =
-        ResponseEntity
+    ): ErrorResponse {
+        val compressionSource = requestCompression.compressionSource
+        val addCompressionEncoding: BodyBuilder.() -> Unit = {
+            if (compressionSource is org.genspectrum.lapis.controller.middleware.CompressionSource.RequestProperty) {
+                header(HttpHeaders.CONTENT_ENCODING, compressionSource.compression.value)
+            }
+        }
+
+        return ResponseEntity
             .status(httpStatus)
             .contentType(MediaType.APPLICATION_JSON)
             .also(alsoDoOnBuilder)
+            .also(addCompressionEncoding)
             .body(
                 LapisErrorResponse(
                     error = ProblemDetail.forStatus(httpStatus).also {
@@ -136,6 +147,7 @@ class ExceptionHandler(
                     info = lapisInfoFactory.create(),
                 ),
             )
+    }
 
     private fun truncate(
         value: String?,
@@ -191,8 +203,8 @@ class NotFoundView(
 class ErrorController(
     private val databaseConfig: DatabaseConfig,
     errorAttributes: ErrorAttributes,
-    serverProperties: ServerProperties,
-) : BasicErrorController(errorAttributes, serverProperties.error) {
+    webProperties: WebProperties,
+) : BasicErrorController(errorAttributes, webProperties.error) {
     override fun errorHtml(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -1230,7 +1230,7 @@ class LapisController(
         response: HttpServletResponse,
     ) {
         val treeResponse = siloQueryModel.getNewick(sequenceFilters = request)
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion)
+        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
         if (response.contentType == null) {
             response.contentType = "${LapisMediaType.TEXT_NEWICK_VALUE};charset=UTF-8"
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -9,6 +9,7 @@ import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_CSV_VALUE
+import org.genspectrum.lapis.controller.LapisMediaType.TEXT_NEWICK
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_NEWICK_VALUE
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_TSV_VALUE
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_X_FASTA_VALUE
@@ -1232,7 +1233,7 @@ class LapisController(
         val treeResponse = siloQueryModel.getNewick(sequenceFilters = request)
         response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
         if (response.contentType == null) {
-            response.contentType = "${LapisMediaType.TEXT_NEWICK_VALUE};charset=UTF-8"
+            response.contentType = MediaType(TEXT_NEWICK, Charsets.UTF_8).toString()
         }
         val newick = treeResponse.use { it.toList() }.first().subtreeNewick
         response.outputStream.write(newick.toByteArray(Charsets.UTF_8))

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.servlet.http.HttpServletResponse
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
-import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_CSV_VALUE
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_NEWICK
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_NEWICK_VALUE
@@ -89,6 +88,7 @@ import org.genspectrum.lapis.response.ResponseFormat
 import org.genspectrum.lapis.response.SequencesStreamer
 import org.genspectrum.lapis.silo.DataVersion
 import org.genspectrum.lapis.silo.SequenceType
+import org.genspectrum.lapis.silo.setHeaderOn
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -1231,7 +1231,7 @@ class LapisController(
         response: HttpServletResponse,
     ) {
         val treeResponse = siloQueryModel.getNewick(sequenceFilters = request)
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
+        dataVersion.setHeaderOn(response)
         if (response.contentType == null) {
             response.contentType = MediaType(TEXT_NEWICK, Charsets.UTF_8).toString()
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -1191,7 +1191,7 @@ class LapisController(
         @RequestParam
         aminoAcidInsertions: List<AminoAcidInsertion>?,
         response: HttpServletResponse,
-    ): String {
+    ) {
         val request = PhyloTreeSequenceFiltersRequest(
             sequenceFilters?.filterKeys { !SPECIAL_REQUEST_PROPERTIES.contains(it) }
                 ?: emptyMap(),
@@ -1206,7 +1206,7 @@ class LapisController(
             ).fieldName,
         )
 
-        return getNewickSubtree(request, response)
+        writeNewickSubtree(request, response)
     }
 
     @PostMapping(
@@ -1223,15 +1223,20 @@ class LapisController(
         @RequestBody
         request: PhyloTreeSequenceFiltersRequest,
         response: HttpServletResponse,
-    ): String = getNewickSubtree(request, response)
+    ) = writeNewickSubtree(request, response)
 
-    private fun getNewickSubtree(
+    private fun writeNewickSubtree(
         request: PhyloTreeSequenceFiltersRequest,
         response: HttpServletResponse,
-    ): String {
+    ) {
         val treeResponse = siloQueryModel.getNewick(sequenceFilters = request)
         response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion)
-        return treeResponse.use { it.toList() }.first().subtreeNewick
+        if (response.contentType == null) {
+            response.contentType = "${LapisMediaType.TEXT_NEWICK_VALUE};charset=UTF-8"
+        }
+        val newick = treeResponse.use { it.toList() }.first().subtreeNewick
+        response.outputStream.write(newick.toByteArray(Charsets.UTF_8))
+        response.outputStream.flush()
     }
 
     @GetMapping(DETAILS_ROUTE, produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeController.kt
@@ -96,6 +96,6 @@ class QueriesOverTimeController(
     private fun <Result> createResponse(resultData: Result) =
         ResponseEntity
             .ok()
-            .header(LAPIS_DATA_VERSION, dataVersion.dataVersion)
+            .header(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
             .body(QueriesOverTimeResponse(resultData, lapisInfoFactory.create()))
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeController.kt
@@ -3,7 +3,6 @@ package org.genspectrum.lapis.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
-import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.model.mutationsOverTime.MutationsOverTimeResult
 import org.genspectrum.lapis.model.mutationsOverTime.QueriesOverTimeModel
 import org.genspectrum.lapis.model.mutationsOverTime.QueriesOverTimeResult
@@ -15,6 +14,7 @@ import org.genspectrum.lapis.request.QueriesOverTimeRequest
 import org.genspectrum.lapis.response.LapisInfoFactory
 import org.genspectrum.lapis.response.QueriesOverTimeResponse
 import org.genspectrum.lapis.silo.DataVersion
+import org.genspectrum.lapis.silo.setHeaderOn
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -94,8 +94,6 @@ class QueriesOverTimeController(
     }
 
     private fun <Result> createResponse(resultData: Result) =
-        ResponseEntity
-            .ok()
-            .header(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
+        dataVersion.setHeaderOn(ResponseEntity.ok())
             .body(QueriesOverTimeResponse(resultData, lapisInfoFactory.create()))
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueryController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueryController.kt
@@ -39,7 +39,7 @@ class QueryController(
         )
         return ResponseEntity
             .ok()
-            .header(LAPIS_DATA_VERSION, dataVersion.dataVersion)
+            .header(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
             .body(QueryParseResponse(data, lapisInfoFactory.create()))
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueryController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/QueryController.kt
@@ -1,12 +1,12 @@
 package org.genspectrum.lapis.controller
 
 import io.swagger.v3.oas.annotations.Operation
-import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.model.QueryParseModel
 import org.genspectrum.lapis.request.QueryParseRequest
 import org.genspectrum.lapis.response.LapisInfoFactory
 import org.genspectrum.lapis.response.QueryParseResponse
 import org.genspectrum.lapis.silo.DataVersion
+import org.genspectrum.lapis.silo.setHeaderOn
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -37,9 +37,7 @@ class QueryController(
             queries = request.queries,
             doFullValidation = request.doFullValidation,
         )
-        return ResponseEntity
-            .ok()
-            .header(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
+        return dataVersion.setHeaderOn(ResponseEntity.ok())
             .body(QueryParseResponse(data, lapisInfoFactory.create()))
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/CompressionFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/CompressionFilter.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller.middleware
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.luben.zstd.ZstdOutputStream
 import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletOutputStream
@@ -15,20 +14,18 @@ import org.genspectrum.lapis.response.LapisInfoFactory
 import org.genspectrum.lapis.util.CachedBodyHttpServletRequest
 import org.genspectrum.lapis.util.ResponseWithContentType
 import org.springframework.boot.context.properties.bind.Binder
-import org.springframework.boot.web.servlet.server.Encoding
 import org.springframework.core.annotation.Order
 import org.springframework.core.env.Environment
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpHeaders.ACCEPT_ENCODING
 import org.springframework.http.HttpHeaders.CONTENT_ENCODING
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
 import org.springframework.http.converter.StringHttpMessageConverter
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.stereotype.Component
 import org.springframework.web.context.annotation.RequestScope
 import org.springframework.web.filter.OncePerRequestFilter
+import tools.jackson.databind.ObjectMapper
 import java.io.IOException
 import java.io.OutputStream
 import java.nio.charset.Charset
@@ -273,59 +270,23 @@ class CompressingServletOutputStream(
 }
 
 @Component
-class CompressionAwareMappingJackson2HttpMessageConverter(
-    objectMapper: ObjectMapper,
-    private val requestCompression: RequestCompression,
-) : MappingJackson2HttpMessageConverter(objectMapper) {
-    override fun canWrite(mediaType: MediaType?): Boolean {
-        if (requestCompression.compressionSource.compression?.contentType?.isCompatibleWith(mediaType) == true) {
-            return true
-        }
-
-        return super.canWrite(mediaType)
-    }
-
-    override fun addDefaultHeaders(
-        headers: HttpHeaders,
-        value: Any,
-        contentType: MediaType?,
-    ) {
-        val compressionSource = requestCompression.compressionSource
-        if (
-            compressionSource is CompressionSource.RequestProperty &&
-            compressionSource.compression.contentType != contentType
-        ) {
-            headers.set(CONTENT_ENCODING, compressionSource.compression.value)
-        }
-
-        super.addDefaultHeaders(headers, value, contentType)
-    }
-}
-
-@Component
 class StringHttpMessageConverterWithUnknownContentLengthInCaseOfCompression(
     environment: Environment,
     private val requestCompression: RequestCompression,
 ) : StringHttpMessageConverter(getCharsetFromEnvironment(environment)) {
-    // The original method is declared in Java as returning Long (can be null)
-    // but in Kotlin it is Long! (platform type) which is not nullable.
-    @Suppress("INCOMPATIBLE_OVERRIDE")
     override fun getContentLength(
         str: String,
         contentType: MediaType?,
-    ): Long? =
+    ): Long =
         when (requestCompression.compressionSource.compression) {
             null -> super.getContentLength(str, contentType)
-            else -> null
+            else -> -1L
         }
 
     companion object {
-        // taken from the initialization in
-        // org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration
-        // since this class replaces that one
         private fun getCharsetFromEnvironment(environment: Environment): Charset =
             Binder.get(environment)
-                .bindOrCreate("server.servlet.encoding", Encoding::class.java)
-                .charset
+                .bind("server.servlet.encoding.charset", Charset::class.java)
+                .orElse(Charsets.UTF_8) ?: Charsets.UTF_8
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/CompressionFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/CompressionFilter.kt
@@ -284,6 +284,9 @@ class StringHttpMessageConverterWithUnknownContentLengthInCaseOfCompression(
         }
 
     companion object {
+        // taken from the initialization in
+        // org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration
+        // since this class replaces that one
         private fun getCharsetFromEnvironment(environment: Environment): Charset =
             Binder.get(environment)
                 .bind("server.servlet.encoding.charset", Charset::class.java)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/DataFormatParameterFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/DataFormatParameterFilter.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller.middleware
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -14,6 +13,7 @@ import org.springframework.http.HttpHeaders.ACCEPT
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+import tools.jackson.databind.ObjectMapper
 
 const val HEADERS_ACCEPT_HEADER_PARAMETER = "headers"
 const val ESCAPED_ACCEPT_HEADER_PARAMETER = "escaped"

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/DownloadAsFileFilter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/DownloadAsFileFilter.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller.middleware
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -19,6 +18,7 @@ import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+import tools.jackson.databind.ObjectMapper
 
 @Component
 @Order(DOWNLOAD_AS_FILE_FILTER_ORDER)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/JacksonFormHttpMessageConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/JacksonFormHttpMessageConverter.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller.middleware
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.genspectrum.lapis.util.tryToGuessTheType
 import org.springframework.http.HttpInputMessage
 import org.springframework.http.HttpOutputMessage
@@ -8,6 +7,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.converter.AbstractHttpMessageConverter
 import org.springframework.http.converter.FormHttpMessageConverter
 import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
 
 @Component
 class JacksonFormHttpMessageConverter(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/YamlHttpMessageConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/middleware/YamlHttpMessageConverter.kt
@@ -3,13 +3,14 @@ package org.genspectrum.lapis.controller.middleware
 import org.genspectrum.lapis.controller.LapisMediaType
 import org.genspectrum.lapis.util.YamlObjectMapper
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter
+import org.springframework.http.converter.AbstractJacksonHttpMessageConverter
 import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
 
 @Component
 class YamlHttpMessageConverter(
     yamlObjectMapper: YamlObjectMapper,
-) : AbstractJackson2HttpMessageConverter(
+) : AbstractJacksonHttpMessageConverter<ObjectMapper>(
         yamlObjectMapper.objectMapper,
         MediaType.parseMediaType(LapisMediaType.APPLICATION_YAML_VALUE),
     )

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
@@ -3,9 +3,9 @@ package org.genspectrum.lapis.health
 import org.genspectrum.lapis.silo.CachedSiloClient
 import org.genspectrum.lapis.silo.SiloNotReachableException
 import org.genspectrum.lapis.silo.SiloUnavailableException
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
-import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.boot.health.contributor.Status
 import org.springframework.stereotype.Component
 
 @Component
@@ -30,7 +30,7 @@ class SiloHealthIndicator(
                     it
                         .withDetail("siloStatus", Status.DOWN)
                         .withDetail("error", "SILO unavailable (HTTP 503)")
-                        .withDetail("retryAfter", e.retryAfter)
+                        .withDetail("retryAfter", e.retryAfter ?: "unknown")
                 } catch (_: Exception) {
                     it
                         .withDetail("siloStatus", Status.DOWN)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/logging/RequestContext.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/logging/RequestContext.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.logging
 
-import com.fasterxml.jackson.core.JsonProcessingException
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -11,6 +10,7 @@ import org.slf4j.Logger
 import org.springframework.stereotype.Component
 import org.springframework.web.context.annotation.RequestScope
 import org.springframework.web.filter.OncePerRequestFilter
+import tools.jackson.core.JacksonException
 
 @Component
 @RequestScope
@@ -58,7 +58,7 @@ class RequestContextLogger(
             requestContext.responseTimeInMilliSeconds = timeFactory.now() - before
             try {
                 statisticsLogger.info(objectMapper.writeValueAsString(requestContext))
-            } catch (e: JsonProcessingException) {
+            } catch (e: JacksonException) {
                 log.error(e) { "Could not log statistics message: " + e.message }
             }
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/logging/StatisticsLogObjectMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/logging/StatisticsLogObjectMapper.kt
@@ -11,7 +11,9 @@ class StatisticsLogObjectMapper {
     private val mapper = JsonMapper.builder()
         .addModule(kotlinModule())
         .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-        .changeDefaultPropertyInclusion { JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, null) }
+        .changeDefaultPropertyInclusion {
+            JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.USE_DEFAULTS)
+        }
         .build()
 
     fun writeValueAsString(requestContext: RequestContext): String =

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/logging/StatisticsLogObjectMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/logging/StatisticsLogObjectMapper.kt
@@ -1,24 +1,18 @@
 package org.genspectrum.lapis.logging
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.kotlinModule
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.stereotype.Component
+import tools.jackson.databind.SerializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 @Component
-class StatisticsLogObjectMapper(
-    objectMapperBuilder: Jackson2ObjectMapperBuilder,
-) {
-    private val mapper = objectMapperBuilder.build<ObjectMapper>().apply {
-        registerModule(JavaTimeModule())
-        registerModule(kotlinModule())
-        configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-        setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    }
+class StatisticsLogObjectMapper {
+    private val mapper = JsonMapper.builder()
+        .addModule(kotlinModule())
+        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+        .changeDefaultPropertyInclusion { JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, null) }
+        .build()
 
     fun writeValueAsString(requestContext: RequestContext): String =
         mapper.writerFor(RequestContext::class.java).writeValueAsString(requestContext)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/FastaHeaderTemplate.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/FastaHeaderTemplate.kt
@@ -1,11 +1,11 @@
 package org.genspectrum.lapis.model
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.request.CaseInsensitiveFieldsCleaner
 import org.springframework.stereotype.Component
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
 import java.util.Locale
 
 private const val SEGMENT_PLACEHOLDER = ".segment"
@@ -29,8 +29,8 @@ data class FastaHeaderTemplate(
             .map { field ->
                 when (field) {
                     is TemplateField.MetadataField -> field.fieldNameInTemplate to values[field.fieldNameInConfig]
-                    TemplateField.GeneField -> GENE_PLACEHOLDER to TextNode(sequenceName)
-                    TemplateField.SegmentField -> SEGMENT_PLACEHOLDER to TextNode(sequenceName)
+                    TemplateField.GeneField -> GENE_PLACEHOLDER to StringNode(sequenceName)
+                    TemplateField.SegmentField -> SEGMENT_PLACEHOLDER to StringNode(sequenceName)
                 }
             }
             .filter { (_, value) -> value != null }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/FastaHeaderTemplate.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/FastaHeaderTemplate.kt
@@ -37,7 +37,7 @@ data class FastaHeaderTemplate(
             .forEach { (field, value) ->
                 val replacement = when (value) {
                     is NullNode -> ""
-                    else -> value!!.asText()
+                    else -> value!!.asString()
                 }
                 result = result.replace("{$field}", replacement, ignoreCase = true)
             }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -406,7 +406,7 @@ class QueriesOverTimeModel(
         dateField: String,
         dateRanges: List<DateRange>,
     ): Int? {
-        val dateString = datum.fields[dateField]?.asText() ?: return null
+        val dateString = datum.fields[dateField]?.asString() ?: return null
 
         val date = LocalDate.parse(dateString)
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -64,7 +64,7 @@ import org.genspectrum.lapis.request.SEGMENTS_PROPERTY
 import org.genspectrum.lapis.response.COUNT_PROPERTY
 import org.genspectrum.lapis.response.LapisInfo
 import org.genspectrum.lapis.silo.ORDER_BY_RANDOM_FIELD_NAME
-import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties
 
 const val SECURITY_SCHEMA_NAME = "bearerAuth"
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
@@ -239,7 +239,12 @@ annotation class LapisMostRecentCommonAncestorResponse
 @Retention(AnnotationRetention.RUNTIME)
 @LapisResponseAnnotation(
     description = PHYLO_SUBTREE_ENDPOINT_DESCRIPTION,
-    content = [Content(examples = [ExampleObject("(seq1:3,(seq2:2,seq3:1)node2:1)node1:1;")])],
+    content = [
+        Content(
+            schema = Schema(type = "string"),
+            examples = [ExampleObject("(seq1:3,(seq2:2,seq3:1)node2:1)node1:1;")],
+        ),
+    ],
 )
 annotation class LapisPhyloSubtreeResponse
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidInsertion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidInsertion.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.ValueDeserializer
 
 const val STOP_CODON = "*"
 const val ESCAPED_STOP_CODON = "\\*"
@@ -64,10 +64,10 @@ private val AMINO_ACID_INSERTION_REGEX =
         ),
     )
 
-@JsonComponent
+@JacksonComponent
 class AminoAcidInsertionDeserializer(
     private val referenceGenomeSchema: ReferenceGenomeSchema,
-) : JsonDeserializer<AminoAcidInsertion>() {
+) : ValueDeserializer<AminoAcidInsertion>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidMutation.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/AminoAcidMutation.kt
@@ -1,14 +1,14 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
 import org.genspectrum.lapis.config.ReferenceGenome
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.ValueDeserializer
 
 data class AminoAcidMutation(
     val gene: String,
@@ -68,10 +68,10 @@ private val AMINO_ACID_MUTATION_REGEX =
         """^((?<gene>[a-zA-Z0-9_-]+):)(?<symbolFrom>[a-zA-Z*]?)(?<position>\d+)(?<symbolTo>[a-zA-Z*.-])?$""",
     )
 
-@JsonComponent
+@JacksonComponent
 class AminoAcidMutationDeserializer(
     private val referenceGenomeSchema: ReferenceGenomeSchema,
-) : JsonDeserializer<AminoAcidMutation>() {
+) : ValueDeserializer<AminoAcidMutation>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.ObjectCodec
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
-import com.fasterxml.jackson.databind.node.JsonNodeType
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.controller.BadRequestException
 import org.springframework.util.MultiValueMap
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.JsonNodeType
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
 
 typealias SequenceFilters = Map<String, List<String?>>
 typealias GetRequestSequenceFilters = MultiValueMap<String, String>
@@ -35,14 +35,14 @@ interface CommonSequenceFilters : BaseSequenceFilters {
 
 fun parseCommonFields(
     node: JsonNode,
-    codec: ObjectCodec,
+    ctxt: DeserializationContext,
 ): ParsedCommonFields {
-    val parsedMutationsAndInsertions = parseMutationsAndInsertions(node, codec)
+    val parsedMutationsAndInsertions = parseMutationsAndInsertions(node, ctxt)
 
     val orderByFields =
         when (val orderByNode = node.get(ORDER_BY_PROPERTY)) {
             null -> OrderBySpec.EMPTY
-            else -> codec.treeToValue(orderByNode, OrderBySpec::class.java)
+            else -> ctxt.readTreeAsValue(orderByNode, OrderBySpec::class.java)
         }
 
     val limitNode = node.get(LIMIT_PROPERTY)
@@ -75,39 +75,51 @@ fun parseCommonFields(
 
 fun parseMutationsAndInsertions(
     node: JsonNode,
-    codec: ObjectCodec,
+    ctxt: DeserializationContext,
 ): ParsedMutationsAndInsertions {
-    val nucleotideMutations = when (val nucleotideMutationsNode = node.get(NUCLEOTIDE_MUTATIONS_PROPERTY)) {
-        null -> emptyList()
-        is ArrayNode -> nucleotideMutationsNode.map { codec.treeToValue(it, NucleotideMutation::class.java) }
-        else -> throw BadRequestException(
-            "nucleotideMutations must be an array or null, ${butWas(nucleotideMutationsNode)}",
-        )
-    }
+    val nucleotideMutations: List<NucleotideMutation> =
+        when (val nucleotideMutationsNode = node.get(NUCLEOTIDE_MUTATIONS_PROPERTY)) {
+            null -> emptyList()
+            is ArrayNode -> nucleotideMutationsNode.toList().map {
+                ctxt.readTreeAsValue(it, NucleotideMutation::class.java)
+            }
+            else -> throw BadRequestException(
+                "nucleotideMutations must be an array or null, ${butWas(nucleotideMutationsNode)}",
+            )
+        }
 
-    val aminoAcidMutations = when (val aminoAcidMutationsNode = node.get(AMINO_ACID_MUTATIONS_PROPERTY)) {
-        null -> emptyList()
-        is ArrayNode -> aminoAcidMutationsNode.map { codec.treeToValue(it, AminoAcidMutation::class.java) }
-        else -> throw BadRequestException(
-            "aminoAcidMutations must be an array or null, ${butWas(aminoAcidMutationsNode)}",
-        )
-    }
+    val aminoAcidMutations: List<AminoAcidMutation> =
+        when (val aminoAcidMutationsNode = node.get(AMINO_ACID_MUTATIONS_PROPERTY)) {
+            null -> emptyList()
+            is ArrayNode -> aminoAcidMutationsNode.toList().map {
+                ctxt.readTreeAsValue(it, AminoAcidMutation::class.java)
+            }
+            else -> throw BadRequestException(
+                "aminoAcidMutations must be an array or null, ${butWas(aminoAcidMutationsNode)}",
+            )
+        }
 
-    val nucleotideInsertions = when (val nucleotideInsertionsNode = node.get(NUCLEOTIDE_INSERTIONS_PROPERTY)) {
-        null -> emptyList()
-        is ArrayNode -> nucleotideInsertionsNode.map { codec.treeToValue(it, NucleotideInsertion::class.java) }
-        else -> throw BadRequestException(
-            "nucleotideInsertions must be an array or null, ${butWas(nucleotideInsertionsNode)}",
-        )
-    }
+    val nucleotideInsertions: List<NucleotideInsertion> =
+        when (val nucleotideInsertionsNode = node.get(NUCLEOTIDE_INSERTIONS_PROPERTY)) {
+            null -> emptyList()
+            is ArrayNode -> nucleotideInsertionsNode.toList().map {
+                ctxt.readTreeAsValue(it, NucleotideInsertion::class.java)
+            }
+            else -> throw BadRequestException(
+                "nucleotideInsertions must be an array or null, ${butWas(nucleotideInsertionsNode)}",
+            )
+        }
 
-    val aminoAcidInsertions = when (val aminoAcidInsertionsNode = node.get(AMINO_ACID_INSERTIONS_PROPERTY)) {
-        null -> emptyList()
-        is ArrayNode -> aminoAcidInsertionsNode.map { codec.treeToValue(it, AminoAcidInsertion::class.java) }
-        else -> throw BadRequestException(
-            "aminoAcidInsertions must be an array or null, ${butWas(aminoAcidInsertionsNode)}",
-        )
-    }
+    val aminoAcidInsertions: List<AminoAcidInsertion> =
+        when (val aminoAcidInsertionsNode = node.get(AMINO_ACID_INSERTIONS_PROPERTY)) {
+            null -> emptyList()
+            is ArrayNode -> aminoAcidInsertionsNode.toList().map {
+                ctxt.readTreeAsValue(it, AminoAcidInsertion::class.java)
+            }
+            else -> throw BadRequestException(
+                "aminoAcidInsertions must be an array or null, ${butWas(aminoAcidInsertionsNode)}",
+            )
+        }
 
     return ParsedMutationsAndInsertions(
         nucleotideMutations,
@@ -124,7 +136,7 @@ fun parseSequenceFilters(
     node.properties()
         .asSequence()
         .filter { !fieldsToExclude.contains(it.key) }
-        .associate { it.key to getValuesList(it.value, it.key) }
+        .associate { (key, value) -> key to getValuesList(value, key) }
 
 fun butWas(jsonNode: JsonNode) = "but was $jsonNode (${jsonNode.nodeType})"
 
@@ -152,7 +164,7 @@ fun getValuesList(
 ) = when {
     value.isValueNode -> listOf(getValueNode(value))
 
-    value.nodeType == JsonNodeType.ARRAY -> value.map {
+    value.nodeType == JsonNodeType.ARRAY -> value.toList().map {
         when {
             it.isValueNode -> getValueNode(it)
             else -> throw BadRequestException(
@@ -175,7 +187,7 @@ fun getValueNode(value: JsonNode): String? {
 
 fun parseFastaHeaderTemplateParameter(node: JsonNode) =
     when (val fastaHeaderTemplate = node.get(FASTA_HEADER_TEMPLATE_PROPERTY)) {
-        is TextNode -> fastaHeaderTemplate.asText()
+        is StringNode -> fastaHeaderTemplate.asText()
         is NullNode -> null
         null -> null
         else -> throw BadRequestException(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
@@ -182,12 +182,12 @@ fun getValueNode(value: JsonNode): String? {
     if (value.isNull) {
         return null
     }
-    return value.asText()
+    return value.asString()
 }
 
 fun parseFastaHeaderTemplateParameter(node: JsonNode) =
     when (val fastaHeaderTemplate = node.get(FASTA_HEADER_TEMPLATE_PROPERTY)) {
-        is StringNode -> fastaHeaderTemplate.asText()
+        is StringNode -> fastaHeaderTemplate.asString()
         is NullNode -> null
         null -> null
         else -> throw BadRequestException(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/CommonSequenceFilters.kt
@@ -77,49 +77,45 @@ fun parseMutationsAndInsertions(
     node: JsonNode,
     ctxt: DeserializationContext,
 ): ParsedMutationsAndInsertions {
-    val nucleotideMutations: List<NucleotideMutation> =
-        when (val nucleotideMutationsNode = node.get(NUCLEOTIDE_MUTATIONS_PROPERTY)) {
-            null -> emptyList()
-            is ArrayNode -> nucleotideMutationsNode.toList().map {
-                ctxt.readTreeAsValue(it, NucleotideMutation::class.java)
-            }
-            else -> throw BadRequestException(
-                "nucleotideMutations must be an array or null, ${butWas(nucleotideMutationsNode)}",
-            )
+    val nucleotideMutations = when (val nucleotideMutationsNode = node.get(NUCLEOTIDE_MUTATIONS_PROPERTY)) {
+        null -> emptyList()
+        is ArrayNode -> nucleotideMutationsNode.toList().map {
+            ctxt.readTreeAsValue(it, NucleotideMutation::class.java)
         }
+        else -> throw BadRequestException(
+            "nucleotideMutations must be an array or null, ${butWas(nucleotideMutationsNode)}",
+        )
+    }
 
-    val aminoAcidMutations: List<AminoAcidMutation> =
-        when (val aminoAcidMutationsNode = node.get(AMINO_ACID_MUTATIONS_PROPERTY)) {
-            null -> emptyList()
-            is ArrayNode -> aminoAcidMutationsNode.toList().map {
-                ctxt.readTreeAsValue(it, AminoAcidMutation::class.java)
-            }
-            else -> throw BadRequestException(
-                "aminoAcidMutations must be an array or null, ${butWas(aminoAcidMutationsNode)}",
-            )
+    val aminoAcidMutations = when (val aminoAcidMutationsNode = node.get(AMINO_ACID_MUTATIONS_PROPERTY)) {
+        null -> emptyList()
+        is ArrayNode -> aminoAcidMutationsNode.toList().map {
+            ctxt.readTreeAsValue(it, AminoAcidMutation::class.java)
         }
+        else -> throw BadRequestException(
+            "aminoAcidMutations must be an array or null, ${butWas(aminoAcidMutationsNode)}",
+        )
+    }
 
-    val nucleotideInsertions: List<NucleotideInsertion> =
-        when (val nucleotideInsertionsNode = node.get(NUCLEOTIDE_INSERTIONS_PROPERTY)) {
-            null -> emptyList()
-            is ArrayNode -> nucleotideInsertionsNode.toList().map {
-                ctxt.readTreeAsValue(it, NucleotideInsertion::class.java)
-            }
-            else -> throw BadRequestException(
-                "nucleotideInsertions must be an array or null, ${butWas(nucleotideInsertionsNode)}",
-            )
+    val nucleotideInsertions = when (val nucleotideInsertionsNode = node.get(NUCLEOTIDE_INSERTIONS_PROPERTY)) {
+        null -> emptyList()
+        is ArrayNode -> nucleotideInsertionsNode.toList().map {
+            ctxt.readTreeAsValue(it, NucleotideInsertion::class.java)
         }
+        else -> throw BadRequestException(
+            "nucleotideInsertions must be an array or null, ${butWas(nucleotideInsertionsNode)}",
+        )
+    }
 
-    val aminoAcidInsertions: List<AminoAcidInsertion> =
-        when (val aminoAcidInsertionsNode = node.get(AMINO_ACID_INSERTIONS_PROPERTY)) {
-            null -> emptyList()
-            is ArrayNode -> aminoAcidInsertionsNode.toList().map {
-                ctxt.readTreeAsValue(it, AminoAcidInsertion::class.java)
-            }
-            else -> throw BadRequestException(
-                "aminoAcidInsertions must be an array or null, ${butWas(aminoAcidInsertionsNode)}",
-            )
+    val aminoAcidInsertions = when (val aminoAcidInsertionsNode = node.get(AMINO_ACID_INSERTIONS_PROPERTY)) {
+        null -> emptyList()
+        is ArrayNode -> aminoAcidInsertionsNode.toList().map {
+            ctxt.readTreeAsValue(it, AminoAcidInsertion::class.java)
         }
+        else -> throw BadRequestException(
+            "aminoAcidInsertions must be an array or null, ${butWas(aminoAcidInsertionsNode)}",
+        )
+    }
 
     return ParsedMutationsAndInsertions(
         nucleotideMutations,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.NumericNode
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.NumericNode
 
 const val DEFAULT_MIN_PROPORTION = 0.05
 
@@ -48,14 +48,13 @@ enum class MutationsField(
     }
 }
 
-@JsonComponent
-class MutationProportionsRequestDeserializer : JsonDeserializer<MutationProportionsRequest>() {
+@JacksonComponent
+class MutationProportionsRequestDeserializer : ValueDeserializer<MutationProportionsRequest>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): MutationProportionsRequest {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val minProportion = when (val minProportionNode = node.get(MIN_PROPORTION_PROPERTY)) {
             null, is NullNode -> DEFAULT_MIN_PROPORTION
@@ -65,7 +64,7 @@ class MutationProportionsRequestDeserializer : JsonDeserializer<MutationProporti
         }
 
         val fields = parseFieldsProperty(node) { MutationsField.fromString(it) }
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return MutationProportionsRequest(
             sequenceFilters = parsedCommonFields.sequenceFilters,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideInsertion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideInsertion.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.ValueDeserializer
 
 const val LAPIS_INSERTION_AMBIGUITY_SYMBOL = "?"
 const val SILO_INSERTION_AMBIGUITY_SYMBOL = ".*"
@@ -64,10 +64,10 @@ private val NUCLEOTIDE_INSERTION_REGEX =
         ),
     )
 
-@JsonComponent
+@JacksonComponent
 class NucleotideInsertionDeserializer(
     private val referenceGenomeSchema: ReferenceGenomeSchema,
-) : JsonDeserializer<NucleotideInsertion>() {
+) : ValueDeserializer<NucleotideInsertion>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideMutation.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideMutation.kt
@@ -1,14 +1,14 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
 import org.genspectrum.lapis.config.ReferenceGenome
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.ValueDeserializer
 
 data class NucleotideMutation(
     val sequenceName: String?,
@@ -72,10 +72,10 @@ private val NUCLEOTIDE_MUTATION_REGEX =
         """^((?<sequenceName>[a-zA-Z0-9_-]+)(?=:):)?(?<symbolFrom>[a-zA-Z]?)(?<position>\d+)(?<symbolTo>[a-zA-Z.-])?$""",
     )
 
-@JsonComponent
+@JacksonComponent
 class NucleotideMutationDeserializer(
     private val referenceGenomeSchema: ReferenceGenomeSchema,
-) : JsonDeserializer<NucleotideMutation>() {
+) : ValueDeserializer<NucleotideMutation>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/OrderByField.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/OrderByField.kt
@@ -98,7 +98,7 @@ class OrderByFieldDeserializer(
         ctxt: DeserializationContext,
     ): OrderByField =
         when (val value = jsonParser.readValueAsTree<JsonNode>()) {
-            is StringNode -> OrderByField(orderByFieldsCleaner.clean(value.asText()), Order.ASCENDING)
+            is StringNode -> OrderByField(orderByFieldsCleaner.clean(value.asString()), Order.ASCENDING)
             is ObjectNode -> deserializeOrderByField(value)
             else -> throw BadRequestException("orderByField must be a string or an object")
         }
@@ -109,13 +109,13 @@ class OrderByFieldDeserializer(
             throw BadRequestException("orderByField must have a string property \"field\", was $value")
         }
 
-        val ascending = when (value.get("type")?.asText()) {
+        val ascending = when (value.get("type")?.asString()) {
             "ascending", null -> Order.ASCENDING
             "descending" -> Order.DESCENDING
             else -> throw BadRequestException("orderByField type must be \"ascending\" or \"descending\"")
         }
 
-        return OrderByField(orderByFieldsCleaner.clean(fieldNode.asText()), ascending)
+        return OrderByField(orderByFieldsCleaner.clean(fieldNode.asString()), ascending)
     }
 }
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/OrderByField.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/OrderByField.kt
@@ -2,16 +2,16 @@ package org.genspectrum.lapis.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
 import org.springframework.core.convert.converter.Converter
 import org.springframework.stereotype.Component
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.node.ObjectNode
+import tools.jackson.databind.node.StringNode
 
 /**
  * Order by can either be a list of fields or it can be random, with an integer seed
@@ -39,8 +39,8 @@ sealed class OrderBySpec {
  * or random with seed:
  * `{random: 123}`
  */
-@JsonComponent
-class OrderBySpecDeserializer : JsonDeserializer<OrderBySpec>() {
+@JacksonComponent
+class OrderBySpecDeserializer : ValueDeserializer<OrderBySpec>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,
@@ -49,9 +49,9 @@ class OrderBySpecDeserializer : JsonDeserializer<OrderBySpec>() {
 
         return when {
             node.isArray -> {
-                val fields =
-                    node.map { fieldNode ->
-                        p.codec.treeToValue(fieldNode, OrderByField::class.java)
+                val fields: List<OrderByField> =
+                    node.toList().map { fieldNode ->
+                        ctxt.readTreeAsValue(fieldNode, OrderByField::class.java)
                     }
                 fields.toOrderBySpec()
             }
@@ -89,23 +89,23 @@ enum class Order {
     DESCENDING,
 }
 
-@JsonComponent
+@JacksonComponent
 class OrderByFieldDeserializer(
     private val orderByFieldsCleaner: OrderByFieldsCleaner,
-) : JsonDeserializer<OrderByField>() {
+) : ValueDeserializer<OrderByField>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): OrderByField =
         when (val value = jsonParser.readValueAsTree<JsonNode>()) {
-            is TextNode -> OrderByField(orderByFieldsCleaner.clean(value.asText()), Order.ASCENDING)
+            is StringNode -> OrderByField(orderByFieldsCleaner.clean(value.asText()), Order.ASCENDING)
             is ObjectNode -> deserializeOrderByField(value)
             else -> throw BadRequestException("orderByField must be a string or an object")
         }
 
     private fun deserializeOrderByField(value: ObjectNode): OrderByField {
         val fieldNode = value.get("field")
-        if (fieldNode == null || fieldNode !is TextNode) {
+        if (fieldNode == null || fieldNode !is StringNode) {
             throw BadRequestException("orderByField must have a string property \"field\", was $value")
         }
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/PhyloTreeSequenceFiltersRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/PhyloTreeSequenceFiltersRequest.kt
@@ -103,12 +103,12 @@ fun parsePhyloTreeProperty(
             "$PHYLO_TREE_FIELD_PROPERTY is required and must be a string representing a phylo tree field",
         )
     }
-    if (!phyloTreeField.isTextual) {
+    if (!phyloTreeField.isString) {
         throw BadRequestException(
             "$PHYLO_TREE_FIELD_PROPERTY must be a string, but was ${phyloTreeField.nodeType}",
         )
     }
-    return validatePhyloTreeField(phyloTreeField.textValue(), fieldConverter, databaseConfig)
+    return validatePhyloTreeField(phyloTreeField.stringValue(), fieldConverter, databaseConfig)
 }
 
 fun parsePrintNodesNotInTree(node: JsonNode): Boolean {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/PhyloTreeSequenceFiltersRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/PhyloTreeSequenceFiltersRequest.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.node.JsonNodeFactory
 
 data class PhyloTreeSequenceFiltersRequest(
     override val sequenceFilters: SequenceFilters,
@@ -34,20 +34,19 @@ data class MRCASequenceFiltersRequest(
     val printNodesNotInTree: Boolean = false,
 ) : CommonSequenceFilters
 
-@JsonComponent
+@JacksonComponent
 class PhyloTreeSequenceFiltersRequestDeserializer(
     private val fieldConverter: CaseInsensitiveFieldConverter,
     private val databaseConfig: DatabaseConfig,
-) : JsonDeserializer<PhyloTreeSequenceFiltersRequest>() {
+) : ValueDeserializer<PhyloTreeSequenceFiltersRequest>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): PhyloTreeSequenceFiltersRequest {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val phyloTreeField = parsePhyloTreeProperty(node, fieldConverter, databaseConfig)
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return PhyloTreeSequenceFiltersRequest(
             parsedCommonFields.sequenceFilters,
@@ -63,21 +62,20 @@ class PhyloTreeSequenceFiltersRequestDeserializer(
     }
 }
 
-@JsonComponent
+@JacksonComponent
 class MRCASequenceFiltersRequestDeserializer(
     private val fieldConverter: CaseInsensitiveFieldConverter,
     private val databaseConfig: DatabaseConfig,
-) : JsonDeserializer<MRCASequenceFiltersRequest>() {
+) : ValueDeserializer<MRCASequenceFiltersRequest>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): MRCASequenceFiltersRequest {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val phyloTreeField = parsePhyloTreeProperty(node, fieldConverter, databaseConfig)
         val printNodesNotInTree = parsePrintNodesNotInTree(node)
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return MRCASequenceFiltersRequest(
             parsedCommonFields.sequenceFilters,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/QueriesOverTimeRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/QueriesOverTimeRequest.kt
@@ -1,12 +1,12 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.v3.oas.annotations.media.Schema
 import org.genspectrum.lapis.model.mutationsOverTime.DateRange
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
 
 data class NucleotideMutationsOverTimeRequest(
     val filters: QueriesOverTimeRequestFilters,
@@ -52,16 +52,15 @@ data class QueriesOverTimeRequestFilters(
     override val aminoAcidInsertions: List<AminoAcidInsertion>,
 ) : BaseSequenceFilters
 
-@JsonComponent
-class QueriesOverTimeRequestFiltersDeserializer : JsonDeserializer<QueriesOverTimeRequestFilters>() {
+@JacksonComponent
+class QueriesOverTimeRequestFiltersDeserializer : ValueDeserializer<QueriesOverTimeRequestFilters>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): QueriesOverTimeRequestFilters {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return QueriesOverTimeRequestFilters(
             parsedCommonFields.sequenceFilters,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequest.kt
@@ -1,10 +1,10 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
 
 data class SequenceFiltersRequest(
     override val sequenceFilters: SequenceFilters,
@@ -18,17 +18,16 @@ data class SequenceFiltersRequest(
     val fastaHeaderTemplate: String? = null,
 ) : CommonSequenceFilters
 
-@JsonComponent
-class SequenceFiltersRequestDeserializer : JsonDeserializer<SequenceFiltersRequest>() {
+@JacksonComponent
+class SequenceFiltersRequestDeserializer : ValueDeserializer<SequenceFiltersRequest>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): SequenceFiltersRequest {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val fastaHeaderTemplate = parseFastaHeaderTemplateParameter(node)
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return SequenceFiltersRequest(
             sequenceFilters = parsedCommonFields.sequenceFilters,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
@@ -52,7 +52,7 @@ fun <T> parseFieldsProperty(
     fieldConverter: FieldConverter<T>,
 ) = when (val fields = node.get(FIELDS_PROPERTY)) {
     null -> emptyList()
-    is ArrayNode -> fields.asSequence().map { fieldConverter.convert(it.asText()) }.toList()
+    is ArrayNode -> fields.asSequence().map { fieldConverter.convert(it.asString()) }.toList()
     else -> throw BadRequestException(
         "$FIELDS_PROPERTY must be an array or null",
     )

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
@@ -1,12 +1,12 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.node.ArrayNode
 
 data class SequenceFiltersRequestWithFields(
     override val sequenceFilters: SequenceFilters,
@@ -20,19 +20,18 @@ data class SequenceFiltersRequestWithFields(
     override val offset: Int? = null,
 ) : CommonSequenceFilters
 
-@JsonComponent
+@JacksonComponent
 class SequenceFiltersRequestWithFieldsDeserializer(
     private val caseInsensitiveFieldConverter: CaseInsensitiveFieldConverter,
-) : JsonDeserializer<SequenceFiltersRequestWithFields>() {
+) : ValueDeserializer<SequenceFiltersRequestWithFields>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): SequenceFiltersRequestWithFields {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val fields = parseFieldsProperty(node, caseInsensitiveFieldConverter)
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return SequenceFiltersRequestWithFields(
             parsedCommonFields.sequenceFilters,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithGenes.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithGenes.kt
@@ -57,13 +57,13 @@ class SequenceFiltersRequestWithGenesDeserializer(
                 genes.toList().map {
                     if (!it.isString) {
                         throw BadRequestException(
-                            "$GENES_PROPERTY items must be strings, but was ${it.nodeType}: ${it.stringValue()}",
+                            "$GENES_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asString()}",
                         )
                     }
                     referenceGenomeSchema.getGene(it.stringValue())
                         ?.name
                         ?: throw BadRequestException(
-                            "Unknown gene: ${it.stringValue()}, " +
+                            "Unknown gene: ${it.asString()}, " +
                                 "available genes: ${referenceGenomeSchema.getGeneNames()}",
                         )
                 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithGenes.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithGenes.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.node.ArrayNode
 
 data class SequenceFiltersRequestWithGenes(
     override val sequenceFilters: SequenceFilters,
@@ -22,20 +22,19 @@ data class SequenceFiltersRequestWithGenes(
     val fastaHeaderTemplate: String? = null,
 ) : CommonSequenceFilters
 
-@JsonComponent
+@JacksonComponent
 class SequenceFiltersRequestWithGenesDeserializer(
     private val referenceGenomeSchema: ReferenceGenomeSchema,
-) : JsonDeserializer<SequenceFiltersRequestWithGenes>() {
+) : ValueDeserializer<SequenceFiltersRequestWithGenes>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): SequenceFiltersRequestWithGenes {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val genes = parseGenes(node)
         val fastaHeaderTemplate = parseFastaHeaderTemplateParameter(node)
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return SequenceFiltersRequestWithGenes(
             sequenceFilters = parsedCommonFields.sequenceFilters,
@@ -51,11 +50,11 @@ class SequenceFiltersRequestWithGenesDeserializer(
         )
     }
 
-    private fun parseGenes(node: JsonNode) =
+    private fun parseGenes(node: JsonNode): List<String> =
         when (val genes = node.get(GENES_PROPERTY)) {
             null -> referenceGenomeSchema.getGeneNames()
             is ArrayNode -> {
-                genes.map {
+                genes.toList().map {
                     if (!it.isTextual) {
                         throw BadRequestException(
                             "$GENES_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asText()}",

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithGenes.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithGenes.kt
@@ -55,15 +55,15 @@ class SequenceFiltersRequestWithGenesDeserializer(
             null -> referenceGenomeSchema.getGeneNames()
             is ArrayNode -> {
                 genes.toList().map {
-                    if (!it.isTextual) {
+                    if (!it.isString) {
                         throw BadRequestException(
-                            "$GENES_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asText()}",
+                            "$GENES_PROPERTY items must be strings, but was ${it.nodeType}: ${it.stringValue()}",
                         )
                     }
-                    referenceGenomeSchema.getGene(it.textValue())
+                    referenceGenomeSchema.getGene(it.stringValue())
                         ?.name
                         ?: throw BadRequestException(
-                            "Unknown gene: ${it.asText()}, " +
+                            "Unknown gene: ${it.stringValue()}, " +
                                 "available genes: ${referenceGenomeSchema.getGeneNames()}",
                         )
                 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithSegments.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithSegments.kt
@@ -55,15 +55,15 @@ class SequenceFiltersRequestWithSegmentsDeserializer(
             null -> referenceGenomeSchema.getNucleotideSequenceNames()
             is ArrayNode -> {
                 segments.toList().map {
-                    if (!it.isTextual) {
+                    if (!it.isString) {
                         throw BadRequestException(
-                            "$SEGMENTS_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asText()}",
+                            "$SEGMENTS_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asString()}",
                         )
                     }
-                    referenceGenomeSchema.getNucleotideSequence(it.textValue())
+                    referenceGenomeSchema.getNucleotideSequence(it.asString())
                         ?.name
                         ?: throw BadRequestException(
-                            "Unknown segment: ${it.asText()}, " +
+                            "Unknown segment: ${it.asString()}, " +
                                 "available segments: ${referenceGenomeSchema.getNucleotideSequenceNames()}",
                         )
                 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithSegments.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithSegments.kt
@@ -1,13 +1,13 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.node.ArrayNode
 
 data class SequenceFiltersRequestWithSegments(
     override val sequenceFilters: SequenceFilters,
@@ -22,20 +22,19 @@ data class SequenceFiltersRequestWithSegments(
     val fastaHeaderTemplate: String? = null,
 ) : CommonSequenceFilters
 
-@JsonComponent
+@JacksonComponent
 class SequenceFiltersRequestWithSegmentsDeserializer(
     private val referenceGenomeSchema: ReferenceGenomeSchema,
-) : JsonDeserializer<SequenceFiltersRequestWithSegments>() {
+) : ValueDeserializer<SequenceFiltersRequestWithSegments>() {
     override fun deserialize(
         jsonParser: JsonParser,
         ctxt: DeserializationContext,
     ): SequenceFiltersRequestWithSegments {
         val node = jsonParser.readValueAsTree<JsonNode>()
-        val codec = jsonParser.codec
 
         val segments = parseSegments(node)
         val fastaHeaderTemplate = parseFastaHeaderTemplateParameter(node)
-        val parsedCommonFields = parseCommonFields(node, codec)
+        val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return SequenceFiltersRequestWithSegments(
             sequenceFilters = parsedCommonFields.sequenceFilters,
@@ -51,11 +50,11 @@ class SequenceFiltersRequestWithSegmentsDeserializer(
         )
     }
 
-    private fun parseSegments(node: JsonNode) =
+    private fun parseSegments(node: JsonNode): List<String> =
         when (val segments = node.get(SEGMENTS_PROPERTY)) {
             null -> referenceGenomeSchema.getNucleotideSequenceNames()
             is ArrayNode -> {
-                segments.map {
+                segments.toList().map {
                     if (!it.isTextual) {
                         throw BadRequestException(
                             "$SEGMENTS_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asText()}",

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithSegments.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithSegments.kt
@@ -60,7 +60,7 @@ class SequenceFiltersRequestWithSegmentsDeserializer(
                             "$SEGMENTS_PROPERTY items must be strings, but was ${it.nodeType}: ${it.asString()}",
                         )
                     }
-                    referenceGenomeSchema.getNucleotideSequence(it.asString())
+                    referenceGenomeSchema.getNucleotideSequence(it.stringValue())
                         ?.name
                         ?: throw BadRequestException(
                             "Unknown segment: ${it.asString()}, " +

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SpecialProperties.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SpecialProperties.kt
@@ -1,6 +1,6 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.node.JsonNodeType
+import tools.jackson.databind.node.JsonNodeType
 
 const val FORMAT_PROPERTY = "dataFormat"
 const val MIN_PROPORTION_PROPERTY = "minProportion"

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponseStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponseStreamer.kt
@@ -1,7 +1,6 @@
 package org.genspectrum.lapis.response
 
 import jakarta.servlet.http.HttpServletResponse
-import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_CSV_VALUE
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_TSV_VALUE
 import org.genspectrum.lapis.controller.middleware.ESCAPED_ACCEPT_HEADER_PARAMETER
@@ -11,6 +10,7 @@ import org.genspectrum.lapis.request.CommonSequenceFilters
 import org.genspectrum.lapis.response.Delimiter.COMMA
 import org.genspectrum.lapis.response.Delimiter.TAB
 import org.genspectrum.lapis.silo.DataVersion
+import org.genspectrum.lapis.silo.setHeaderOn
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -45,7 +45,7 @@ class LapisResponseStreamer(
         requestContext.filter = request
         val data = getData(request)
 
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
+        dataVersion.setHeaderOn(response)
 
         when (responseFormat) {
             is ResponseFormat.Json -> {
@@ -145,7 +145,7 @@ class LapisResponseStreamer(
             else -> MediaType(targetMediaType, Charset.defaultCharset())
         }
 
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
+        dataVersion.setHeaderOn(response)
         if (response.contentType == null) {
             response.contentType = contentType.toString()
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponseStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponseStreamer.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.response
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletResponse
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_CSV_VALUE
@@ -15,6 +14,7 @@ import org.genspectrum.lapis.silo.DataVersion
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
 import java.nio.charset.Charset
 import java.util.stream.Stream
 
@@ -71,14 +71,13 @@ class LapisResponseStreamer(
             response.contentType = MediaType(MediaType.APPLICATION_JSON).toString()
         }
 
-        val jsonFactory = objectMapper.factory
         sequenceData.use { inputStream ->
             response.outputStream.writer().use { outputStream ->
-                jsonFactory.createGenerator(outputStream).use { generator ->
+                objectMapper.createGenerator(outputStream).use { generator ->
                     streamAndLogDisconnect("Plain JSON data") {
                         generator.writeStartArray()
                         inputStream.forEach {
-                            generator.writeObject(it)
+                            generator.writePOJO(it)
                         }
                         generator.writeEndArray()
                     }
@@ -95,21 +94,19 @@ class LapisResponseStreamer(
             response.contentType = MediaType(MediaType.APPLICATION_JSON).toString()
         }
 
-        val jsonFactory = objectMapper.factory
-
         sequenceData.use { inputStream ->
             response.outputStream.writer().use { outputStream ->
-                jsonFactory.createGenerator(outputStream).use { generator ->
+                objectMapper.createGenerator(outputStream).use { generator ->
                     streamAndLogDisconnect("Lapis JSON data") {
                         generator.writeStartObject()
 
-                        generator.writeArrayFieldStart("data")
+                        generator.writeArrayPropertyStart("data")
                         inputStream.forEach {
-                            generator.writeObject(it)
+                            generator.writePOJO(it)
                         }
                         generator.writeEndArray()
 
-                        generator.writePOJOField("info", lapisInfoFactory.create())
+                        generator.writePOJOProperty("info", lapisInfoFactory.create())
 
                         generator.writeEndObject()
                     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponseStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponseStreamer.kt
@@ -45,7 +45,7 @@ class LapisResponseStreamer(
         requestContext.filter = request
         val data = getData(request)
 
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion)
+        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
 
         when (responseFormat) {
             is ResponseFormat.Json -> {
@@ -145,7 +145,7 @@ class LapisResponseStreamer(
             else -> MediaType(targetMediaType, Charset.defaultCharset())
         }
 
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion)
+        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
         if (response.contentType == null) {
             response.contentType = contentType.toString()
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/QueryParseResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/QueryParseResponse.kt
@@ -9,7 +9,7 @@ data class QueryParseResponse(
 )
 
 sealed interface ParsedQueryResult {
-    @Schema(description = "Successful query parse result")
+    @Schema(description = "Successful query parse result", requiredProperties = ["filter", "type"])
     data class Success(
         @field:Schema(description = "The parsed SILO filter expression")
         val filter: SiloFilterExpression,
@@ -22,7 +22,7 @@ sealed interface ParsedQueryResult {
             get() = "success"
     }
 
-    @Schema(description = "Failed query parse result")
+    @Schema(description = "Failed query parse result", requiredProperties = ["error", "type"])
     data class Failure(
         @field:Schema(description = "Error message describing why parsing failed")
         val error: String,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/QueryParseResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/QueryParseResponse.kt
@@ -9,7 +9,7 @@ data class QueryParseResponse(
 )
 
 sealed interface ParsedQueryResult {
-    @Schema(description = "Successful query parse result", requiredProperties = ["filter", "type"])
+    @Schema(description = "Successful query parse result")
     data class Success(
         @field:Schema(description = "The parsed SILO filter expression")
         val filter: SiloFilterExpression,
@@ -22,7 +22,7 @@ sealed interface ParsedQueryResult {
             get() = "success"
     }
 
-    @Schema(description = "Failed query parse result", requiredProperties = ["error", "type"])
+    @Schema(description = "Failed query parse result")
     data class Failure(
         @field:Schema(description = "Error message describing why parsing failed")
         val error: String,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/ResponseCollections.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/ResponseCollections.kt
@@ -1,8 +1,8 @@
 package org.genspectrum.lapis.response
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.NullNode
 import org.genspectrum.lapis.request.MutationsField
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.NullNode
 import java.util.stream.Stream
 
 class AggregatedCollection(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/ResponseCollections.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/ResponseCollections.kt
@@ -45,7 +45,7 @@ class DetailsCollection(
 private fun JsonNode.toCsvValue() =
     when (this) {
         is NullNode -> null
-        else -> asText()
+        else -> asString()
     }
 
 class MutationsCollection(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
@@ -1,11 +1,11 @@
 package org.genspectrum.lapis.response
 
 import jakarta.servlet.http.HttpServletResponse
-import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_X_FASTA
 import org.genspectrum.lapis.controller.middleware.SequencesDataFormat
 import org.genspectrum.lapis.model.SequencesResponse
 import org.genspectrum.lapis.silo.DataVersion
+import org.genspectrum.lapis.silo.setHeaderOn
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
@@ -22,7 +22,7 @@ class SequencesStreamer(
         response: HttpServletResponse,
         sequencesDataFormat: SequencesDataFormat,
     ) {
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
+        dataVersion.setHeaderOn(response)
 
         when (sequencesDataFormat) {
             SequencesDataFormat.FASTA -> streamFasta(response, sequencesResponse)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
@@ -22,7 +22,7 @@ class SequencesStreamer(
         response: HttpServletResponse,
         sequencesDataFormat: SequencesDataFormat,
     ) {
-        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion)
+        response.setHeader(LAPIS_DATA_VERSION, dataVersion.dataVersion ?: "")
 
         when (sequencesDataFormat) {
             SequencesDataFormat.FASTA -> streamFasta(response, sequencesResponse)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
@@ -53,7 +53,7 @@ class SequencesStreamer(
                                 values = it,
                                 sequenceName = sequenceName,
                             )
-                            outputStream.appendLine(">$fastaHeader\n${sequence.asText()}")
+                            outputStream.appendLine(">$fastaHeader\n${sequence.asString()}")
                         }
                     }
                 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SequencesStreamer.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.response
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.NullNode
 import jakarta.servlet.http.HttpServletResponse
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_X_FASTA
@@ -10,6 +8,8 @@ import org.genspectrum.lapis.model.SequencesResponse
 import org.genspectrum.lapis.silo.DataVersion
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.node.NullNode
 import java.nio.charset.Charset
 
 @Component

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -1,11 +1,11 @@
 package org.genspectrum.lapis.response
 
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.SerializerProvider
 import io.swagger.v3.oas.annotations.media.Schema
-import org.springframework.boot.jackson.JsonComponent
+import org.springframework.boot.jackson.JacksonComponent
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueSerializer
 
 const val COUNT_PROPERTY = "count"
 
@@ -18,16 +18,16 @@ data class DetailsData(
     val map: Map<String, JsonNode>,
 ) : Map<String, JsonNode> by map
 
-@JsonComponent
-class AggregationDataSerializer : JsonSerializer<AggregationData>() {
+@JacksonComponent
+class AggregationDataSerializer : ValueSerializer<AggregationData>() {
     override fun serialize(
         value: AggregationData,
         gen: JsonGenerator,
-        serializers: SerializerProvider,
+        serializers: SerializationContext,
     ) {
         gen.writeStartObject()
-        gen.writeNumberField(COUNT_PROPERTY, value.count)
-        value.fields.forEach { (key, value) -> gen.writeObjectField(key, value) }
+        gen.writeNumberProperty(COUNT_PROPERTY, value.count)
+        value.fields.forEach { (key, value) -> gen.writePOJOProperty(key, value) }
         gen.writeEndObject()
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -1,13 +1,5 @@
 package org.genspectrum.lapis.silo
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.FloatNode
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.LongNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.apache.arrow.vector.BigIntVector
 import org.apache.arrow.vector.BitVector
 import org.apache.arrow.vector.DateDayVector
@@ -25,6 +17,14 @@ import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
 import org.genspectrum.lapis.util.UNALIGNED_PREFIX
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.BooleanNode
+import tools.jackson.databind.node.DoubleNode
+import tools.jackson.databind.node.FloatNode
+import tools.jackson.databind.node.IntNode
+import tools.jackson.databind.node.LongNode
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
 
 /**
  * Converts one row at `rowIndex` from an Arrow [org.apache.arrow.vector.VectorSchemaRoot] to a typed Kotlin object.
@@ -183,13 +183,13 @@ private fun VectorSchemaRoot.fieldValueAsJsonNode(
     val vector = fieldVectors[columnIndex]
     if (vector.isNull(rowIndex)) return NullNode.instance
     return when (vector) {
-        is VarCharVector -> TextNode(String(vector.get(rowIndex), Charsets.UTF_8))
+        is VarCharVector -> StringNode(String(vector.get(rowIndex), Charsets.UTF_8))
         is IntVector -> IntNode(vector.get(rowIndex))
         is BigIntVector -> LongNode(vector.get(rowIndex))
         is Float8Vector -> DoubleNode(vector.get(rowIndex))
         is Float4Vector -> FloatNode(vector.get(rowIndex))
         is BitVector -> BooleanNode.valueOf(vector.get(rowIndex) != 0)
-        is DateDayVector -> TextNode(java.time.LocalDate.ofEpochDay(vector.get(rowIndex).toLong()).toString())
-        else -> TextNode(vector.getObject(rowIndex)?.toString() ?: "")
+        is DateDayVector -> StringNode(java.time.LocalDate.ofEpochDay(vector.get(rowIndex).toLong()).toString())
+        else -> StringNode(vector.getObject(rowIndex)?.toString() ?: "")
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/DataVersion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/DataVersion.kt
@@ -1,5 +1,8 @@
 package org.genspectrum.lapis.silo
 
+import jakarta.servlet.http.HttpServletResponse
+import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.web.context.annotation.RequestScope
 
@@ -8,3 +11,10 @@ import org.springframework.web.context.annotation.RequestScope
 data class DataVersion(
     var dataVersion: String? = null,
 )
+
+fun DataVersion.setHeaderOn(response: HttpServletResponse) {
+    dataVersion?.let { response.setHeader(LAPIS_DATA_VERSION, it) }
+}
+
+fun DataVersion.setHeaderOn(builder: ResponseEntity.BodyBuilder): ResponseEntity.BodyBuilder =
+    dataVersion?.let { builder.header(LAPIS_DATA_VERSION, it) } ?: builder

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -1,8 +1,6 @@
 package org.genspectrum.lapis.silo
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.ipc.ArrowStreamReader
 import org.genspectrum.lapis.config.DatabaseConfig
@@ -18,6 +16,8 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.context.request.RequestContextHolder
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.io.IOException
 import java.io.InputStream
 import java.net.ConnectException

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -3,10 +3,6 @@ package org.genspectrum.lapis.silo
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.JsonSerializer
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
 import org.genspectrum.lapis.response.AggregationData
@@ -16,6 +12,10 @@ import org.genspectrum.lapis.response.MostCommonAncestorData
 import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.ValueSerializer
+import tools.jackson.databind.annotation.JsonSerialize
 import java.time.LocalDate
 
 data class SiloQuery<ResponseType>(
@@ -457,11 +457,11 @@ sealed class RandomizeConfig {
     ) : RandomizeConfig()
 }
 
-class RandomizeConfigSerializer : JsonSerializer<RandomizeConfig>() {
+class RandomizeConfigSerializer : ValueSerializer<RandomizeConfig>() {
     override fun serialize(
         value: RandomizeConfig,
         gen: JsonGenerator,
-        serializers: SerializerProvider,
+        serializers: SerializationContext,
     ) {
         when (value) {
             is RandomizeConfig.Enabled -> {
@@ -474,7 +474,7 @@ class RandomizeConfigSerializer : JsonSerializer<RandomizeConfig>() {
 
             is RandomizeConfig.WithSeed -> {
                 gen.writeStartObject()
-                gen.writeNumberField("seed", value.seed)
+                gen.writeNumberProperty("seed", value.seed)
                 gen.writeEndObject()
             }
         }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/util/CachedBodyHttpServletRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/util/CachedBodyHttpServletRequest.kt
@@ -94,8 +94,8 @@ class CachedBodyHttpServletRequest private constructor(
         }
         if (method != HttpMethod.GET.name()) {
             val fieldValue = parsedBody[fieldName]
-            if (fieldValue?.isTextual == true) {
-                return fieldValue.asText()
+            if (fieldValue?.isString == true) {
+                return fieldValue.asString()
             }
         }
         return null
@@ -120,7 +120,7 @@ class CachedBodyHttpServletRequest private constructor(
 
         val fieldValue = parsedBody[fieldName]
         if (fieldValue?.isArray == true) {
-            return fieldValue.toList().map { it.asText() }
+            return fieldValue.toList().map { it.asString() }
         }
         return emptyList()
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/util/CachedBodyHttpServletRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/util/CachedBodyHttpServletRequest.kt
@@ -1,8 +1,5 @@
 package org.genspectrum.lapis.util
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import jakarta.servlet.ReadListener
 import jakarta.servlet.ServletInputStream
 import jakarta.servlet.http.HttpServletRequest
@@ -10,6 +7,9 @@ import jakarta.servlet.http.HttpServletRequestWrapper
 import org.genspectrum.lapis.log
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -120,7 +120,7 @@ class CachedBodyHttpServletRequest private constructor(
 
         val fieldValue = parsedBody[fieldName]
         if (fieldValue?.isArray == true) {
-            return fieldValue.map { it.asText() }
+            return fieldValue.toList().map { it.asText() }
         }
         return emptyList()
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/util/TryToGuessTheType.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/util/TryToGuessTheType.kt
@@ -1,17 +1,17 @@
 package org.genspectrum.lapis.util
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.databind.node.JsonNodeType.ARRAY
-import com.fasterxml.jackson.databind.node.JsonNodeType.BOOLEAN
-import com.fasterxml.jackson.databind.node.JsonNodeType.NULL
-import com.fasterxml.jackson.databind.node.JsonNodeType.NUMBER
-import com.fasterxml.jackson.databind.node.JsonNodeType.STRING
-import com.fasterxml.jackson.databind.node.LongNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.request.SPECIAL_REQUEST_PROPERTY_TYPES
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.BooleanNode
+import tools.jackson.databind.node.DoubleNode
+import tools.jackson.databind.node.JsonNodeFactory
+import tools.jackson.databind.node.JsonNodeType.ARRAY
+import tools.jackson.databind.node.JsonNodeType.BOOLEAN
+import tools.jackson.databind.node.JsonNodeType.NULL
+import tools.jackson.databind.node.JsonNodeType.NUMBER
+import tools.jackson.databind.node.JsonNodeType.STRING
+import tools.jackson.databind.node.LongNode
+import tools.jackson.databind.node.StringNode
 
 /**
  * Try conversion of special request properties to their correct types of form url encoded requests
@@ -24,22 +24,22 @@ fun tryToGuessTheType(entry: Map.Entry<String, List<String>>): JsonNode {
 
     if (jsonNodeType == ARRAY || values.size != 1) {
         return JsonNodeFactory.instance.arrayNode()
-            .addAll(values.map { TextNode(it) })
+            .addAll(values.map { StringNode(it) })
     }
 
     val value = values.first()
 
     return when (jsonNodeType) {
-        null, NULL, STRING -> TextNode(value)
+        null, NULL, STRING -> StringNode(value)
         BOOLEAN -> when (val booleanValue = value.toBooleanStrictOrNull()) {
-            null -> TextNode(value)
+            null -> StringNode(value)
             else -> BooleanNode.valueOf(booleanValue)
         }
 
         NUMBER -> value.toLongOrNull()?.let { LongNode(it) }
             ?: value.toDoubleOrNull()?.let { DoubleNode(it) }
-            ?: TextNode(value)
+            ?: StringNode(value)
 
-        else -> TextNode(value)
+        else -> StringNode(value)
     }
 }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/util/YamlObjectMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/util/YamlObjectMapper.kt
@@ -1,11 +1,13 @@
 package org.genspectrum.lapis.util
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 @Component
 object YamlObjectMapper {
-    val objectMapper: ObjectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
+    val objectMapper: ObjectMapper = YAMLMapper.builder()
+        .addModule(kotlinModule())
+        .build()
 }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/SwaggerUiTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/SwaggerUiTest.kt
@@ -1,19 +1,18 @@
 package org.genspectrum.lapis
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.dataformat.yaml.YAMLMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
@@ -44,8 +43,8 @@ class SwaggerUiTest(
             .andExpect(content().contentType("application/vnd.oai.openapi"))
             .andReturn()
 
-        val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
-        val yaml = objectMapper.readTree(result.response.contentAsString)
+        val yamlMapper = YAMLMapper.builder().addModule(kotlinModule()).build()
+        val yaml = yamlMapper.readTree(result.response.contentAsString)
         assertTrue(yaml.has("openapi"))
         assertTrue(yaml.get("paths").has("/sample/aggregated"))
     }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
@@ -10,8 +10,8 @@ import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/InfoControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/InfoControllerTest.kt
@@ -9,8 +9,8 @@ import org.hamcrest.Matchers.matchesPattern
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LandingPageControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LandingPageControllerTest.kt
@@ -5,8 +5,8 @@ import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.TEXT_HTML
 import org.springframework.http.MediaType.TEXT_HTML_VALUE

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller
 
-import com.fasterxml.jackson.databind.node.TextNode
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.genspectrum.lapis.FIELD_WITH_ONLY_LOWERCASE_LETTERS
@@ -29,14 +28,15 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 @SpringBootTest
@@ -71,7 +71,7 @@ class LapisControllerCommonFieldsTest(
                     listOf(OrderByField("country", Order.ASCENDING)).toOrderBySpec(),
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(getSample("$AGGREGATED_ROUTE?orderBy=country"))
             .andExpect(status().isOk)
@@ -97,7 +97,7 @@ class LapisControllerCommonFieldsTest(
                     ).toOrderBySpec(),
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         val uppercaseField = FIELD_WITH_ONLY_LOWERCASE_LETTERS.uppercase()
         val lowercaseField = FIELD_WITH_UPPERCASE_LETTER.lowercase()
@@ -129,7 +129,7 @@ class LapisControllerCommonFieldsTest(
                     ).toOrderBySpec(),
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(request)
             .andExpect(status().isOk)
@@ -154,7 +154,7 @@ class LapisControllerCommonFieldsTest(
                     ).toOrderBySpec(),
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         val request = postSample(AGGREGATED_ROUTE)
             .content(
@@ -200,7 +200,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(getSample("$DETAILS_ROUTE?orderBy=random&fields=country"))
             .andExpect(status().isOk)
@@ -216,7 +216,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         val request = postSample(DETAILS_ROUTE)
             .content(
@@ -243,7 +243,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         val request = postSample(DETAILS_ROUTE)
             .content(
@@ -270,7 +270,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(getSample("$DETAILS_ROUTE?orderBy=random(123)&orderBy=age&fields=country"))
             .andExpect(status().isOk)
@@ -286,7 +286,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         val request = postSample(DETAILS_ROUTE)
             .content(
@@ -313,7 +313,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         val request = postSample(DETAILS_ROUTE)
             .content(
@@ -340,7 +340,7 @@ class LapisControllerCommonFieldsTest(
                         it.fields == listOf(Field("country"))
                 },
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"))))
 
         val request = postSample(DETAILS_ROUTE)
             .param("orderBy", "random(123)")
@@ -368,7 +368,7 @@ class LapisControllerCommonFieldsTest(
                     100,
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(getSample("$AGGREGATED_ROUTE?limit=100"))
             .andExpect(status().isOk)
@@ -395,7 +395,7 @@ class LapisControllerCommonFieldsTest(
                     100,
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(requestWithLimit(100))
             .andExpect(status().isOk)
@@ -429,7 +429,7 @@ class LapisControllerCommonFieldsTest(
                     5,
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(getSample("$AGGREGATED_ROUTE?offset=5"))
             .andExpect(status().isOk)
@@ -457,7 +457,7 @@ class LapisControllerCommonFieldsTest(
                     5,
                 ),
             )
-        } returns Stream.of(AggregationData(0, mapOf("country" to TextNode("Switzerland"))))
+        } returns Stream.of(AggregationData(0, mapOf("country" to StringNode("Switzerland"))))
 
         mockMvc.perform(requestWithOffset(5))
             .andExpect(status().isOk)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCompressionTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCompressionTest.kt
@@ -28,8 +28,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.HttpHeaders.ACCEPT_ENCODING
 import org.springframework.http.HttpHeaders.CONTENT_ENCODING
 import org.springframework.http.HttpHeaders.CONTENT_LENGTH

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDataFormatTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDataFormatTest.kt
@@ -1,8 +1,5 @@
 package org.genspectrum.lapis.controller
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_CSV_VALUE
@@ -20,8 +17,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.HttpHeaders.ACCEPT
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -30,6 +27,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 private const val DATA_VERSION = "1234"
@@ -143,7 +143,7 @@ class LapisControllerDataFormatTest(
         every { siloQueryModelMock.getAggregated(any()) } returns Stream.of(
             AggregationData(
                 1,
-                mapOf("primaryKey" to TextNode("someValue"), "date" to NullNode.instance),
+                mapOf("primaryKey" to StringNode("someValue"), "date" to NullNode.instance),
             ),
         )
 
@@ -168,9 +168,9 @@ class LapisControllerDataFormatTest(
         every { siloQueryModelMock.getDetails(any()) } returns Stream.of(
             DetailsData(
                 mapOf(
-                    "primaryKey" to TextNode("some first value"),
+                    "primaryKey" to StringNode("some first value"),
                     "date" to NullNode.instance,
-                    "country" to TextNode("someValue"),
+                    "country" to StringNode("someValue"),
                 ),
             ),
         )
@@ -196,11 +196,19 @@ class LapisControllerDataFormatTest(
         every { siloQueryModelMock.getAggregated(any()) } returns Stream.of(
             AggregationData(
                 1,
-                mapOf("date" to TextNode("date1"), "primaryKey" to TextNode("key1"), "region" to TextNode("region1")),
+                mapOf(
+                    "date" to StringNode("date1"),
+                    "primaryKey" to StringNode("key1"),
+                    "region" to StringNode("region1"),
+                ),
             ),
             AggregationData(
                 2,
-                mapOf("date" to TextNode("date2"), "primaryKey" to TextNode("key2"), "region" to TextNode("region2")),
+                mapOf(
+                    "date" to StringNode("date2"),
+                    "primaryKey" to StringNode("key2"),
+                    "region" to StringNode("region2"),
+                ),
             ),
         )
 
@@ -230,10 +238,18 @@ class LapisControllerDataFormatTest(
     fun `returns details csv columns in correct order`(scenario: ColumnOrderScenario) {
         every { siloQueryModelMock.getDetails(any()) } returns Stream.of(
             DetailsData(
-                mapOf("date" to TextNode("date1"), "primaryKey" to TextNode("key1"), "region" to TextNode("region1")),
+                mapOf(
+                    "date" to StringNode("date1"),
+                    "primaryKey" to StringNode("key1"),
+                    "region" to StringNode("region1"),
+                ),
             ),
             DetailsData(
-                mapOf("date" to TextNode("date2"), "primaryKey" to TextNode("key2"), "region" to TextNode("region2")),
+                mapOf(
+                    "date" to StringNode("date2"),
+                    "primaryKey" to StringNode("key2"),
+                    "region" to StringNode("region2"),
+                ),
             ),
         )
 
@@ -254,8 +270,8 @@ class LapisControllerDataFormatTest(
         every { siloQueryModelMock.getDetails(any()) } returns Stream.of(
             DetailsData(
                 mapOf(
-                    "primaryKey" to TextNode("key1\tfoo"),
-                    "region" to TextNode("regionLine1\nregionLine2"),
+                    "primaryKey" to StringNode("key1\tfoo"),
+                    "region" to StringNode("regionLine1\nregionLine2"),
                 ),
             ),
         )

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDownloadAsFileTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerDownloadAsFileTest.kt
@@ -28,8 +28,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.HttpHeaders.ACCEPT
 import org.springframework.http.HttpHeaders.ACCEPT_ENCODING
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerFastaHeaderTemplateTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerFastaHeaderTemplateTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller
 
-import com.fasterxml.jackson.databind.node.TextNode
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.genspectrum.lapis.config.REFERENCE_GENOME_GENES_APPLICATION_ARG_PREFIX
@@ -16,14 +15,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 private const val SEGMENT_NAME = "main"
@@ -78,8 +78,8 @@ class LapisControllerFastaHeaderTemplateTest(
         every {
             siloClient.sendQuery(query = any<SiloQuery<SequenceData>>())
         } returns Stream.of(
-            SequenceData(mapOf(SEGMENT_NAME to TextNode("AAAA"), "primaryKey" to TextNode("1234"))),
-            SequenceData(mapOf(SEGMENT_NAME to TextNode("GGGG"), "primaryKey" to TextNode("5678"))),
+            SequenceData(mapOf(SEGMENT_NAME to StringNode("AAAA"), "primaryKey" to StringNode("1234"))),
+            SequenceData(mapOf(SEGMENT_NAME to StringNode("GGGG"), "primaryKey" to StringNode("5678"))),
         )
 
         mockMvc.perform(scenario.request)
@@ -93,8 +93,8 @@ class LapisControllerFastaHeaderTemplateTest(
         every {
             siloClient.sendQuery(query = any<SiloQuery<SequenceData>>())
         } returns Stream.of(
-            SequenceData(mapOf(GENE_NAME to TextNode("AAAA"), "primaryKey" to TextNode("1234"))),
-            SequenceData(mapOf(GENE_NAME to TextNode("GGGG"), "primaryKey" to TextNode("5678"))),
+            SequenceData(mapOf(GENE_NAME to StringNode("AAAA"), "primaryKey" to StringNode("1234"))),
+            SequenceData(mapOf(GENE_NAME to StringNode("GGGG"), "primaryKey" to StringNode("5678"))),
         )
 
         mockMvc.perform(scenario.request)
@@ -404,8 +404,8 @@ class LapisControllerSingleSegmentedFastaHeaderTemplateTest(
         every {
             siloClient.sendQuery(query = any<SiloQuery<SequenceData>>())
         } returns Stream.of(
-            SequenceData(mapOf(SEGMENT_NAME to TextNode("AAAA"), "primaryKey" to TextNode("1234"))),
-            SequenceData(mapOf(SEGMENT_NAME to TextNode("GGGG"), "primaryKey" to TextNode("5678"))),
+            SequenceData(mapOf(SEGMENT_NAME to StringNode("AAAA"), "primaryKey" to StringNode("1234"))),
+            SequenceData(mapOf(SEGMENT_NAME to StringNode("GGGG"), "primaryKey" to StringNode("5678"))),
         )
 
         mockMvc.perform(scenario.request)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerPhyloTreeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerPhyloTreeTest.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.controller
 
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.TextNode
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.genspectrum.lapis.controller.SequenceEndpointTestScenario.Mode.AllSequences
@@ -27,8 +25,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
@@ -38,6 +36,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.node.IntNode
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 @SpringBootTest
@@ -69,7 +69,7 @@ class LapisControllerTest(
         } returns Stream.of(
             AggregationData(
                 0,
-                mapOf("country" to TextNode("Switzerland"), "age" to IntNode(42)),
+                mapOf("country" to StringNode("Switzerland"), "age" to IntNode(42)),
             ),
         )
 
@@ -98,7 +98,7 @@ class LapisControllerTest(
         } returns Stream.of(
             AggregationData(
                 0,
-                mapOf("country" to TextNode("Switzerland"), "date" to TextNode("a date")),
+                mapOf("country" to StringNode("Switzerland"), "date" to StringNode("a date")),
             ),
         )
 
@@ -124,7 +124,7 @@ class LapisControllerTest(
         } returns Stream.of(
             AggregationData(
                 0,
-                mapOf("country" to TextNode("Switzerland")),
+                mapOf("country" to StringNode("Switzerland")),
             ),
         )
 
@@ -467,7 +467,7 @@ class LapisControllerTest(
                 "POST JSON",
                 { route: String ->
                     postSample(route)
-                        .content("""{"country": "Switzerland", "fields": ["country","date"]}}""")
+                        .content("""{"country": "Switzerland", "fields": ["country","date"]}""")
                         .contentType(MediaType.APPLICATION_JSON)
                 },
             ),
@@ -503,7 +503,7 @@ class LapisControllerTest(
     ) {
         every {
             siloQueryModelMock.getDetails(sequenceFiltersRequestWithFields(mapOf("country" to "Switzerland")))
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"), "age" to IntNode(42))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"), "age" to IntNode(42))))
 
         mockMvc.perform(request(DETAILS_ROUTE))
             .andExpect(status().isOk)
@@ -526,7 +526,7 @@ class LapisControllerTest(
                     fields = listOf("country", "date"),
                 ),
             )
-        } returns Stream.of(DetailsData(mapOf("country" to TextNode("Switzerland"), "date" to TextNode("a date"))))
+        } returns Stream.of(DetailsData(mapOf("country" to StringNode("Switzerland"), "date" to StringNode("a date"))))
 
         mockMvc.perform(request(DETAILS_ROUTE))
             .andExpect(status().isOk)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MockData.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MockData.kt
@@ -1,10 +1,5 @@
 package org.genspectrum.lapis.controller
 
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_CSV_VALUE
 import org.genspectrum.lapis.controller.LapisMediaType.TEXT_NEWICK_VALUE
@@ -27,6 +22,11 @@ import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.`is`
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.MediaType.APPLICATION_NDJSON_VALUE
+import tools.jackson.databind.node.DoubleNode
+import tools.jackson.databind.node.IntNode
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.util.stream.Stream
 
 data class MockDataCollection(
@@ -290,9 +290,13 @@ object MockDataForEndpoints {
             getSequencesResponse = {
                 SequencesResponse(
                     sequenceData = listOf<SequenceData>(
-                        SequenceData(mapOf("primaryKey" to TextNode("sequence1"), sequenceName to TextNode("CAGAA"))),
-                        SequenceData(mapOf("primaryKey" to TextNode("sequence2"), sequenceName to TextNode("CAGAT"))),
-                        SequenceData(mapOf("primaryKey" to TextNode("sequence3"), sequenceName to NullNode.instance)),
+                        SequenceData(
+                            mapOf("primaryKey" to StringNode("sequence1"), sequenceName to StringNode("CAGAA")),
+                        ),
+                        SequenceData(
+                            mapOf("primaryKey" to StringNode("sequence2"), sequenceName to StringNode("CAGAT")),
+                        ),
+                        SequenceData(mapOf("primaryKey" to StringNode("sequence3"), sequenceName to NullNode.instance)),
                     ).stream(),
                     requestedSequenceNames = listOf(sequenceName),
                     fastaHeaderTemplate = FastaHeaderTemplate(
@@ -334,28 +338,28 @@ object MockDataForEndpoints {
                     sequenceData = listOf(
                         SequenceData(
                             mapOf(
-                                "primaryKey" to TextNode("key1"),
-                                "sequence1" to TextNode("CAGAA"),
-                                "sequence2" to TextNode("CAGAT"),
+                                "primaryKey" to StringNode("key1"),
+                                "sequence1" to StringNode("CAGAA"),
+                                "sequence2" to StringNode("CAGAT"),
                             ),
                         ),
                         SequenceData(
                             mapOf(
-                                "primaryKey" to TextNode("key2"),
-                                "sequence1" to TextNode("CAGAT"),
+                                "primaryKey" to StringNode("key2"),
+                                "sequence1" to StringNode("CAGAT"),
                                 "sequence2" to NullNode.instance,
                             ),
                         ),
                         SequenceData(
                             mapOf(
-                                "primaryKey" to TextNode("key3"),
+                                "primaryKey" to StringNode("key3"),
                                 "sequence1" to NullNode.instance,
-                                "sequence2" to TextNode("CAGAC"),
+                                "sequence2" to StringNode("CAGAC"),
                             ),
                         ),
                         SequenceData(
                             mapOf(
-                                "primaryKey" to TextNode("key4"),
+                                "primaryKey" to StringNode("key4"),
                                 "sequence1" to NullNode.instance,
                                 "sequence2" to NullNode.instance,
                             ),
@@ -406,7 +410,7 @@ object MockDataForEndpoints {
         modelData = listOf(
             AggregationData(
                 0,
-                mapOf("country" to TextNode("Switzerland"), "age" to IntNode(42)),
+                mapOf("country" to StringNode("Switzerland"), "age" to IntNode(42)),
             ),
         ),
         fields = listOf("country", "age"),
@@ -436,14 +440,14 @@ object MockDataForEndpoints {
         modelData = listOf(
             DetailsData(
                 mapOf(
-                    "country" to TextNode("Switzerland"),
+                    "country" to StringNode("Switzerland"),
                     "age" to IntNode(42),
                     "floatValue" to DoubleNode(3.14),
                 ),
             ),
             DetailsData(
                 mapOf(
-                    "country" to TextNode("Switzerland"),
+                    "country" to StringNode("Switzerland"),
                     "age" to IntNode(43),
                     "floatValue" to NullNode.instance,
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
@@ -20,8 +20,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/OAuthTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/OAuthTest.kt
@@ -15,9 +15,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.context.annotation.Bean
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
@@ -70,13 +70,13 @@ class OAuthTest(
         if (scenario.supportsGet) {
             mockMvc.perform(get(scenario.path))
                 .andExpect(status().isUnauthorized)
-                .andExpect(header().string("WWW-Authenticate", "Bearer"))
+                .andExpect(header().string("WWW-Authenticate", containsString("Bearer")))
         }
 
         if (scenario.supportsPost) {
             mockMvc.perform(post(scenario.path))
                 .andExpect(status().isUnauthorized)
-                .andExpect(header().string("WWW-Authenticate", "Bearer"))
+                .andExpect(header().string("WWW-Authenticate", containsString("Bearer")))
         }
     }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeControllerTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.controller
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.github.luben.zstd.ZstdInputStream
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
@@ -25,14 +24,15 @@ import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.time.LocalDate

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueryControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueryControllerTest.kt
@@ -13,8 +13,8 @@ import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/SingleSegmentedSequenceControllerTest.kt
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/logging/RequestContextLoggerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/logging/RequestContextLoggerTest.kt
@@ -62,7 +62,7 @@ internal class RequestContextLoggerTest {
         verify {
             loggerMock.info(
                 """
-                {"unixTimestamp":100,"responseTimeInMilliSeconds":99,"endpoint":"/shouldBeLogged","responseCode":200}
+                {"endpoint":"/shouldBeLogged","responseCode":200,"responseTimeInMilliSeconds":99,"unixTimestamp":100}
                 """.trimIndent(),
             )
         }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/FastaHeaderTemplateTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/FastaHeaderTemplateTest.kt
@@ -1,10 +1,5 @@
 package org.genspectrum.lapis.model
 
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.config.DatabaseMetadata
 import org.genspectrum.lapis.config.MetadataType
 import org.genspectrum.lapis.controller.BadRequestException
@@ -15,6 +10,11 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.node.BooleanNode
+import tools.jackson.databind.node.DoubleNode
+import tools.jackson.databind.node.IntNode
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
 
 class FastaHeaderTemplateTest {
     private val fastaHeaderTemplateParser = FastaHeaderTemplateParser(
@@ -41,7 +41,7 @@ class FastaHeaderTemplateTest {
         )
 
         val filledTemplate = template.fillTemplate(
-            values = mapOf("accession" to TextNode("my_accession")),
+            values = mapOf("accession" to StringNode("my_accession")),
             sequenceName = "sequenceName",
         )
 
@@ -72,7 +72,7 @@ class FastaHeaderTemplateTest {
 
         val filledTemplate = template.fillTemplate(
             values = mapOf(
-                "accession" to TextNode("my_accession"),
+                "accession" to StringNode("my_accession"),
                 "age" to IntNode(42),
                 "qc" to DoubleNode(0.987),
                 "isBoolean" to BooleanNode.TRUE,
@@ -96,8 +96,8 @@ class FastaHeaderTemplateTest {
 
         val filledTemplate = template.fillTemplate(
             values = mapOf(
-                "accession" to TextNode("my_accession"),
-                "superfluous" to TextNode("should be ignored"),
+                "accession" to StringNode("my_accession"),
+                "superfluous" to StringNode("should be ignored"),
             ),
             sequenceName = "sequenceName",
         )
@@ -117,7 +117,7 @@ class FastaHeaderTemplateTest {
 
         val filledTemplate = template.fillTemplate(
             values = mapOf(
-                "accession" to TextNode("my_accession"),
+                "accession" to StringNode("my_accession"),
                 // "age" is missing
                 "qc" to DoubleNode(0.987),
             ),
@@ -135,7 +135,7 @@ class FastaHeaderTemplateTest {
         )
 
         val filledTemplate = template.fillTemplate(
-            values = mapOf("accession" to TextNode("my_accession"), "age" to IntNode(42)),
+            values = mapOf("accession" to StringNode("my_accession"), "age" to IntNode(42)),
             sequenceName = "sequenceName",
         )
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.model.mutationsOverTime
 
-import com.fasterxml.jackson.databind.node.TextNode
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 private val DUMMY_MUTATION1 = AminoAcidMutation("S", 1, "R")
@@ -113,8 +113,8 @@ AminoAcidMutationsOverTimeModelTest {
             DUMMY_MUTATION_EQUALS1,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(1, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-06-01"))),
             ),
         )
         mockSiloCountQuery(
@@ -122,9 +122,9 @@ AminoAcidMutationsOverTimeModelTest {
             DUMMY_MUTATION_EQUALS2,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(3, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(3, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
         mockSiloAminoAcidCoverageQuery(
@@ -133,8 +133,8 @@ AminoAcidMutationsOverTimeModelTest {
             1,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(5, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(6, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(5, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(6, fields = mapOf("date" to StringNode("2022-06-01"))),
             ),
         )
         mockSiloAminoAcidCoverageQuery(
@@ -143,18 +143,18 @@ AminoAcidMutationsOverTimeModelTest {
             2,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(0, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(1, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(0, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
         mockSiloTotalCountQuery(
             siloQueryClient,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(10, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(11, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(12, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(10, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(11, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(12, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
     }
@@ -248,7 +248,7 @@ AminoAcidMutationsOverTimeModelTest {
             WithDataVersion(
                 version,
                 Stream.of(
-                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to TextNode("2021-06-01"))),
+                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to StringNode("2021-06-01"))),
                 ),
             )
         }
@@ -276,7 +276,7 @@ AminoAcidMutationsOverTimeModelTest {
             WithDataVersion(
                 version,
                 Stream.of(
-                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to TextNode("2021-06-01"))),
+                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to StringNode("2021-06-01"))),
                 ),
             )
         }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.model.mutationsOverTime
 
-import com.fasterxml.jackson.databind.node.TextNode
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 private val DUMMY_MUTATION1 = NucleotideMutation(null, 1, "T")
@@ -112,8 +112,8 @@ class NucleotideMutationsOverTimeModelTest {
             DUMMY_MUTATION_EQUALS1,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(1, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-06-01"))),
             ),
         )
         mockSiloCountQuery(
@@ -121,9 +121,9 @@ class NucleotideMutationsOverTimeModelTest {
             DUMMY_MUTATION_EQUALS2,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(3, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(3, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
         mockSiloNucleotideCoverageQuery(
@@ -132,8 +132,8 @@ class NucleotideMutationsOverTimeModelTest {
             1,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(5, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(6, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(5, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(6, fields = mapOf("date" to StringNode("2022-06-01"))),
             ),
         )
         mockSiloNucleotideCoverageQuery(
@@ -142,18 +142,18 @@ class NucleotideMutationsOverTimeModelTest {
             2,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
-                AggregationData(0, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(1, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(0, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
         mockSiloTotalCountQuery(
             siloQueryClient,
             DUMMY_DATE_BETWEEN_ALL,
             queryResult = Stream.of(
-                AggregationData(10, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(11, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(12, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(10, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(11, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(12, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
     }
@@ -250,7 +250,7 @@ class NucleotideMutationsOverTimeModelTest {
             WithDataVersion(
                 version,
                 Stream.of(
-                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to TextNode("2021-06-01"))),
+                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to StringNode("2021-06-01"))),
                 ),
             )
         }
@@ -278,7 +278,7 @@ class NucleotideMutationsOverTimeModelTest {
             WithDataVersion(
                 version,
                 Stream.of(
-                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to TextNode("2021-06-01"))),
+                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to StringNode("2021-06-01"))),
                 ),
             )
         }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModelTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.model.mutationsOverTime
 
-import com.fasterxml.jackson.databind.node.TextNode
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -27,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.node.StringNode
 import java.util.stream.Stream
 
 private val DUMMY_QUERY_ITEM_1 = QueryOverTimeItem(
@@ -140,8 +140,8 @@ class QueriesOverTimeModelTest {
             mutationFilter = DUMMY_FILTER_1,
             dateBetweenFilter = DUMMY_DATE_BETWEEN_ALL,
             queryResult = Stream.of(
-                AggregationData(1, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-06-01"))),
             ),
         )
         mockSiloCountQuery(
@@ -149,17 +149,17 @@ class QueriesOverTimeModelTest {
             mutationFilter = DUMMY_FILTER_2,
             dateBetweenFilter = DUMMY_DATE_BETWEEN_ALL,
             queryResult = Stream.of(
-                AggregationData(3, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(2, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(3, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(2, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
         mockSiloCoverageQuery(
             siloClient = siloQueryClient,
             dateBetween = DUMMY_DATE_BETWEEN_ALL,
             queryResult = Stream.of(
-                AggregationData(5, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(6, fields = mapOf("date" to TextNode("2022-06-01"))),
+                AggregationData(5, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(6, fields = mapOf("date" to StringNode("2022-06-01"))),
             ),
             coverageFilterExpressionFn = { it == DUMMY_FILTER_COVERAGE_1 },
         )
@@ -167,9 +167,9 @@ class QueriesOverTimeModelTest {
             siloClient = siloQueryClient,
             dateBetween = DUMMY_DATE_BETWEEN_ALL,
             queryResult = Stream.of(
-                AggregationData(0, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(1, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(1, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(0, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(1, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
             coverageFilterExpressionFn = { it == DUMMY_FILTER_COVERAGE_2 },
         )
@@ -177,9 +177,9 @@ class QueriesOverTimeModelTest {
             siloQueryClient,
             DUMMY_DATE_BETWEEN_ALL,
             queryResult = Stream.of(
-                AggregationData(10, fields = mapOf("date" to TextNode("2021-06-01"))),
-                AggregationData(11, fields = mapOf("date" to TextNode("2022-06-01"))),
-                AggregationData(12, fields = mapOf("date" to TextNode("2022-07-01"))),
+                AggregationData(10, fields = mapOf("date" to StringNode("2021-06-01"))),
+                AggregationData(11, fields = mapOf("date" to StringNode("2022-06-01"))),
+                AggregationData(12, fields = mapOf("date" to StringNode("2022-07-01"))),
             ),
         )
     }
@@ -281,7 +281,7 @@ class QueriesOverTimeModelTest {
             WithDataVersion(
                 version,
                 Stream.of(
-                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to TextNode("2021-06-01"))),
+                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to StringNode("2021-06-01"))),
                 ),
             )
         }
@@ -309,7 +309,7 @@ class QueriesOverTimeModelTest {
             WithDataVersion(
                 version,
                 Stream.of(
-                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to TextNode("2021-06-01"))),
+                    AggregationData(1, fields = mapOf(DUMMY_DATE_FIELD to StringNode("2021-06-01"))),
                 ),
             )
         }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidInsertionTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidInsertionTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -11,6 +9,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest
 class AminoAcidInsertionTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidMutationTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/AminoAcidMutationTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -11,6 +9,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest
 class AminoAcidMutationTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/MutationProportionsRequestTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/MutationProportionsRequestTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -12,6 +10,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest
 class MutationProportionsRequestTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideInsertionTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideInsertionTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -11,6 +9,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest
 class NucleotideInsertionTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideMutationTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideMutationTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -11,6 +9,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest
 class NucleotideMutationTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/OrderBySpecDeserializerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/OrderBySpecDeserializerTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -9,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
 
 @SpringBootTest
 class OrderBySpecDeserializerTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFieldsTest.kt
@@ -1,7 +1,5 @@
 package org.genspectrum.lapis.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import org.genspectrum.lapis.FIELD_WITH_ONLY_LOWERCASE_LETTERS
 import org.genspectrum.lapis.FIELD_WITH_UPPERCASE_LETTER
 import org.genspectrum.lapis.controller.BadRequestException
@@ -14,6 +12,8 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest
 class SequenceFiltersRequestWithFieldsTest {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/response/MutationResponseTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/response/MutationResponseTest.kt
@@ -1,11 +1,11 @@
 package org.genspectrum.lapis.response
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
 
 @SpringBootTest
 class MutationResponseTest(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -1,9 +1,5 @@
 package org.genspectrum.lapis.silo
 
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.IntNode
-import com.fasterxml.jackson.databind.node.NullNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.config.SiloVersion
 import org.genspectrum.lapis.logging.RequestIdContext
 import org.genspectrum.lapis.request.Order
@@ -41,6 +37,10 @@ import org.mockserver.model.MediaType
 import org.mockserver.model.MediaType.parse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.node.DoubleNode
+import tools.jackson.databind.node.IntNode
+import tools.jackson.databind.node.NullNode
+import tools.jackson.databind.node.StringNode
 import java.time.LocalDate
 
 private const val MOCK_SERVER_PORT = 1080
@@ -102,8 +102,8 @@ class SiloClientTest(
             result,
             equalTo(
                 listOf(
-                    AggregationData(6, mapOf("division" to TextNode("Aargau"))),
-                    AggregationData(8, mapOf("division" to TextNode("Basel-Land"))),
+                    AggregationData(6, mapOf("division" to StringNode("Aargau"))),
+                    AggregationData(8, mapOf("division" to StringNode("Basel-Land"))),
                 ),
             ),
         )
@@ -200,9 +200,9 @@ class SiloClientTest(
         assertThat(
             result,
             containsInAnyOrder(
-                SequenceData(mapOf("primaryKey" to TextNode("key1"), "someSequenceName" to TextNode("ABCD"))),
-                SequenceData(mapOf("primaryKey" to TextNode("key2"), "someSequenceName" to TextNode("DEFG"))),
-                SequenceData(mapOf("primaryKey" to TextNode("key3"), "someSequenceName" to NullNode.instance)),
+                SequenceData(mapOf("primaryKey" to StringNode("key1"), "someSequenceName" to StringNode("ABCD"))),
+                SequenceData(mapOf("primaryKey" to StringNode("key2"), "someSequenceName" to StringNode("DEFG"))),
+                SequenceData(mapOf("primaryKey" to StringNode("key3"), "someSequenceName" to NullNode.instance)),
             ),
         )
     }
@@ -233,9 +233,9 @@ class SiloClientTest(
         assertThat(
             result,
             containsInAnyOrder(
-                SequenceData(mapOf("primaryKey" to TextNode("key1"), "someSequenceName" to TextNode("ABCD"))),
-                SequenceData(mapOf("primaryKey" to TextNode("key2"), "someSequenceName" to TextNode("DEFG"))),
-                SequenceData(mapOf("primaryKey" to TextNode("key3"), "someSequenceName" to NullNode.instance)),
+                SequenceData(mapOf("primaryKey" to StringNode("key1"), "someSequenceName" to StringNode("ABCD"))),
+                SequenceData(mapOf("primaryKey" to StringNode("key2"), "someSequenceName" to StringNode("DEFG"))),
+                SequenceData(mapOf("primaryKey" to StringNode("key3"), "someSequenceName" to NullNode.instance)),
             ),
         )
     }
@@ -277,18 +277,18 @@ class SiloClientTest(
                 DetailsData(
                     mapOf(
                         "age" to IntNode(50),
-                        "country" to TextNode("Switzerland"),
-                        "date" to TextNode("2021-02-23"),
-                        "pango_lineage" to TextNode("B.1.1.7"),
+                        "country" to StringNode("Switzerland"),
+                        "date" to StringNode("2021-02-23"),
+                        "pango_lineage" to StringNode("B.1.1.7"),
                         "qc_value" to DoubleNode(0.95),
                     ),
                 ),
                 DetailsData(
                     mapOf(
                         "age" to IntNode(54),
-                        "country" to TextNode("Switzerland"),
-                        "date" to TextNode("2021-03-19"),
-                        "pango_lineage" to TextNode("B.1.1.7"),
+                        "country" to StringNode("Switzerland"),
+                        "date" to StringNode("2021-03-19"),
+                        "pango_lineage" to StringNode("B.1.1.7"),
                         "qc_value" to DoubleNode(0.94),
                     ),
                 ),
@@ -319,9 +319,9 @@ class SiloClientTest(
         assertThat(
             result,
             containsInAnyOrder(
-                DetailsData(mapOf("date" to TextNode("2021-02-23"), "label" to TextNode("A"))),
-                DetailsData(mapOf("date" to TextNode("2021-03-19"), "label" to TextNode("B"))),
-                DetailsData(mapOf("date" to NullNode.instance, "label" to TextNode("C"))),
+                DetailsData(mapOf("date" to StringNode("2021-02-23"), "label" to StringNode("A"))),
+                DetailsData(mapOf("date" to StringNode("2021-03-19"), "label" to StringNode("B"))),
+                DetailsData(mapOf("date" to NullNode.instance, "label" to StringNode("C"))),
             ),
         )
     }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -1,6 +1,5 @@
 package org.genspectrum.lapis.silo
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.genspectrum.lapis.request.Order
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
@@ -13,6 +12,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import tools.jackson.databind.ObjectMapper
 import java.time.LocalDate
 
 @SpringBootTest

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/util/TryToGuessTheTypeKtTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/util/TryToGuessTheTypeKtTest.kt
@@ -1,11 +1,5 @@
 package org.genspectrum.lapis.util
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.BooleanNode
-import com.fasterxml.jackson.databind.node.DoubleNode
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.databind.node.LongNode
-import com.fasterxml.jackson.databind.node.TextNode
 import org.genspectrum.lapis.request.DOWNLOAD_AS_FILE_PROPERTY
 import org.genspectrum.lapis.request.LIMIT_PROPERTY
 import org.genspectrum.lapis.request.NUCLEOTIDE_MUTATIONS_PROPERTY
@@ -14,6 +8,12 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.BooleanNode
+import tools.jackson.databind.node.DoubleNode
+import tools.jackson.databind.node.JsonNodeFactory
+import tools.jackson.databind.node.LongNode
+import tools.jackson.databind.node.StringNode
 
 class TryToGuessTheTypeKtTest {
     @ParameterizedTest(name = "{0}")
@@ -34,7 +34,7 @@ class TryToGuessTheTypeKtTest {
             Arguments.of(
                 "non-special field with single value should map to single text value",
                 entry("someField", listOf("value")),
-                TextNode("value"),
+                StringNode("value"),
             ),
             Arguments.of(
                 "non-special field with multiple values should map to multiple text values",
@@ -49,7 +49,7 @@ class TryToGuessTheTypeKtTest {
             Arguments.of(
                 "special bool-valued field should map non-boolean value to text",
                 entry(DOWNLOAD_AS_FILE_PROPERTY, listOf("not a boolean")),
-                TextNode("not a boolean"),
+                StringNode("not a boolean"),
             ),
             Arguments.of(
                 "special bool-valued field should map true to boolean",
@@ -74,7 +74,7 @@ class TryToGuessTheTypeKtTest {
             Arguments.of(
                 "special number-valued field should map non-number to text",
                 entry(LIMIT_PROPERTY, listOf("not a number")),
-                TextNode("not a number"),
+                StringNode("not a number"),
             ),
         )
 


### PR DESCRIPTION
resolves #1476

## Summary

Spring Boot 3.5.6 → 4.0.6, Jackson 2 → 3, springdoc 2 → 3.

**`com.fasterxml.jackson.module:jackson-module-kotlin` kept alongside Jackson 3** — springdoc/swagger-core is still on Jackson 2 and needs it for Kotlin nullability detection (`required` fields in OpenAPI spec). Without it, all schema properties become optional. See [springdoc#3172](https://github.com/springdoc/springdoc-openapi/issues/3172), blocked on [swagger-core#4991](https://github.com/swagger-api/swagger-core/issues/4991). Can be removed once swagger-core migrates to Jackson 3.

**`CompressionAwareMappingJackson2HttpMessageConverter` deleted** — Boot 4 places custom `@Component` converter beans before defaults, which caused String responses (OpenAPI JSON, Newick) to be double-encoded. Instead of fighting converter ordering, phyloSubtree now writes directly to `response.outputStream` (like every other endpoint). `Content-Encoding` for compressed error responses moved to `ExceptionHandler`. Compression media types registered on `JacksonJsonHttpMessageConverter` via `configureMessageConverters` so error responses can serialize through the forced content type.

**Custom `JsonMapper.Builder` bean** — Jackson 3's `StreamReadConstraints` are immutable on `JsonFactory`, so they must be set at construction time. No `JsonMapperBuilderCustomizer` hook exists for this. The bean calls all customizers manually to preserve Boot's default Jackson config.

**`ProblemDetail.type` omitted in some cases** — Spring Framework 7 no longer defaults it; Jackson 3 omits null URI fields. This occurs in some error cases. Strictly speaking, this is breaking, but IMO this is fine.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] All necessary changes are explained in the `llms.txt`.~~
- [x] The implemented feature is covered by an appropriate test.