### PR TITLE
feat(lapis): add sublineage-inclusive aggregation via includeSublineagesFor

### DIFF
--- a/.github/workflows/lapis.yml
+++ b/.github/workflows/lapis.yml
@@ -4,7 +4,10 @@ on: [ push ]
 
 env:
   DOCKER_IMAGE_NAME: ghcr.io/genspectrum/lapis
-  SILO_TAG: latest
+  # TEMPORARY: pin e2e to the SILO PR image (GenSpectrum/LAPIS-SILO#1366) which contains the
+  # `includeSublineagesFor` support this PR depends on. REVERT to `latest` before merging, once
+  # the SILO PR is merged and `lapis-silo:latest` includes the feature.
+  SILO_TAG: pr-1366
 
 jobs:
   Tests:

--- a/lapis-docs/src/content/docs/concepts/lineage-queries.mdx
+++ b/lapis-docs/src/content/docs/concepts/lineage-queries.mdx
@@ -37,6 +37,39 @@ To include sub-lineages, add `*` at the end of the lineage:
 `B.1.1*` and `B.1.1.*` are equivalent.
 Both match `B.1.1` itself and descendants such as `B.1.1.7`.
 
+## Aggregating Including Sublineages
+
+The `*` suffix above includes descendants when _filtering_.
+The `includeSublineagesFor` parameter is the _aggregation_ counterpart:
+it groups the [`/sample/aggregated`](../references/introduction) results by a lineage field so that each
+lineage's count includes the sequences assigned to that lineage **or any of its sublineages**.
+
+Name the lineage field to expand with `includeSublineagesFor`, and list that same field in `fields`:
+
+<Code lang='http' code={`GET /sample/aggregated?fields=${lineageField}&includeSublineagesFor=${lineageField}`} />
+
+In a POST request:
+
+<Code lang='json' code={JSON.stringify({ fields: [lineageField], includeSublineagesFor: lineageField }, null, 4)} />
+
+The response contains **one row per lineage defined for that field**, including lineages that have a
+count of zero. This makes the result well-suited to building lineage facets, where you want every
+possible lineage listed even if no sequence currently matches.
+
+:::caution
+**`includeSublineagesFor` can only group by a single field.**
+The field it names must be the **only** entry in `fields`. Combining sublineage-inclusive aggregation
+with any other group-by field (for example adding `country` to `fields`) is **not supported** and
+returns an error. If you need a breakdown by another field as well, run separate queries.
+:::
+
+:::caution
+Unlike a plain group-by, these counts do **not** partition the data.
+A sequence is counted under its own lineage _and_ under every ancestor lineage,
+so if `B.1.1` is a sub-lineage of `B.1`, a `B.1.1` sequence contributes to both the `B.1.1` and the
+`B.1` count. As a result the counts do not sum to the total number of sequences.
+:::
+
 ## Advanced Queries
 
 Lineage-indexed fields can also be used in [advanced queries](../concepts/advanced-query):

--- a/lapis-docs/src/content/docs/concepts/pango-lineage-query.mdx
+++ b/lapis-docs/src/content/docs/concepts/pango-lineage-query.mdx
@@ -32,3 +32,7 @@ maximal-length name (e.g., B.1.617.2) will get an alias. A list of aliases can b
 the alias AY so that AY.1 would be a sub-lineage of B.1.617.2. LAPIS is aware of aliases. Filtering B.1.617.2\* will
 include every lineage that starts with AY. It is further possible to search for B.1.617.2.1 which will then return the
 same results as AY.1.
+
+To _aggregate_ a count per Pango lineage that includes each lineage's sublineages (rather than filter),
+use the `includeSublineagesFor` parameter documented in
+[lineage queries](../concepts/lineage-queries#aggregating-including-sublineages).

--- a/lapis-docs/src/content/docs/references/fields.mdx
+++ b/lapis-docs/src/content/docs/references/fields.mdx
@@ -12,3 +12,17 @@ This page is generated from the underlying LAPIS configuration.
 This instance of LAPIS supports the following fields:
 
 <FieldsTable />
+
+## Grouping By Fields
+
+On `/sample/aggregated` you can group the counts by one or more of these fields with the `fields`
+parameter, for example `GET /sample/aggregated?fields=country` to get the count per country.
+
+For a lineage-indexed field you can additionally group so that each lineage's count includes all of
+its sublineages, using the `includeSublineagesFor` parameter.
+See [aggregating including sublineages](../concepts/lineage-queries#aggregating-including-sublineages).
+
+:::caution
+`includeSublineagesFor` can only group by a **single** field: the field it names must be the only
+entry in `fields`. It cannot be combined with grouping by any other field.
+:::

--- a/lapis-e2e/test/aggregatedQueries/groupByPangoLineageIncludingSublineages.json
+++ b/lapis-e2e/test/aggregatedQueries/groupByPangoLineageIncludingSublineages.json
@@ -1,0 +1,201 @@
+{
+  "_comment": "Sublineage-inclusive aggregation (includeSublineagesFor). This case FAILS in CI until a lapis-silo image containing the feature is published and SILO_TAG (lapis.yml / docker-compose.yml) is bumped to it; the LAPIS PR depends on a SILO release. orderBy(count desc, pangoLineage asc) + limit make the returned set deterministic (the full result is one row per defined lineage incl. thousands of zero-count rows). Expected counts were produced by running the built SILO + LAPIS against this same testData/singleSegmented dataset.",
+  "testCaseName": "aggregate by pango lineage including sublineages",
+  "lapisRequest": {
+    "fields": ["pangoLineage"],
+    "includeSublineagesFor": "pangoLineage",
+    "orderBy": [
+      {
+        "field": "count",
+        "type": "descending"
+      },
+      {
+        "field": "pangoLineage",
+        "type": "ascending"
+      }
+    ],
+    "limit": 45
+  },
+  "expected": [
+    {
+      "pangoLineage": "B",
+      "count": 97
+    },
+    {
+      "pangoLineage": "B.1",
+      "count": 97
+    },
+    {
+      "pangoLineage": "B.1.1",
+      "count": 61
+    },
+    {
+      "pangoLineage": "B.1.1.7",
+      "count": 51
+    },
+    {
+      "pangoLineage": "B.1.177",
+      "count": 11
+    },
+    {
+      "pangoLineage": "B.1.617",
+      "count": 8
+    },
+    {
+      "pangoLineage": "B.1.617.2",
+      "count": 8
+    },
+    {
+      "pangoLineage": "B.1.160",
+      "count": 7
+    },
+    {
+      "pangoLineage": "AY.43",
+      "count": 4
+    },
+    {
+      "pangoLineage": "B.1.221",
+      "count": 3
+    },
+    {
+      "pangoLineage": "Q.7",
+      "count": 3
+    },
+    {
+      "pangoLineage": "B.1.1.189",
+      "count": 2
+    },
+    {
+      "pangoLineage": "B.1.1.39",
+      "count": 2
+    },
+    {
+      "pangoLineage": "B.1.177.44",
+      "count": 2
+    },
+    {
+      "pangoLineage": "B.1.258",
+      "count": 2
+    },
+    {
+      "pangoLineage": "AY.122",
+      "count": 1
+    },
+    {
+      "pangoLineage": "AY.9",
+      "count": 1
+    },
+    {
+      "pangoLineage": "AY.9.2",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.1.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.1.28",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.1.70",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.160.16",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.258.17",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.36",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.36.35",
+      "count": 1
+    },
+    {
+      "pangoLineage": "B.1.525",
+      "count": 1
+    },
+    {
+      "pangoLineage": "C.36",
+      "count": 1
+    },
+    {
+      "pangoLineage": "C.36.3",
+      "count": 1
+    },
+    {
+      "pangoLineage": "GD.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "GL.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "P.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XAY",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XAY.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XAY.1.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XAY.1.1.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XBB",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XBB.1",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XBB.1.9",
+      "count": 1
+    },
+    {
+      "pangoLineage": "XBB.1.9.3",
+      "count": 1
+    },
+    {
+      "pangoLineage": "A",
+      "count": 0
+    },
+    {
+      "pangoLineage": "A.1",
+      "count": 0
+    },
+    {
+      "pangoLineage": "A.11",
+      "count": 0
+    },
+    {
+      "pangoLineage": "A.12",
+      "count": 0
+    },
+    {
+      "pangoLineage": "A.15",
+      "count": 0
+    },
+    {
+      "pangoLineage": "A.16",
+      "count": 0
+    }
+  ]
+}

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ControllerDescriptions.kt
@@ -69,6 +69,14 @@ const val AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION =
     """The fields to stratify by.
 If empty, only the overall count is returned.
 If requesting CSV or TSV data, the columns are ordered in the same order as the fields are specified here."""
+const val INCLUDE_SUBLINEAGES_FOR_DESCRIPTION =
+    """The name of a lineage field to group by *including all sublineages*: the response contains one row
+    per lineage defined for that field (including lineages with a count of zero), where each count includes
+    all sequences in that lineage or any of its sublineages.
+    The named field must be a lineage field and must be the single entry in \"fields\"
+    (grouping by lineage-with-sublineages together with other fields is not supported).
+    Note that, unlike a plain groupBy, counts do not partition the data: a sequence is counted under its
+    lineage and under every ancestor lineage, so the counts do not sum to the total."""
 const val AGGREGATED_ORDER_BY_FIELDS_DESCRIPTION =
     """The fields of the response to order by. 
     Fields specified here must either be \"count\" or also be present in \"fields\".

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/LapisController.kt
@@ -33,6 +33,7 @@ import org.genspectrum.lapis.openApi.GENES_DESCRIPTION
 import org.genspectrum.lapis.openApi.GENE_SCHEMA
 import org.genspectrum.lapis.openApi.Gene
 import org.genspectrum.lapis.openApi.INSERTIONS_REQUEST_SCHEMA
+import org.genspectrum.lapis.openApi.IncludeSublineagesForField
 import org.genspectrum.lapis.openApi.InsertionsOrderByFields
 import org.genspectrum.lapis.openApi.LapisAggregatedResponse
 import org.genspectrum.lapis.openApi.LapisAlignedAminoAcidSequenceResponse
@@ -121,6 +122,9 @@ class LapisController(
         @FieldsToAggregateBy
         @RequestParam
         fields: List<String>?,
+        @IncludeSublineagesForField
+        @RequestParam
+        includeSublineagesFor: String?,
         @AggregatedOrderByFields
         @RequestParam
         orderBy: List<OrderByField>?,
@@ -157,6 +161,7 @@ class LapisController(
             orderBy.toOrderBySpec(),
             limit,
             offset,
+            includeSublineagesFor,
         )
 
         lapisResponseStreamer.streamData(
@@ -179,6 +184,9 @@ class LapisController(
         @FieldsToAggregateBy
         @RequestParam
         fields: List<String>?,
+        @IncludeSublineagesForField
+        @RequestParam
+        includeSublineagesFor: String?,
         @AggregatedOrderByFields
         @RequestParam
         orderBy: List<OrderByField>?,
@@ -216,6 +224,7 @@ class LapisController(
             orderBy.toOrderBySpec(),
             limit,
             offset,
+            includeSublineagesFor,
         )
 
         lapisResponseStreamer.streamData(
@@ -241,6 +250,9 @@ class LapisController(
         @FieldsToAggregateBy
         @RequestParam
         fields: List<String>?,
+        @IncludeSublineagesForField
+        @RequestParam
+        includeSublineagesFor: String?,
         @AggregatedOrderByFields
         @RequestParam
         orderBy: List<OrderByField>?,
@@ -278,6 +290,7 @@ class LapisController(
             orderBy.toOrderBySpec(),
             limit,
             offset,
+            includeSublineagesFor,
         )
 
         lapisResponseStreamer.streamData(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -2,6 +2,7 @@ package org.genspectrum.lapis.model
 
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.request.CommonSequenceFilters
 import org.genspectrum.lapis.request.MRCASequenceFiltersRequest
 import org.genspectrum.lapis.request.MutationProportionsRequest
@@ -10,6 +11,7 @@ import org.genspectrum.lapis.request.OrderBySpec
 import org.genspectrum.lapis.request.PhyloTreeSequenceFiltersRequest
 import org.genspectrum.lapis.request.SequenceFiltersRequest
 import org.genspectrum.lapis.request.SequenceFiltersRequestWithFields
+import org.genspectrum.lapis.response.AggregationData
 import org.genspectrum.lapis.response.ExplicitlyNullable
 import org.genspectrum.lapis.response.InfoData
 import org.genspectrum.lapis.response.InsertionResponse
@@ -34,18 +36,73 @@ class SiloQueryModel(
 ) {
     private val allMetadataFields = databaseConfig.schema.metadata.map { it.name }
 
-    fun getAggregated(sequenceFilters: SequenceFiltersRequestWithFields) =
-        siloClient.sendQuery(
+    private val canonicalFieldNameByLowercase =
+        databaseConfig.schema.metadata.associate { it.name.lowercase() to it.name }
+
+    private val lineageFieldNames =
+        databaseConfig.schema.metadata.filter { it.generateLineageIndex != null }.map { it.name }.toSet()
+
+    fun getAggregated(sequenceFilters: SequenceFiltersRequestWithFields): Stream<AggregationData> {
+        val fields = sequenceFilters.fields.map { it.fieldName }
+        val includeSublineagesFor = resolveIncludeSublineagesFor(sequenceFilters.includeSublineagesFor, fields)
+
+        return siloClient.sendQuery(
             SiloQuery(
                 SiloAction.aggregated(
-                    sequenceFilters.fields.map { it.fieldName },
+                    fields,
                     sequenceFilters.orderByFields,
                     sequenceFilters.limit,
                     sequenceFilters.offset,
+                    includeSublineagesFor = includeSublineagesFor,
                 ),
                 siloFilterExpressionMapper.map(sequenceFilters),
             ),
         )
+    }
+
+    /**
+     * Validates the `includeSublineagesFor` request parameter and resolves it to the canonical field name.
+     *
+     * v1 constraint (enforced by the SILO backend): when set, the named field must be a lineage-indexed
+     * field, must be present in [fields], and must be the only group-by field. We reject unsupported
+     * combinations here with a clear message rather than forwarding a query SILO would reject cryptically.
+     */
+    private fun resolveIncludeSublineagesFor(
+        includeSublineagesFor: String?,
+        fields: List<String>,
+    ): String? {
+        if (includeSublineagesFor == null) {
+            return null
+        }
+
+        val canonicalName = canonicalFieldNameByLowercase[includeSublineagesFor.lowercase()]
+            ?: throw BadRequestException(
+                "Unknown field '$includeSublineagesFor' in 'includeSublineagesFor', known values are $allMetadataFields",
+            )
+
+        if (canonicalName !in lineageFieldNames) {
+            throw BadRequestException(
+                "'includeSublineagesFor' must name a lineage field, but '$canonicalName' is not a lineage field. " +
+                    "Lineage fields are $lineageFieldNames",
+            )
+        }
+
+        if (canonicalName !in fields) {
+            throw BadRequestException(
+                "'includeSublineagesFor' field '$canonicalName' must also be present in 'fields'",
+            )
+        }
+
+        if (fields.size != 1) {
+            throw BadRequestException(
+                "When 'includeSublineagesFor' is set, 'fields' must contain exactly the single lineage field " +
+                    "'$canonicalName'. Grouping by lineage-with-sublineages together with other fields is not " +
+                    "supported.",
+            )
+        }
+
+        return canonicalName
+    }
 
     fun computeNucleotideMutationProportions(sequenceFilters: MutationProportionsRequest): Stream<MutationResponse> {
         val fields = sequenceFilters.fields

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/OpenApiDocs.kt
@@ -24,6 +24,7 @@ import org.genspectrum.lapis.controller.AMINO_ACID_FASTA_HEADER_TEMPLATE_DESCRIP
 import org.genspectrum.lapis.controller.AMINO_ACID_MUTATION_DESCRIPTION
 import org.genspectrum.lapis.controller.DATA_FORMAT_DESCRIPTION
 import org.genspectrum.lapis.controller.DETAILS_FIELDS_DESCRIPTION
+import org.genspectrum.lapis.controller.INCLUDE_SUBLINEAGES_FOR_DESCRIPTION
 import org.genspectrum.lapis.controller.LIMIT_DESCRIPTION
 import org.genspectrum.lapis.controller.NUCLEOTIDE_FASTA_HEADER_TEMPLATE_DESCRIPTION
 import org.genspectrum.lapis.controller.NUCLEOTIDE_MUTATION_DESCRIPTION
@@ -48,6 +49,7 @@ import org.genspectrum.lapis.request.FASTA_HEADER_TEMPLATE_PROPERTY
 import org.genspectrum.lapis.request.FIELDS_PROPERTY
 import org.genspectrum.lapis.request.FORMAT_PROPERTY
 import org.genspectrum.lapis.request.GENES_PROPERTY
+import org.genspectrum.lapis.request.INCLUDE_SUBLINEAGES_FOR_PROPERTY
 import org.genspectrum.lapis.request.LIMIT_PROPERTY
 import org.genspectrum.lapis.request.MIN_PROPORTION_PROPERTY
 import org.genspectrum.lapis.request.MutationsField
@@ -120,6 +122,9 @@ fun buildOpenApiSchema(
                         ),
                         AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION,
                         databaseConfig.schema.metadata,
+                        includeSublineagesForSchema = fieldsEnum(
+                            databaseConfig.schema.metadata.filter { it.generateLineageIndex != null },
+                        ).description(INCLUDE_SUBLINEAGES_FOR_DESCRIPTION),
                     ),
                 )
                 .addSchemas(
@@ -327,6 +332,13 @@ fun buildOpenApiSchema(
                     ),
                 )
                 .addSchemas(FIELDS_TO_AGGREGATE_BY_SCHEMA, fieldsArray(databaseConfig.schema.metadata))
+                .addSchemas(
+                    INCLUDE_SUBLINEAGES_FOR_SCHEMA,
+                    fieldsEnum(
+                        databaseConfig.schema.metadata
+                            .filter { it.generateLineageIndex != null },
+                    ),
+                )
                 .addSchemas(DETAILS_FIELDS_SCHEMA, fieldsArray(databaseConfig.schema.metadata))
                 .addSchemas(
                     PRINT_NODES_NOT_IN_TREE_FIELD_PROPERTY,
@@ -625,6 +637,7 @@ private fun requestSchemaWithFields(
     requestProperties: Map<SequenceFilterFieldName, Schema<out Any>>,
     fieldsDescription: String,
     databaseConfig: List<DatabaseMetadata>,
+    includeSublineagesForSchema: Schema<*>? = null,
 ): Schema<*> =
     Schema<Any>()
         .types(setOf("object"))
@@ -633,7 +646,12 @@ private fun requestSchemaWithFields(
             requestProperties + Pair(
                 FIELDS_PROPERTY,
                 fieldsArray(databaseConfig).description(fieldsDescription),
-            ),
+            ) +
+                if (includeSublineagesForSchema != null) {
+                    mapOf(INCLUDE_SUBLINEAGES_FOR_PROPERTY to includeSublineagesForSchema)
+                } else {
+                    emptyMap()
+                },
         )
 
 private fun requestSchemaPhyloTree(requestProperties: Map<SequenceFilterFieldName, Schema<out Any>>): Schema<*> =

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/openApi/Schemas.kt
@@ -21,6 +21,7 @@ import org.genspectrum.lapis.controller.DATA_FORMAT_DESCRIPTION
 import org.genspectrum.lapis.controller.DETAILS_ENDPOINT_DESCRIPTION
 import org.genspectrum.lapis.controller.DETAILS_FIELDS_DESCRIPTION
 import org.genspectrum.lapis.controller.DETAILS_ORDER_BY_FIELDS_DESCRIPTION
+import org.genspectrum.lapis.controller.INCLUDE_SUBLINEAGES_FOR_DESCRIPTION
 import org.genspectrum.lapis.controller.INSERTIONS_ORDER_BY_FIELDS_DESCRIPTION
 import org.genspectrum.lapis.controller.LIMIT_DESCRIPTION
 import org.genspectrum.lapis.controller.LapisHeaders.LAPIS_DATA_VERSION
@@ -89,6 +90,7 @@ const val TREE_DATA_FORMAT_SCHEMA = "TreeDataFormat"
 const val NUCLEOTIDE_FASTA_HEADER_TEMPLATE_SCHEMA = "NucleotideFastaHeaderTemplate"
 const val AMINO_ACID_FASTA_HEADER_TEMPLATE_SCHEMA = "AminoAcidFastaHeaderTemplate"
 const val FIELDS_TO_AGGREGATE_BY_SCHEMA = "FieldsToAggregateBy"
+const val INCLUDE_SUBLINEAGES_FOR_SCHEMA = "IncludeSublineagesFor"
 const val DETAILS_FIELDS_SCHEMA = "DetailsFields"
 const val PHYLO_TREE_FIELD_SCHEMA = "PhyloTreeField"
 const val MUTATIONS_FIELDS_SCHEMA = "MutationsFields"
@@ -546,6 +548,14 @@ annotation class AminoAcidFastaHeaderTemplateParam
     description = AGGREGATED_GROUP_BY_FIELDS_DESCRIPTION,
 )
 annotation class FieldsToAggregateBy
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@Parameter(
+    schema = Schema(ref = "#/components/schemas/$INCLUDE_SUBLINEAGES_FOR_SCHEMA"),
+    description = INCLUDE_SUBLINEAGES_FOR_DESCRIPTION,
+)
+annotation class IncludeSublineagesForField
 
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SequenceFiltersRequestWithFields.kt
@@ -7,6 +7,7 @@ import tools.jackson.databind.DeserializationContext
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ValueDeserializer
 import tools.jackson.databind.node.ArrayNode
+import tools.jackson.databind.node.NullNode
 
 data class SequenceFiltersRequestWithFields(
     override val sequenceFilters: SequenceFilters,
@@ -18,6 +19,11 @@ data class SequenceFiltersRequestWithFields(
     override val orderByFields: OrderBySpec = OrderBySpec.EMPTY,
     override val limit: Int? = null,
     override val offset: Int? = null,
+    /**
+     * When set, names the lineage field to group by *including all sublineages* (see the
+     * `includeSublineagesFor` request parameter). Validated and resolved in [SiloQueryModel.getAggregated].
+     */
+    val includeSublineagesFor: String? = null,
 ) : CommonSequenceFilters
 
 @JacksonComponent
@@ -31,6 +37,7 @@ class SequenceFiltersRequestWithFieldsDeserializer(
         val node = jsonParser.readValueAsTree<JsonNode>()
 
         val fields = parseFieldsProperty(node, caseInsensitiveFieldConverter)
+        val includeSublineagesFor = parseIncludeSublineagesForProperty(node)
         val parsedCommonFields = parseCommonFields(node, ctxt)
 
         return SequenceFiltersRequestWithFields(
@@ -43,9 +50,22 @@ class SequenceFiltersRequestWithFieldsDeserializer(
             parsedCommonFields.orderByFields,
             parsedCommonFields.limit,
             parsedCommonFields.offset,
+            includeSublineagesFor,
         )
     }
 }
+
+fun parseIncludeSublineagesForProperty(node: JsonNode): String? =
+    when (val value = node.get(INCLUDE_SUBLINEAGES_FOR_PROPERTY)) {
+        null, is NullNode -> null
+        else -> if (value.isString) {
+            value.stringValue()
+        } else {
+            throw BadRequestException(
+                "$INCLUDE_SUBLINEAGES_FOR_PROPERTY must be a string, ${butWas(value)}",
+            )
+        }
+    }
 
 fun <T> parseFieldsProperty(
     node: JsonNode,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/SpecialProperties.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/SpecialProperties.kt
@@ -5,6 +5,7 @@ import tools.jackson.databind.node.JsonNodeType
 const val FORMAT_PROPERTY = "dataFormat"
 const val MIN_PROPORTION_PROPERTY = "minProportion"
 const val FIELDS_PROPERTY = "fields"
+const val INCLUDE_SUBLINEAGES_FOR_PROPERTY = "includeSublineagesFor"
 const val NUCLEOTIDE_MUTATIONS_PROPERTY = "nucleotideMutations"
 const val AMINO_ACID_MUTATIONS_PROPERTY = "aminoAcidMutations"
 const val NUCLEOTIDE_INSERTIONS_PROPERTY = "nucleotideInsertions"
@@ -25,6 +26,7 @@ val SPECIAL_REQUEST_PROPERTY_TYPES = mapOf(
     FORMAT_PROPERTY to JsonNodeType.STRING,
     MIN_PROPORTION_PROPERTY to JsonNodeType.NUMBER,
     FIELDS_PROPERTY to JsonNodeType.ARRAY,
+    INCLUDE_SUBLINEAGES_FOR_PROPERTY to JsonNodeType.STRING,
     NUCLEOTIDE_MUTATIONS_PROPERTY to JsonNodeType.ARRAY,
     AMINO_ACID_MUTATIONS_PROPERTY to JsonNodeType.ARRAY,
     NUCLEOTIDE_INSERTIONS_PROPERTY to JsonNodeType.ARRAY,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -82,14 +82,24 @@ sealed class SiloAction<ResponseType>(
         }
 
     companion object {
+        /**
+         * @param includeSublineagesFor when non-null, names the single lineage-indexed field to group by
+         * *including all sublineages*. In this case [groupByFields] is ignored and the group-by column is
+         * rendered as `lineage(<field>, includeSublineages:=true)`. Callers must have validated that this
+         * field is a lineage field, is present in [groupByFields], and is the only group-by field.
+         */
         fun aggregated(
             groupByFields: List<String> = emptyList(),
             orderByFields: OrderBySpec = OrderBySpec.EMPTY,
             limit: Int? = null,
             offset: Int? = null,
+            includeSublineagesFor: String? = null,
         ): SiloAction<AggregationData> =
             AggregatedAction(
-                groupByFields = groupByFields,
+                groupByFields = when (includeSublineagesFor) {
+                    null -> groupByFields.map { GroupByField.Plain(it) }
+                    else -> listOf(GroupByField.LineageWithSublineages(includeSublineagesFor))
+                },
                 orderByFields = getOrderByFieldsList(orderByFields),
                 randomize = getRandomize(orderByFields),
                 limit = limit,
@@ -223,7 +233,7 @@ sealed class SiloAction<ResponseType>(
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     data class AggregatedAction(
-        val groupByFields: List<String>,
+        val groupByFields: List<GroupByField>,
         override val orderByFields: List<OrderByField> = emptyList(),
         override val randomize: RandomizeConfig? = null,
         override val limit: Int? = null,
@@ -241,7 +251,7 @@ sealed class SiloAction<ResponseType>(
                     positionalArgs = buildList {
                         add(SaneQlList(listOf(SaneQlAssignment("count", SaneQlFunctionCall("count")))))
                         if (groupByFields.isNotEmpty()) {
-                            add(SaneQlList(groupByFields.map { id(it) }))
+                            add(SaneQlList(groupByFields.map { it.toSaneQl() }))
                         }
                     },
                 ),
@@ -399,6 +409,61 @@ sealed class SiloAction<ResponseType>(
         override fun ownSaneQlSteps(): List<SaneQlStep> {
             val allFields = additionalFields + sequenceNames
             return listOf(SaneQlStep("project", positionalArgs = listOf(SaneQlList(allFields.map { id(it) }))))
+        }
+    }
+}
+
+/**
+ * A single group-by column of an [SiloAction.AggregatedAction].
+ *
+ * [Plain] renders as a bare column identifier (`id(name)` → `"name"`), exactly as before.
+ * [LineageWithSublineages] renders as `lineage("name", includeSublineages:=true)`, telling SILO to
+ * produce one count per defined lineage where each count includes that lineage's sublineages.
+ */
+@JsonSerialize(using = GroupByFieldSerializer::class)
+sealed interface GroupByField {
+    val name: String
+
+    fun toSaneQl(): SaneQlExpression
+
+    data class Plain(
+        override val name: String,
+    ) : GroupByField {
+        override fun toSaneQl(): SaneQlExpression = id(name)
+    }
+
+    data class LineageWithSublineages(
+        override val name: String,
+    ) : GroupByField {
+        override fun toSaneQl(): SaneQlExpression =
+            SaneQlFunctionCall(
+                "lineage",
+                positionalArgs = listOf(id(name)),
+                namedArgs = listOf(SaneQlNamedArg("includeSublineages", SaneQlBoolean(true))),
+            )
+    }
+}
+
+/**
+ * Serializes [GroupByField] so the (non-wire, informational) action JSON keeps its historic shape:
+ * a [GroupByField.Plain] becomes a bare string, so `groupByFields` still renders as `["a", "b"]`.
+ * A [GroupByField.LineageWithSublineages] becomes `{"lineage": "...", "includeSublineages": true}`.
+ * The actual query sent to SILO is the SaneQL string from [SiloQuery.toSaneQl], not this JSON.
+ */
+class GroupByFieldSerializer : ValueSerializer<GroupByField>() {
+    override fun serialize(
+        value: GroupByField,
+        gen: JsonGenerator,
+        serializers: SerializationContext,
+    ) {
+        when (value) {
+            is GroupByField.Plain -> gen.writeString(value.name)
+            is GroupByField.LineageWithSublineages -> {
+                gen.writeStartObject()
+                gen.writeStringProperty("lineage", value.name)
+                gen.writeBooleanProperty("includeSublineages", true)
+                gen.writeEndObject()
+            }
         }
     }
 }

--- a/lapis/src/main/resources/templates/llms.txt
+++ b/lapis/src/main/resources/templates/llms.txt
@@ -27,7 +27,8 @@ You can use metadata fields as filter parameters in your queries. The filter syn
 [# th:if="${stringField != null}"]- **String fields**: Use exact or regex match.
   You can also supply an array - the fields will be combined with logical OR.
   Examples: `"[(${stringField})]": "someValue"`, `"[(${stringField})].regex": "^startsWithThis*"`, `"[(${stringField})]": ["someValue", "orOtherValue"]`[/]
-[# th:if="${lineageField != null}"]- **Lineage fields**: For string fields that also have a lineage index, you can filter for exact matches (`"[(${lineageField})]": "lineage"`) or including sublineages (`"[(${lineageField})]": "lineage*"`).[/]
+[# th:if="${lineageField != null}"]- **Lineage fields**: For string fields that also have a lineage index, you can filter for exact matches (`"[(${lineageField})]": "lineage"`) or including sublineages (`"[(${lineageField})]": "lineage*"`).
+  On `sample/aggregated` you can also get a sublineage-inclusive count per lineage by setting `"includeSublineagesFor": "[(${lineageField})]"` (with `"fields": ["[(${lineageField})]"]` as the only field). The response has one row per defined lineage (including zero counts), and each count includes all sequences in that lineage or any of its sublineages. Note these counts overlap (a sequence is counted under its lineage and every ancestor), so they do not sum to the total.[/]
 [# th:if="${dateField != null}"]- **Date fields**: Use exact match, or `From`/`To` suffixes for ranges. You can also supply an array for exact match - the values will be combined with logical OR, and may include `null`.
   Examples: `"[(${dateField})]": "2023-01-15"`, `"[(${dateField})]From": "2023-01-01", "[(${dateField})]To": "2023-12-31"`, `"[(${dateField})]": ["2023-01-15", "2023-02-20"]`[/]
 [# th:if="${intField != null}"]- **Integer fields**: Use exact match or `From`/`To` for ranges. You can also supply an array for exact match - the values will be combined with logical OR, and may include `null`.

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/ExceptionHandlerTest.kt
@@ -43,7 +43,7 @@ class ExceptionHandlerTest(
     private val validRoute = "/aggregated"
 
     private fun MockKMatcherScope.validControllerCall() =
-        lapisController.aggregated(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+        lapisController.aggregated(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
 
     @Test
     fun `throw NOT_FOUND(404) when route is not found`() {

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
@@ -45,6 +45,7 @@ fun mutationProportionsRequest(
 fun sequenceFiltersRequestWithFields(
     sequenceFilters: Map<String, String>,
     fields: List<String> = emptyList(),
+    includeSublineagesFor: String? = null,
 ) = SequenceFiltersRequestWithFields(
     sequenceFilters.mapValues { listOf(it.value) },
     emptyList(),
@@ -53,6 +54,7 @@ fun sequenceFiltersRequestWithFields(
     emptyList(),
     fields.map { Field(it) },
     OrderBySpec.EMPTY,
+    includeSublineagesFor = includeSublineagesFor,
 )
 
 fun phyloTreeSequenceFiltersRequest(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerTest.kt
@@ -82,6 +82,48 @@ class LapisControllerTest(
             .andExpect(jsonPath("\$.info.dataVersion").value(1234))
     }
 
+    @Test
+    fun `GIVEN GET request with includeSublineagesFor THEN passes it through to the model`() {
+        every {
+            siloQueryModelMock.getAggregated(
+                sequenceFiltersRequestWithFields(
+                    sequenceFilters = emptyMap(),
+                    fields = listOf("pangoLineage"),
+                    includeSublineagesFor = "pangoLineage",
+                ),
+            )
+        } returns Stream.of(AggregationData(0, mapOf("pangoLineage" to StringNode("B.1"))))
+
+        mockMvc.perform(
+            getSample("aggregated")
+                .param("fields", "pangoLineage")
+                .param("includeSublineagesFor", "pangoLineage"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$.data[0].count").value(0))
+    }
+
+    @Test
+    fun `GIVEN POST request with includeSublineagesFor THEN passes it through to the model`() {
+        every {
+            siloQueryModelMock.getAggregated(
+                sequenceFiltersRequestWithFields(
+                    sequenceFilters = emptyMap(),
+                    fields = listOf("pangoLineage"),
+                    includeSublineagesFor = "pangoLineage",
+                ),
+            )
+        } returns Stream.of(AggregationData(0, mapOf("pangoLineage" to StringNode("B.1"))))
+
+        mockMvc.perform(
+            postSample("aggregated")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"fields": ["pangoLineage"], "includeSublineagesFor": "pangoLineage"}"""),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("\$.data[0].count").value(0))
+    }
+
     @ParameterizedTest(name = "{0} aggregated with fields")
     @MethodSource("getRequestsWithFields")
     fun `aggregated with fields`(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
@@ -8,6 +8,7 @@ import org.genspectrum.lapis.config.DatabaseMetadata
 import org.genspectrum.lapis.config.MetadataType
 import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.config.ReferenceSequenceSchema
+import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.controller.mutationData
 import org.genspectrum.lapis.controller.mutationProportionsRequest
 import org.genspectrum.lapis.controller.sequenceFiltersRequest
@@ -36,9 +37,11 @@ import org.genspectrum.lapis.silo.SiloClient
 import org.genspectrum.lapis.silo.SiloQuery
 import org.genspectrum.lapis.silo.True
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.stream.Stream
 
 private val someMutationData = MutationData(
@@ -80,6 +83,11 @@ class SiloQueryModelTest {
             DatabaseMetadata(name = "isBoolean", type = MetadataType.BOOLEAN),
             DatabaseMetadata(name = "date", type = MetadataType.DATE),
             DatabaseMetadata(name = "primaryKey", type = MetadataType.STRING),
+            DatabaseMetadata(
+                name = "pangoLineage",
+                type = MetadataType.STRING,
+                generateLineageIndex = "pangoLineageDefinition.yaml",
+            ),
         ),
         primaryKey = "primaryKey",
     )
@@ -101,6 +109,20 @@ class SiloQueryModelTest {
             databaseConfig = testDatabaseConfig,
         )
     }
+
+    private fun aggregatedRequest(
+        fields: List<Field>,
+        includeSublineagesFor: String? = null,
+    ) = SequenceFiltersRequestWithFields(
+        emptyMap(),
+        emptyList(),
+        emptyList(),
+        emptyList(),
+        emptyList(),
+        fields,
+        OrderBySpec.EMPTY,
+        includeSublineagesFor = includeSublineagesFor,
+    )
 
     @Test
     fun `aggregate calls the SILO client with an aggregated action`() {
@@ -128,6 +150,106 @@ class SiloQueryModelTest {
     }
 
     @Test
+    fun `GIVEN includeSublineagesFor names the sole lineage field THEN sends a sublineage-inclusive aggregation`() {
+        every { siloClientMock.sendQuery(any<SiloQuery<AggregationData>>()) } returns Stream.empty()
+        every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
+
+        underTest.getAggregated(
+            aggregatedRequest(
+                fields = listOf(Field("pangoLineage")),
+                includeSublineagesFor = "pangoLineage",
+            ),
+        )
+
+        verify {
+            siloClientMock.sendQuery(
+                SiloQuery(
+                    SiloAction.aggregated(listOf("pangoLineage"), includeSublineagesFor = "pangoLineage"),
+                    True,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `GIVEN includeSublineagesFor with different casing THEN normalizes to the canonical field name`() {
+        every { siloClientMock.sendQuery(any<SiloQuery<AggregationData>>()) } returns Stream.empty()
+        every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
+
+        underTest.getAggregated(
+            aggregatedRequest(
+                fields = listOf(Field("pangoLineage")),
+                includeSublineagesFor = "PANGOLINEAGE",
+            ),
+        )
+
+        verify {
+            siloClientMock.sendQuery(
+                SiloQuery(
+                    SiloAction.aggregated(listOf("pangoLineage"), includeSublineagesFor = "pangoLineage"),
+                    True,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `GIVEN includeSublineagesFor names an unknown field THEN throws BadRequestException`() {
+        val exception = assertThrows<BadRequestException> {
+            underTest.getAggregated(
+                aggregatedRequest(
+                    fields = listOf(Field("notAField")),
+                    includeSublineagesFor = "notAField",
+                ),
+            )
+        }
+
+        assertThat(exception.message, containsString("Unknown field 'notAField'"))
+    }
+
+    @Test
+    fun `GIVEN includeSublineagesFor names a non-lineage field THEN throws BadRequestException`() {
+        val exception = assertThrows<BadRequestException> {
+            underTest.getAggregated(
+                aggregatedRequest(
+                    fields = listOf(Field("accession")),
+                    includeSublineagesFor = "accession",
+                ),
+            )
+        }
+
+        assertThat(exception.message, containsString("not a lineage field"))
+    }
+
+    @Test
+    fun `GIVEN includeSublineagesFor field is not present in fields THEN throws BadRequestException`() {
+        val exception = assertThrows<BadRequestException> {
+            underTest.getAggregated(
+                aggregatedRequest(
+                    fields = listOf(Field("accession")),
+                    includeSublineagesFor = "pangoLineage",
+                ),
+            )
+        }
+
+        assertThat(exception.message, containsString("must also be present in 'fields'"))
+    }
+
+    @Test
+    fun `GIVEN includeSublineagesFor combined with a second group-by field THEN throws BadRequestException`() {
+        val exception = assertThrows<BadRequestException> {
+            underTest.getAggregated(
+                aggregatedRequest(
+                    fields = listOf(Field("pangoLineage"), Field("accession")),
+                    includeSublineagesFor = "pangoLineage",
+                ),
+            )
+        }
+
+        assertThat(exception.message, containsString("must contain exactly the single lineage field"))
+    }
+
+    @Test
     fun `GIVEN no fields specified THEN getDetails uses all metadata fields`() {
         every { siloClientMock.sendQuery(any<SiloQuery<DetailsData>>()) } returns Stream.empty()
         every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
@@ -148,7 +270,7 @@ class SiloQueryModelTest {
             siloClientMock.sendQuery(
                 SiloQuery(
                     SiloAction.details(
-                        listOf("accession", "age", "qc", "isBoolean", "date", "primaryKey"),
+                        listOf("accession", "age", "qc", "isBoolean", "date", "primaryKey", "pangoLineage"),
                     ),
                     True,
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryToSaneQlTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryToSaneQlTest.kt
@@ -124,6 +124,23 @@ class SiloQueryToSaneQlTest {
                     """.groupBy({count:=count()}, {"field1", "field2"}).orderBy({"field3", "field4".desc()}).offset(50).limit(100)""",
                 ),
                 Arguments.of(
+                    SiloAction.aggregated(
+                        listOf("pangoLineage"),
+                        includeSublineagesFor = "pangoLineage",
+                    ),
+                    """.groupBy({count:=count()}, {lineage("pangoLineage", includeSublineages:=true)})""",
+                ),
+                Arguments.of(
+                    SiloAction.aggregated(
+                        listOf("pangoLineage"),
+                        listOf(OrderByField("count", Order.DESCENDING)).toOrderBySpec(),
+                        limit = 10,
+                        includeSublineagesFor = "pangoLineage",
+                    ),
+                    """.groupBy({count:=count()}, {lineage("pangoLineage", includeSublineages:=true)})""" +
+                        """.orderBy({"count".desc()}).limit(10)""",
+                ),
+                Arguments.of(
                     SiloAction.aggregated(orderByFields = OrderBySpec.Random(seed = null)),
                     ".groupBy({count:=count()}).randomize()",
                 ),


### PR DESCRIPTION
Corresponds to SILO PR: https://github.com/GenSpectrum/LAPIS-SILO/pull/1366

Closes issue: https://github.com/GenSpectrum/LAPIS-SILO/issues/1192

## What

Adds an `includeSublineagesFor` parameter to `/sample/aggregated` that groups by a lineage
field **including each lineage's sublineages**, returning one count row per defined lineage
(including zero-count lineages).

**Motivation:** Loculus's search-filter lineage dropdown shows sublineage-inclusive per-lineage
counts. Today it computes them **client-side** — a flat `/aggregated` groupBy plus a
`lineageDefinition` fetch, then a DAG rollup (alias resolution + descendant summing over
recombinant edges) in JavaScript. `includeSublineagesFor` lets Loculus get those counts
directly from the server in one query, retiring the duplicated client-side tree-walk and the
extra round-trip, with SILO as the single source of truth for the rollup.

```
GET /sample/aggregated?fields=pangoLineage&includeSublineagesFor=pangoLineage
```
```jsonc
// POST /sample/aggregated
{ "fields": ["pangoLineage"], "includeSublineagesFor": "pangoLineage" }
```

Under the hood LAPIS emits:
```
...groupBy({count:=count()}, {lineage("pangoLineage", includeSublineages:=true)})
```

## Requires SILO support

Depends on a `lapis-silo` release that supports the new SaneQL groupBy form
(GenSpectrum/LAPIS-SILO#1366).

## API shape

`includeSublineagesFor` names the lineage field to expand (must be a lineage-indexed field
and the sole group-by field). A dedicated param was chosen over overloading the existing
`*`-suffix (used for lineage *filtering*) because it's explicit and unambiguous when a schema
has more than one lineage column.

**Limitation:** grouping by a lineage-with-sublineages field together with other fields is
not supported (SILO v1 constraint). Requests that combine them — or that name a non-lineage
field, or a field not present in `fields` — are rejected with a clear `400 Bad Request` at the LAPIS layer (never forwarded to SILO).

**Non-partitioning:** a sequence in `A.1` is counted under both `A.1` and `A`; counts don't
sum to the total.

## Implementation

- `GroupByField` sum type (`Plain` → `id(name)`, `LineageWithSublineages` → the `lineage(...)`
  call); `AggregatedAction` renders accordingly, plain grouping unchanged.
- `includeSublineagesFor` parsed for GET and POST, validated at a single point in the model
  layer (`SiloQueryModel`) with access to the database config for the lineage-field check.
- OpenAPI (GET param + POST body) and `llms.txt` updated.

## Tests & docs

- Unit tests: SaneQL rendering, request/model parsing, and the validation rejections.
- `lapis-e2e`: a new aggregated case (`groupByPangoLineageIncludingSublineages.json`) against
  the existing lineage-bearing test dataset; uses `orderBy + limit` for a deterministic
  expected set that still covers zero-count emission. (Red in CI until the SILO release — see
  above.)
- `lapis-docs`: documented in the lineage-queries concept page (with single-field and
  non-partition cautions), cross-referenced from the pango-lineage page, and noted in the
  fields reference.