### PR TITLE
fix(lapis): restore `insertion` and `mutation` format in response

### DIFF
--- a/.github/workflows/lapis.yml
+++ b/.github/workflows/lapis.yml
@@ -4,10 +4,7 @@ on: [ push ]
 
 env:
   DOCKER_IMAGE_NAME: ghcr.io/genspectrum/lapis
-  # Pinned because SILO's `latest` currently breaks single-segmented mutation/insertion
-  # handling (requires an explicit `sequenceName` and prefixes insertions with `main:`).
-  # TODO: bump back to `latest` once SILO is compatible again.
-  SILO_TAG: 0.12.1
+  SILO_TAG: latest
 
 jobs:
   Tests:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Higher versions will also work if they are not specified in the table.
 
 | LAPIS  | SILO   |
 |--------|--------|
+| 0.8.5  | 0.13.0 |
 | 0.8.4  | 0.12.0 |
 | 0.7.0  | 0.10.0 |
 | 0.6.0  | 0.9.0  |

--- a/lapis-e2e/test/aminoAcidMutations.spec.ts
+++ b/lapis-e2e/test/aminoAcidMutations.spec.ts
@@ -40,7 +40,7 @@ describe('The /aminoAcidMutations endpoint', () => {
     expect(mutation).to.deep.equal({
       count: undefined,
       coverage: undefined,
-      mutation: 'ORF1a:A1306S',
+      mutation: 'E:T9I',
       mutationFrom: undefined,
       mutationTo: undefined,
       position: undefined,
@@ -71,7 +71,7 @@ describe('The /aminoAcidMutations endpoint', () => {
       },
     });
 
-    expect(ascendingOrderedResult.data[0]).to.have.property('mutation', 'ORF1a:A1306S');
+    expect(ascendingOrderedResult.data[0]).to.have.property('mutation', 'E:T9I');
 
     const descendingOrderedResult = await lapisClient.postAminoAcidMutations({
       sequenceFiltersWithMinProportion: {
@@ -79,7 +79,7 @@ describe('The /aminoAcidMutations endpoint', () => {
       },
     });
 
-    expect(descendingOrderedResult.data[0]).to.have.property('mutation', 'ORF8:Y73C');
+    expect(descendingOrderedResult.data[0]).to.have.property('mutation', 'S:Y505H');
   });
 
   it('should apply limit and offset', async () => {
@@ -91,7 +91,7 @@ describe('The /aminoAcidMutations endpoint', () => {
     });
 
     expect(resultWithLimit.data).to.have.length(2);
-    expect(resultWithLimit.data[1]).to.have.property('mutation', 'ORF1a:A1708D');
+    expect(resultWithLimit.data[1]).to.have.property('mutation', 'M:A63T');
 
     const resultWithLimitAndOffset = await lapisClient.postAminoAcidMutations({
       sequenceFiltersWithMinProportion: {
@@ -168,9 +168,9 @@ mutation,count,coverage,proportion,sequenceName,mutationFrom,mutationTo,position
 
     expect(resultText).to.contain(
       String.raw`
-N:A220V,1,17,0.058823529411764705,N,A,V,220
-S:A222V,3,16,0.1875,S,A,V,222
-ORF1a:A2529V,3,17,0.17647058823529413,ORF1a,A,V,2529
+E:T9I,4,16,0.25,E,T,I,9
+M:A63T,5,17,0.29411764705882354,M,A,T,63
+M:D3G,3,17,0.17647058823529413,M,D,G,3
 `.trim()
     );
   });
@@ -194,9 +194,9 @@ mutation	count	coverage	proportion	sequenceName	mutationFrom	mutationTo	position
 
     expect(resultText).to.contain(
       String.raw`
-N:A220V	1	17	0.058823529411764705	N	A	V	220
-S:A222V	3	16	0.1875	S	A	V	222
-ORF1a:A2529V	3	17	0.17647058823529413	ORF1a	A	V	2529
+E:T9I	4	16	0.25	E	T	I	9
+M:A63T	5	17	0.29411764705882354	M	A	T	63
+M:D3G	3	17	0.17647058823529413	M	D	G	3
     `.trim()
     );
   });

--- a/lapis-e2e/test/nucleotideInsertions.spec.ts
+++ b/lapis-e2e/test/nucleotideInsertions.spec.ts
@@ -47,7 +47,7 @@ describe('The /nucleotideInsertions endpoint', () => {
         orderBy: [{ field: 'insertion', type: 'ascending' }],
       },
     });
-    expect(ascendingOrderedResult.data[0]).to.have.property('insertion', 'ins_22204:CAGAA');
+    expect(ascendingOrderedResult.data[0]).to.have.property('insertion', 'ins_5959:TAT');
     expect(ascendingOrderedResult.data).to.have.length(4);
 
     const descendingOrderedResult = await lapisClient.postNucleotideInsertions({
@@ -57,7 +57,7 @@ describe('The /nucleotideInsertions endpoint', () => {
     });
 
     expect(descendingOrderedResult.data).to.have.length(4);
-    expect(descendingOrderedResult.data[3]).to.have.property('insertion', 'ins_22204:CAGAA');
+    expect(descendingOrderedResult.data[3]).to.have.property('insertion', 'ins_5959:TAT');
   });
 
   it('advancedQuery can filter out unwanted insertions', async () => {

--- a/lapis-e2e/test/nucleotideMutations.spec.ts
+++ b/lapis-e2e/test/nucleotideMutations.spec.ts
@@ -97,7 +97,7 @@ describe('The /nucleotideMutations endpoint', () => {
       },
     });
 
-    expect(descendingOrderedResult.data[0]).to.have.property('mutation', 'T9-');
+    expect(descendingOrderedResult.data[0]).to.have.property('mutation', 'T29867A');
   });
 
   it('should apply limit and offset', async () => {
@@ -109,7 +109,7 @@ describe('The /nucleotideMutations endpoint', () => {
     });
 
     expect(resultWithLimit.data).to.have.length(2);
-    expect(resultWithLimit.data[1]).to.have.property('mutation', 'A11201G');
+    expect(resultWithLimit.data[1]).to.have.property('mutation', 'A4-');
 
     const resultWithLimitAndOffset = await lapisClient.postNucleotideMutations({
       sequenceFiltersWithMinProportion: {
@@ -186,9 +186,9 @@ mutation,count,coverage,proportion,sequenceName,mutationFrom,mutationTo,position
 
     expect(resultText).to.contain(
       String.raw`
-C7029T,1,16,0.0625,,C,T,7029
-C71-,1,17,0.058823529411764705,,C,-,71
-C7124T,2,17,0.11764705882352941,,C,T,7124
+A1-,5,5,1.0,,A,-,1
+A4-,5,6,0.8333333333333334,,A,-,4
+A5-,5,6,0.8333333333333334,,A,-,5
 `.trim()
     );
   });
@@ -212,9 +212,9 @@ mutation	count	coverage	proportion	sequenceName	mutationFrom	mutationTo	position
 
     expect(resultText).to.contain(
       String.raw`
-C7029T	1	16	0.0625		C	T	7029
-C71-	1	17	0.058823529411764705		C	-	71
-C7124T	2	17	0.11764705882352941		C	T	7124
+A1-	5	5	1.0		A	-	1
+A4-	5	6	0.8333333333333334		A	-	4
+A5-	5	6	0.8333333333333334		A	-	5
     `.trim()
     );
   });

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
@@ -35,6 +35,18 @@ class ReferenceGenomeSchema(
 
     fun isSingleSegmented(): Boolean = nucleotideSequences.size == 1
 
+    /**
+     * SILO requires an explicit sequence name on nucleotide filters. For single-segmented genomes the client may
+     * omit it, so fall back to the only segment's name. Multi-segmented genomes keep the (possibly null) input,
+     * where a missing name is validated by SILO.
+     */
+    fun resolveNucleotideSequenceName(name: String? = null): String? =
+        name ?: if (isSingleSegmented()) {
+            nucleotideSequences.single().name
+        } else {
+            null
+        }
+
     fun getSequenceNameFromCaseInsensitiveName(name: String) =
         nucleotideSequenceNames[name.lowercase()]?.name
             ?: geneNames[name.lowercase()]?.name

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/config/ReferenceGenome.kt
@@ -35,17 +35,7 @@ class ReferenceGenomeSchema(
 
     fun isSingleSegmented(): Boolean = nucleotideSequences.size == 1
 
-    /**
-     * SILO requires an explicit sequence name on nucleotide filters. For single-segmented genomes the client may
-     * omit it, so fall back to the only segment's name. Multi-segmented genomes keep the (possibly null) input,
-     * where a missing name is validated by SILO.
-     */
-    fun resolveNucleotideSequenceName(name: String? = null): String? =
-        name ?: if (isSingleSegmented()) {
-            nucleotideSequences.single().name
-        } else {
-            null
-        }
+    fun firstNucleotideSequenceName() = nucleotideSequences.first().name
 
     fun getSequenceNameFromCaseInsensitiveName(name: String) =
         nucleotideSequenceNames[name.lowercase()]?.name

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -293,11 +293,11 @@ class AdvancedQueryCustomListener(
 
         val expression = when (val secondSymbol = ctx.singleSegmentedMutationQuerySecondSymbol()) {
             null -> HasNucleotideMutation(
-                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                sequenceName = referenceGenomeSchema.firstNucleotideSequenceName(),
                 position = position,
             )
             else -> NucleotideSymbolEquals(
-                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                sequenceName = referenceGenomeSchema.firstNucleotideSequenceName(),
                 position = position,
                 symbol = secondSymbol.text.uppercase(),
             )
@@ -409,7 +409,7 @@ class AdvancedQueryCustomListener(
             NucleotideInsertionContains(
                 ctx.position().text.toInt(),
                 value.uppercase(),
-                referenceGenomeSchema.resolveNucleotideSequenceName(),
+                referenceGenomeSchema.firstNucleotideSequenceName(),
             ),
         )
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/AdvancedQueryCustomListener.kt
@@ -292,8 +292,15 @@ class AdvancedQueryCustomListener(
         val position = ctx.position().text.toInt()
 
         val expression = when (val secondSymbol = ctx.singleSegmentedMutationQuerySecondSymbol()) {
-            null -> HasNucleotideMutation(null, position)
-            else -> NucleotideSymbolEquals(null, position, secondSymbol.text.uppercase())
+            null -> HasNucleotideMutation(
+                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                position = position,
+            )
+            else -> NucleotideSymbolEquals(
+                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                position = position,
+                symbol = secondSymbol.text.uppercase(),
+            )
         }
 
         expressionStack.addLast(expression)
@@ -402,7 +409,7 @@ class AdvancedQueryCustomListener(
             NucleotideInsertionContains(
                 ctx.position().text.toInt(),
                 value.uppercase(),
-                null,
+                referenceGenomeSchema.resolveNucleotideSequenceName(),
             ),
         )
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -1,6 +1,7 @@
 package org.genspectrum.lapis.model
 
 import org.genspectrum.lapis.config.ADVANCED_QUERY_FIELD
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.config.SequenceFilterFieldType
 import org.genspectrum.lapis.config.SequenceFilterFields
 import org.genspectrum.lapis.config.VARIANT_QUERY_FIELD
@@ -52,6 +53,7 @@ class SiloFilterExpressionMapper(
     private val allowedSequenceFilterFields: SequenceFilterFields,
     private val variantQueryFacade: VariantQueryFacade,
     private val advancedQueryFacade: AdvancedQueryFacade,
+    private val referenceGenomeSchema: ReferenceGenomeSchema,
 ) {
     fun map(sequenceFilters: BaseSequenceFilters): SiloFilterExpression {
         if (sequenceFilters.isEmpty()) {
@@ -501,11 +503,14 @@ class SiloFilterExpressionMapper(
         wrapInMaybe(
             nucleotideMutation,
             when (nucleotideMutation.symbol) {
-                null -> HasNucleotideMutation(nucleotideMutation.sequenceName, nucleotideMutation.position)
+                null -> HasNucleotideMutation(
+                    sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(nucleotideMutation.sequenceName),
+                    position = nucleotideMutation.position,
+                )
                 else -> NucleotideSymbolEquals(
-                    nucleotideMutation.sequenceName,
-                    nucleotideMutation.position,
-                    nucleotideMutation.symbol,
+                    sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(nucleotideMutation.sequenceName),
+                    position = nucleotideMutation.position,
+                    symbol = nucleotideMutation.symbol,
                 )
             },
         )
@@ -535,7 +540,7 @@ class SiloFilterExpressionMapper(
         NucleotideInsertionContains(
             nucleotideInsertion.position,
             nucleotideInsertion.insertions,
-            nucleotideInsertion.segment,
+            referenceGenomeSchema.resolveNucleotideSequenceName(nucleotideInsertion.segment),
         )
 
     private fun toAminoAcidInsertionFilter(aminoAcidInsertion: AminoAcidInsertion): AminoAcidInsertionContains =

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -504,11 +504,11 @@ class SiloFilterExpressionMapper(
             nucleotideMutation,
             when (nucleotideMutation.symbol) {
                 null -> HasNucleotideMutation(
-                    sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(nucleotideMutation.sequenceName),
+                    sequenceName = nucleotideMutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
                     position = nucleotideMutation.position,
                 )
                 else -> NucleotideSymbolEquals(
-                    sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(nucleotideMutation.sequenceName),
+                    sequenceName = nucleotideMutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
                     position = nucleotideMutation.position,
                     symbol = nucleotideMutation.symbol,
                 )
@@ -538,9 +538,9 @@ class SiloFilterExpressionMapper(
 
     private fun toNucleotideInsertionFilter(nucleotideInsertion: NucleotideInsertion): NucleotideInsertionContains =
         NucleotideInsertionContains(
-            nucleotideInsertion.position,
-            nucleotideInsertion.insertions,
-            referenceGenomeSchema.resolveNucleotideSequenceName(nucleotideInsertion.segment),
+            position = nucleotideInsertion.position,
+            value = nucleotideInsertion.insertions,
+            sequenceName = nucleotideInsertion.segment ?: referenceGenomeSchema.firstNucleotideSequenceName(),
         )
 
     private fun toAminoAcidInsertionFilter(aminoAcidInsertion: AminoAcidInsertion): AminoAcidInsertionContains =

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapper.kt
@@ -504,11 +504,13 @@ class SiloFilterExpressionMapper(
             nucleotideMutation,
             when (nucleotideMutation.symbol) {
                 null -> HasNucleotideMutation(
-                    sequenceName = nucleotideMutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
+                    sequenceName =
+                        nucleotideMutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
                     position = nucleotideMutation.position,
                 )
                 else -> NucleotideSymbolEquals(
-                    sequenceName = nucleotideMutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
+                    sequenceName =
+                        nucleotideMutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
                     position = nucleotideMutation.position,
                     symbol = nucleotideMutation.symbol,
                 )

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -8,6 +8,7 @@ import org.genspectrum.lapis.request.DetailsFiltersRequest
 import org.genspectrum.lapis.request.MRCASequenceFiltersRequest
 import org.genspectrum.lapis.request.MutationProportionsRequest
 import org.genspectrum.lapis.request.MutationsField
+import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
 import org.genspectrum.lapis.request.PhyloTreeSequenceFiltersRequest
 import org.genspectrum.lapis.request.PlainField
@@ -16,6 +17,7 @@ import org.genspectrum.lapis.request.SequencePositionField
 import org.genspectrum.lapis.response.ExplicitlyNullable
 import org.genspectrum.lapis.response.InfoData
 import org.genspectrum.lapis.response.InsertionResponse
+import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.MutationResponse
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
@@ -26,6 +28,7 @@ import org.genspectrum.lapis.silo.SiloQuery
 import org.genspectrum.lapis.util.toUnalignedSequenceName
 import org.springframework.stereotype.Component
 import java.util.stream.Stream
+import kotlin.collections.emptyList
 
 @Component
 class SiloQueryModel(
@@ -52,35 +55,14 @@ class SiloQueryModel(
         )
 
     fun computeNucleotideMutationProportions(sequenceFilters: MutationProportionsRequest): Stream<MutationResponse> {
-        val fields = siloMutationFields(sequenceFilters.fields)
+        val assembleMutation = { data: MutationData ->
+            val core = "${data.mutationFrom}${data.position}${data.mutationTo}"
+            if (referenceGenomeSchema.isSingleSegmented()) core else "${data.sequenceName}:$core"
+        }
 
-        val data = siloClient.sendQuery(
-            SiloQuery(
-                SiloAction.mutations(
-                    minProportion = sequenceFilters.minProportion,
-                    orderByFields = sequenceFilters.orderByFields,
-                    limit = sequenceFilters.limit,
-                    offset = sequenceFilters.offset,
-                    fields = fields,
-                ),
-                siloFilterExpressionMapper.map(sequenceFilters),
-            ),
-        )
-
-        return data.map {
-            val mutation = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION)) {
-                val core = "${it.mutationFrom}${it.position}${it.mutationTo}"
-                if (referenceGenomeSchema.isSingleSegmented()) {
-                    core
-                } else {
-                    "${it.sequenceName}:$core"
-                }
-            } else {
-                null
-            }
-
+        return queryMutationData(sequenceFilters, SiloAction.Companion::mutations).map {
             MutationResponse(
-                mutation = mutation,
+                mutation = sequenceFilters.ifRequested(MutationsField.MUTATION, assembleMutation(it)),
                 count = it.count,
                 coverage = it.coverage,
                 proportion = it.proportion,
@@ -99,27 +81,13 @@ class SiloQueryModel(
     }
 
     fun computeAminoAcidMutationProportions(sequenceFilters: MutationProportionsRequest): Stream<MutationResponse> {
-        val fields = siloMutationFields(sequenceFilters.fields)
+        val assembleMutation = { data: MutationData ->
+            "${data.sequenceName}:${data.mutationFrom}${data.position}${data.mutationTo}"
+        }
 
-        val data = siloClient.sendQuery(
-            SiloQuery(
-                SiloAction.aminoAcidMutations(
-                    minProportion = sequenceFilters.minProportion,
-                    orderByFields = sequenceFilters.orderByFields,
-                    limit = sequenceFilters.limit,
-                    offset = sequenceFilters.offset,
-                    fields = fields,
-                ),
-                siloFilterExpressionMapper.map(sequenceFilters),
-            ),
-        )
-        return data.map {
+        return queryMutationData(sequenceFilters, SiloAction.Companion::aminoAcidMutations).map {
             MutationResponse(
-                mutation = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION)) {
-                    "${it.sequenceName}:${it.mutationFrom}${it.position}${it.mutationTo}"
-                } else {
-                    null
-                },
+                mutation = sequenceFilters.ifRequested(MutationsField.MUTATION, assembleMutation(it)),
                 count = it.count,
                 coverage = it.coverage,
                 proportion = it.proportion,
@@ -314,15 +282,63 @@ class SiloQueryModel(
 
     fun getLineageDefinition(column: String) = siloClient.getLineageDefinition(column)
 
+    private fun queryMutationData(
+        sequenceFilters: MutationProportionsRequest,
+        actionConstructor: (
+            minProportion: Double?,
+            orderByFields: OrderBySpec,
+            limit: Int?,
+            offset: Int?,
+            fields: List<String>,
+        ) -> SiloAction<MutationData>,
+    ): Stream<MutationData> {
+        val fields = siloMutationFields(sequenceFilters)
+
+        val action = actionConstructor(
+            sequenceFilters.minProportion,
+            expandMutationOrderBy(sequenceFilters.orderByFields),
+            sequenceFilters.limit,
+            sequenceFilters.offset,
+            fields,
+        )
+        return siloClient.sendQuery(SiloQuery(action, siloFilterExpressionMapper.map(sequenceFilters)))
+    }
+
     /**
-     * SILO doesn't know the `mutation` field, instead we need the fields to assemble it.
+     * Since SILO can't order by the assembled `mutation` field, replace any `mutation` order-by entry with its
+     * component fields (in `sequenceName`, `mutationFrom`, `position`, `mutationTo` order), keeping the direction.
      */
-    private fun siloMutationFields(fields: List<MutationsField>): List<String> {
+    private fun expandMutationOrderBy(orderByFields: OrderBySpec): OrderBySpec =
+        when (orderByFields) {
+            is OrderBySpec.ByFields -> OrderBySpec.ByFields(
+                orderByFields.fields.flatMap { field ->
+                    when (field.field) {
+                        MutationsField.MUTATION.value -> listOf(
+                            MutationsField.SEQUENCE_NAME,
+                            MutationsField.MUTATION_FROM,
+                            MutationsField.POSITION,
+                            MutationsField.MUTATION_TO,
+                        ).map { OrderByField(it.value, field.order) }
+
+                        else -> listOf(field)
+                    }
+                },
+            )
+
+            is OrderBySpec.Random -> orderByFields
+        }
+
+    private fun siloMutationFields(request: MutationProportionsRequest): List<String> {
+        val fields = request.fields
         if (fields.isEmpty()) {
             return emptyList()
         }
+
+        val hasOrderByMutation = request.orderByFields is OrderBySpec.ByFields &&
+            request.orderByFields.fields.any { it.field == MutationsField.MUTATION.value }
+
         val expanded = fields.toMutableSet()
-        if (MutationsField.MUTATION in expanded) {
+        if (hasOrderByMutation || MutationsField.MUTATION in expanded) {
             expanded -= MutationsField.MUTATION
             expanded += MutationsField.MUTATION_FROM
             expanded += MutationsField.MUTATION_TO

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -131,7 +131,7 @@ class SiloQueryModel(
         val data = siloClient.sendQuery(
             SiloQuery(
                 SiloAction.nucleotideInsertions(
-                    sequenceFilters.orderByFields,
+                    expandInsertionOrderBy(sequenceFilters.orderByFields),
                     sequenceFilters.limit,
                     sequenceFilters.offset,
                 ),
@@ -158,7 +158,7 @@ class SiloQueryModel(
         val data = siloClient.sendQuery(
             SiloQuery(
                 SiloAction.aminoAcidInsertions(
-                    sequenceFilters.orderByFields,
+                    expandInsertionOrderBy(sequenceFilters.orderByFields),
                     sequenceFilters.limit,
                     sequenceFilters.offset,
                 ),
@@ -319,6 +319,26 @@ class SiloQueryModel(
                             MutationsField.POSITION,
                             MutationsField.MUTATION_TO,
                         ).map { OrderByField(it.value, field.order) }
+
+                        else -> listOf(field)
+                    }
+                },
+            )
+
+            is OrderBySpec.Random -> orderByFields
+        }
+
+    /**
+     * Since SILO can't order by the assembled `insertion` field, replace any `insertion` order-by entry with its
+     * component fields (in `sequenceName`, `position`, `insertedSymbols` order), keeping the direction.
+     */
+    private fun expandInsertionOrderBy(orderByFields: OrderBySpec): OrderBySpec =
+        when (orderByFields) {
+            is OrderBySpec.ByFields -> OrderBySpec.ByFields(
+                orderByFields.fields.flatMap { field ->
+                    when (field.field) {
+                        "insertion" -> listOf("sequenceName", "position", "insertedSymbols")
+                            .map { OrderByField(it, field.order) }
 
                         else -> listOf(field)
                     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -16,7 +16,6 @@ import org.genspectrum.lapis.request.SequencePositionField
 import org.genspectrum.lapis.response.ExplicitlyNullable
 import org.genspectrum.lapis.response.InfoData
 import org.genspectrum.lapis.response.InsertionResponse
-import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.MutationResponse
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
@@ -92,9 +91,9 @@ class SiloQueryModel(
                 } else {
                     ExplicitlyNullable(it.sequenceName)
                 },
-                mutationFrom = mutationFromOrNull(sequenceFilters, it),
-                mutationTo = mutationToOrNull(sequenceFilters, it),
-                position = positionOrNull(sequenceFilters, it),
+                mutationFrom = sequenceFilters.ifRequested(MutationsField.MUTATION_FROM, it.mutationFrom),
+                mutationTo = sequenceFilters.ifRequested(MutationsField.MUTATION_TO, it.mutationTo),
+                position = sequenceFilters.ifRequested(MutationsField.POSITION, it.position),
             )
         }
     }
@@ -129,9 +128,9 @@ class SiloQueryModel(
                 } else {
                     ExplicitlyNullable(it.sequenceName)
                 },
-                mutationFrom = mutationFromOrNull(sequenceFilters, it),
-                mutationTo = mutationToOrNull(sequenceFilters, it),
-                position = positionOrNull(sequenceFilters, it),
+                mutationFrom = sequenceFilters.ifRequested(MutationsField.MUTATION_FROM, it.mutationFrom),
+                mutationTo = sequenceFilters.ifRequested(MutationsField.MUTATION_TO, it.mutationTo),
+                position = sequenceFilters.ifRequested(MutationsField.POSITION, it.position),
             )
         }
     }
@@ -331,33 +330,6 @@ class SiloQueryModel(
             expanded += MutationsField.SEQUENCE_NAME
         }
         return expanded.map { it.value }
-    }
-
-    private fun mutationFromOrNull(
-        sequenceFilters: MutationProportionsRequest,
-        data: MutationData,
-    ) = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION_FROM)) {
-        data.mutationFrom
-    } else {
-        null
-    }
-
-    private fun mutationToOrNull(
-        sequenceFilters: MutationProportionsRequest,
-        data: MutationData,
-    ) = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION_TO)) {
-        data.mutationTo
-    } else {
-        null
-    }
-
-    private fun positionOrNull(
-        sequenceFilters: MutationProportionsRequest,
-        data: MutationData,
-    ) = if (sequenceFilters.shouldResponseContainField(MutationsField.POSITION)) {
-        data.position
-    } else {
-        null
     }
 
     private fun buildInsertion(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -16,6 +16,7 @@ import org.genspectrum.lapis.request.SequencePositionField
 import org.genspectrum.lapis.response.ExplicitlyNullable
 import org.genspectrum.lapis.response.InfoData
 import org.genspectrum.lapis.response.InsertionResponse
+import org.genspectrum.lapis.response.MutationData
 import org.genspectrum.lapis.response.MutationResponse
 import org.genspectrum.lapis.response.PhyloSubtreeData
 import org.genspectrum.lapis.response.SequenceData
@@ -52,14 +53,7 @@ class SiloQueryModel(
         )
 
     fun computeNucleotideMutationProportions(sequenceFilters: MutationProportionsRequest): Stream<MutationResponse> {
-        val fields = sequenceFilters.fields
-            .let {
-                when {
-                    it.contains(MutationsField.MUTATION) -> addSequenceNameIfMissing(it)
-                    else -> it
-                }
-            }
-            .map { it.value }
+        val fields = siloMutationFields(sequenceFilters.fields)
 
         val data = siloClient.sendQuery(
             SiloQuery(
@@ -75,10 +69,15 @@ class SiloQueryModel(
         )
 
         return data.map {
-            val mutation = if (referenceGenomeSchema.isSingleSegmented()) {
-                it.mutation
+            val mutation = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION)) {
+                val core = "${it.mutationFrom}${it.position}${it.mutationTo}"
+                if (referenceGenomeSchema.isSingleSegmented()) {
+                    core
+                } else {
+                    "${it.sequenceName}:$core"
+                }
             } else {
-                "${it.sequenceName}:${it.mutation}"
+                null
             }
 
             MutationResponse(
@@ -86,29 +85,22 @@ class SiloQueryModel(
                 count = it.count,
                 coverage = it.coverage,
                 proportion = it.proportion,
-                sequenceName = if (!sequenceFilters.shouldResponseContainSequenceName()) {
+                sequenceName = if (!sequenceFilters.shouldResponseContainField(MutationsField.SEQUENCE_NAME)) {
                     null
                 } else if (referenceGenomeSchema.isSingleSegmented()) {
                     ExplicitlyNullable(null)
                 } else {
                     ExplicitlyNullable(it.sequenceName)
                 },
-                mutationFrom = it.mutationFrom,
-                mutationTo = it.mutationTo,
-                position = it.position,
+                mutationFrom = mutationFromOrNull(sequenceFilters, it),
+                mutationTo = mutationToOrNull(sequenceFilters, it),
+                position = positionOrNull(sequenceFilters, it),
             )
         }
     }
 
     fun computeAminoAcidMutationProportions(sequenceFilters: MutationProportionsRequest): Stream<MutationResponse> {
-        val fields = sequenceFilters.fields
-            .let {
-                when {
-                    it.contains(MutationsField.MUTATION) -> addSequenceNameIfMissing(it)
-                    else -> it
-                }
-            }
-            .map { it.value }
+        val fields = siloMutationFields(sequenceFilters.fields)
 
         val data = siloClient.sendQuery(
             SiloQuery(
@@ -124,18 +116,22 @@ class SiloQueryModel(
         )
         return data.map {
             MutationResponse(
-                mutation = "${it.sequenceName}:${it.mutation}",
+                mutation = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION)) {
+                    "${it.sequenceName}:${it.mutationFrom}${it.position}${it.mutationTo}"
+                } else {
+                    null
+                },
                 count = it.count,
                 coverage = it.coverage,
                 proportion = it.proportion,
-                sequenceName = if (!sequenceFilters.shouldResponseContainSequenceName()) {
+                sequenceName = if (!sequenceFilters.shouldResponseContainField(MutationsField.SEQUENCE_NAME)) {
                     null
                 } else {
                     ExplicitlyNullable(it.sequenceName)
                 },
-                mutationFrom = it.mutationFrom,
-                mutationTo = it.mutationTo,
-                position = it.position,
+                mutationFrom = mutationFromOrNull(sequenceFilters, it),
+                mutationTo = mutationToOrNull(sequenceFilters, it),
+                position = positionOrNull(sequenceFilters, it),
             )
         }
     }
@@ -177,15 +173,16 @@ class SiloQueryModel(
         )
 
         return data.map {
+            val sequenceName = when (referenceGenomeSchema.isSingleSegmented()) {
+                true -> null
+                false -> it.sequenceName
+            }
             InsertionResponse(
-                insertion = it.insertion,
+                insertion = buildInsertion(sequenceName, it.position, it.insertedSymbols),
                 count = it.count,
                 insertedSymbols = it.insertedSymbols,
                 position = it.position,
-                sequenceName = when (referenceGenomeSchema.isSingleSegmented()) {
-                    true -> null
-                    false -> it.sequenceName
-                },
+                sequenceName = sequenceName,
             )
         }
     }
@@ -204,7 +201,7 @@ class SiloQueryModel(
 
         return data.map {
             InsertionResponse(
-                insertion = it.insertion,
+                insertion = buildInsertion(it.sequenceName, it.position, it.insertedSymbols),
                 count = it.count,
                 insertedSymbols = it.insertedSymbols,
                 position = it.position,
@@ -318,11 +315,59 @@ class SiloQueryModel(
 
     fun getLineageDefinition(column: String) = siloClient.getLineageDefinition(column)
 
-    private fun addSequenceNameIfMissing(fields: List<MutationsField>) =
-        when {
-            !fields.contains(MutationsField.SEQUENCE_NAME) -> fields + MutationsField.SEQUENCE_NAME
-            else -> fields
+    /**
+     * SILO doesn't know the `mutation` field, instead we need the fields to assemble it.
+     */
+    private fun siloMutationFields(fields: List<MutationsField>): List<String> {
+        if (fields.isEmpty()) {
+            return emptyList()
         }
+        val expanded = fields.toMutableSet()
+        if (MutationsField.MUTATION in expanded) {
+            expanded -= MutationsField.MUTATION
+            expanded += MutationsField.MUTATION_FROM
+            expanded += MutationsField.MUTATION_TO
+            expanded += MutationsField.POSITION
+            expanded += MutationsField.SEQUENCE_NAME
+        }
+        return expanded.map { it.value }
+    }
+
+    private fun mutationFromOrNull(
+        sequenceFilters: MutationProportionsRequest,
+        data: MutationData,
+    ) = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION_FROM)) {
+        data.mutationFrom
+    } else {
+        null
+    }
+
+    private fun mutationToOrNull(
+        sequenceFilters: MutationProportionsRequest,
+        data: MutationData,
+    ) = if (sequenceFilters.shouldResponseContainField(MutationsField.MUTATION_TO)) {
+        data.mutationTo
+    } else {
+        null
+    }
+
+    private fun positionOrNull(
+        sequenceFilters: MutationProportionsRequest,
+        data: MutationData,
+    ) = if (sequenceFilters.shouldResponseContainField(MutationsField.POSITION)) {
+        data.position
+    } else {
+        null
+    }
+
+    private fun buildInsertion(
+        sequenceName: String?,
+        position: Int,
+        insertedSymbols: String,
+    ) = when (sequenceName) {
+        null -> "ins_$position:$insertedSymbols"
+        else -> "ins_$sequenceName:$position:$insertedSymbols"
+    }
 }
 
 data class SequencesResponse(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/SiloQueryModel.kt
@@ -28,7 +28,9 @@ import org.genspectrum.lapis.silo.SiloQuery
 import org.genspectrum.lapis.util.toUnalignedSequenceName
 import org.springframework.stereotype.Component
 import java.util.stream.Stream
-import kotlin.collections.emptyList
+
+private const val INSERTION_FIELD = "insertion"
+private val INSERTION_COMPONENT_FIELDS = listOf("sequenceName", "position", "insertedSymbols")
 
 @Component
 class SiloQueryModel(
@@ -337,8 +339,7 @@ class SiloQueryModel(
             is OrderBySpec.ByFields -> OrderBySpec.ByFields(
                 orderByFields.fields.flatMap { field ->
                     when (field.field) {
-                        "insertion" -> listOf("sequenceName", "position", "insertedSymbols")
-                            .map { OrderByField(it, field.order) }
+                        INSERTION_FIELD -> INSERTION_COMPONENT_FIELDS.map { OrderByField(it, field.order) }
 
                         else -> listOf(field)
                     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -61,11 +61,11 @@ class VariantQueryCustomListener(
 
         val expression = when (val secondSymbol = ctx.nucleotideMutationQuerySecondSymbol()) {
             null -> HasNucleotideMutation(
-                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                sequenceName = referenceGenomeSchema.firstNucleotideSequenceName(),
                 position = position,
             )
             else -> NucleotideSymbolEquals(
-                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                sequenceName = referenceGenomeSchema.firstNucleotideSequenceName(),
                 position = position,
                 symbol = secondSymbol.text.uppercase(),
             )
@@ -135,7 +135,7 @@ class VariantQueryCustomListener(
             NucleotideInsertionContains(
                 ctx.position().text.toInt(),
                 value,
-                referenceGenomeSchema.resolveNucleotideSequenceName(),
+                referenceGenomeSchema.firstNucleotideSequenceName(),
             ),
         )
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/VariantQueryCustomListener.kt
@@ -60,8 +60,15 @@ class VariantQueryCustomListener(
         val position = ctx.position().text.toInt()
 
         val expression = when (val secondSymbol = ctx.nucleotideMutationQuerySecondSymbol()) {
-            null -> HasNucleotideMutation(null, position)
-            else -> NucleotideSymbolEquals(null, position, secondSymbol.text.uppercase())
+            null -> HasNucleotideMutation(
+                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                position = position,
+            )
+            else -> NucleotideSymbolEquals(
+                sequenceName = referenceGenomeSchema.resolveNucleotideSequenceName(),
+                position = position,
+                symbol = secondSymbol.text.uppercase(),
+            )
         }
 
         expressionStack.addLast(expression)
@@ -128,7 +135,7 @@ class VariantQueryCustomListener(
             NucleotideInsertionContains(
                 ctx.position().text.toInt(),
                 value,
-                null,
+                referenceGenomeSchema.resolveNucleotideSequenceName(),
             ),
         )
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.annotation.PreDestroy
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenome
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.model.AdvancedQueryFacade
 import org.genspectrum.lapis.model.SiloFilterExpressionMapper
@@ -126,6 +127,7 @@ class QueriesOverTimeModel(
     private val siloClient: SiloClient,
     private val siloFilterExpressionMapper: SiloFilterExpressionMapper,
     private val referenceGenome: ReferenceGenome,
+    private val referenceGenomeSchema: ReferenceGenomeSchema,
     private val dataVersion: DataVersion,
     private val advancedQueryFacade: AdvancedQueryFacade,
     config: DatabaseConfig,
@@ -221,17 +223,20 @@ class QueriesOverTimeModel(
             ParsedQueryItem(
                 displayLabel = mutation.toString(referenceGenome),
                 countQuery = when (mutation.symbol) {
-                    null -> HasNucleotideMutation(mutation.sequenceName, mutation.position)
+                    null -> HasNucleotideMutation(
+                        sequenceName = mutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
+                        position = mutation.position
+                    )
                     else -> NucleotideSymbolEquals(
-                        mutation.sequenceName,
-                        mutation.position,
-                        mutation.symbol,
+                        sequenceName = mutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
+                        position = mutation.position,
+                        symbol = mutation.symbol,
                     )
                 },
                 coverageQuery = Or(
                     (nucleotideSymbols + deletionSymbols).map {
                         NucleotideSymbolEquals(
-                            sequenceName = mutation.sequenceName,
+                            sequenceName = mutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
                             position = mutation.position,
                             symbol = it.toString(),
                         )

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -225,7 +225,7 @@ class QueriesOverTimeModel(
                 countQuery = when (mutation.symbol) {
                     null -> HasNucleotideMutation(
                         sequenceName = mutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),
-                        position = mutation.position
+                        position = mutation.position,
                     )
                     else -> NucleotideSymbolEquals(
                         sequenceName = mutation.sequenceName ?: referenceGenomeSchema.firstNucleotideSequenceName(),

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
@@ -1,6 +1,7 @@
 package org.genspectrum.lapis.request
 
 import org.genspectrum.lapis.controller.BadRequestException
+import org.genspectrum.lapis.response.MutationData
 import org.springframework.boot.jackson.JacksonComponent
 import tools.jackson.core.JsonParser
 import tools.jackson.databind.DeserializationContext
@@ -23,7 +24,7 @@ data class MutationProportionsRequest(
     override val limit: Int? = null,
     override val offset: Int? = null,
 ) : CommonSequenceFilters {
-    fun shouldResponseContainSequenceName() = fields.isEmpty() || fields.contains(MutationsField.SEQUENCE_NAME)
+    fun shouldResponseContainField(field: MutationsField) = fields.isEmpty() || fields.contains(field)
 }
 
 enum class MutationsField(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/MutationProportionsRequest.kt
@@ -1,7 +1,6 @@
 package org.genspectrum.lapis.request
 
 import org.genspectrum.lapis.controller.BadRequestException
-import org.genspectrum.lapis.response.MutationData
 import org.springframework.boot.jackson.JacksonComponent
 import tools.jackson.core.JsonParser
 import tools.jackson.databind.DeserializationContext
@@ -25,6 +24,12 @@ data class MutationProportionsRequest(
     override val offset: Int? = null,
 ) : CommonSequenceFilters {
     fun shouldResponseContainField(field: MutationsField) = fields.isEmpty() || fields.contains(field)
+
+    /** Returns [value] only if [field] was requested (or all fields were requested), otherwise `null`. */
+    fun <T> ifRequested(
+        field: MutationsField,
+        value: T,
+    ): T? = if (shouldResponseContainField(field)) value else null
 }
 
 enum class MutationsField(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideInsertion.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideInsertion.kt
@@ -47,6 +47,13 @@ data class NucleotideInsertion(
                 }
                 ?.name
 
+            if (segmentName == null && !referenceGenomeSchema.isSingleSegmented()) {
+                throw BadRequestException(
+                    "The reference genome is multi-segmented, but no segment was specified in the nucleotide " +
+                        "insertion '$nucleotideInsertion'. Please specify one, e.g. 'ins_segmentName:123:ABC'.",
+                )
+            }
+
             return NucleotideInsertion(
                 position,
                 insertions,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideMutation.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/request/NucleotideMutation.kt
@@ -43,6 +43,13 @@ data class NucleotideMutation(
                 }
                 ?.name
 
+            if (segmentName == null && !referenceGenomeSchema.isSingleSegmented()) {
+                throw BadRequestException(
+                    "The reference genome is multi-segmented, but no segment was specified in the nucleotide " +
+                        "mutation '$nucleotideMutation'. Please specify one, e.g. 'segmentName:A123T'.",
+                )
+            }
+
             return NucleotideMutation(
                 segmentName,
                 position,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/LapisResponse.kt
@@ -78,7 +78,7 @@ data class QueriesOverTimeResponse<T>(
 )
 
 /**
- * In Javascript terms, this is equivalent to using `null` instead of `undefined`.
+ * In JavaScript terms, this is equivalent to using `null` instead of `undefined`.
  * ExplicitlyNullable is used to serialize null values in JSON when the surrounding class ignores null values,
  * i.e. treats `null` as `undefined`.
  * In some cases, you still want to be able to explicitly set `null` on a field.

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/response/SiloResponse.kt
@@ -33,7 +33,6 @@ class AggregationDataSerializer : ValueSerializer<AggregationData>() {
 }
 
 data class MutationData(
-    val mutation: String?,
     val count: Int?,
     val proportion: Double?,
     val sequenceName: String?,
@@ -45,7 +44,6 @@ data class MutationData(
 
 data class InsertionData(
     val count: Int,
-    val insertion: String,
     val insertedSymbols: String,
     val position: Int,
     val sequenceName: String,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/ArrowRowConverter.kt
@@ -65,7 +65,6 @@ val MOST_COMMON_ANCESTOR_DATA_ARROW_CONVERTER: ArrowRowConverter<MostCommonAnces
 
 val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, rowIndex ->
     MutationData(
-        mutation = root.getOptionalString("mutation", rowIndex),
         count = root.getOptionalInt("count", rowIndex),
         proportion = root.getOptionalDouble("proportion", rowIndex),
         sequenceName = root.getOptionalString("sequenceName", rowIndex),
@@ -79,7 +78,6 @@ val MUTATION_DATA_ARROW_CONVERTER: ArrowRowConverter<MutationData> = { root, row
 val INSERTION_DATA_ARROW_CONVERTER: ArrowRowConverter<InsertionData> = { root, rowIndex ->
     InsertionData(
         count = root.getInt("count", rowIndex),
-        insertion = root.getString("insertion", rowIndex),
         insertedSymbols = root.getString("insertedSymbols", rowIndex),
         position = root.getInt("position", rowIndex),
         sequenceName = root.getString("sequenceName", rowIndex),

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -495,37 +495,33 @@ data class LineageEquals(
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class NucleotideSymbolEquals(
-    val sequenceName: String?,
+    val sequenceName: String,
     val position: Int,
     val symbol: String,
 ) : SiloFilterExpression("NucleotideEquals") {
     override fun toSaneQl() =
         SaneQlFunctionCall(
             "nucleotideEquals",
-            namedArgs = buildList {
-                add(SaneQlNamedArg("position", SaneQlInt(position)))
-                add(SaneQlNamedArg("symbol", str(symbol)))
-                if (sequenceName != null) {
-                    add(SaneQlNamedArg("sequenceName", str(sequenceName)))
-                }
-            },
+            namedArgs = listOf(
+                SaneQlNamedArg("position", SaneQlInt(position)),
+                SaneQlNamedArg("symbol", str(symbol)),
+                SaneQlNamedArg("sequenceName", str(sequenceName)),
+            ),
         )
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class HasNucleotideMutation(
-    val sequenceName: String?,
+    val sequenceName: String,
     val position: Int,
 ) : SiloFilterExpression("HasNucleotideMutation") {
     override fun toSaneQl() =
         SaneQlFunctionCall(
             "hasMutation",
-            namedArgs = buildList {
-                add(SaneQlNamedArg("position", SaneQlInt(position)))
-                if (sequenceName != null) {
-                    add(SaneQlNamedArg("sequenceName", str(sequenceName)))
-                }
-            },
+            namedArgs = listOf(
+                SaneQlNamedArg("position", SaneQlInt(position)),
+                SaneQlNamedArg("sequenceName", str(sequenceName)),
+            ),
         )
 }
 
@@ -576,18 +572,16 @@ data class DateBetween(
 data class NucleotideInsertionContains(
     val position: Int,
     val value: String,
-    val sequenceName: String?,
+    val sequenceName: String,
 ) : SiloFilterExpression("InsertionContains") {
     override fun toSaneQl() =
         SaneQlFunctionCall(
             "insertionContains",
-            namedArgs = buildList {
-                add(SaneQlNamedArg("position", SaneQlInt(position)))
-                add(SaneQlNamedArg("value", str(value)))
-                if (sequenceName != null) {
-                    add(SaneQlNamedArg("sequenceName", str(sequenceName)))
-                }
-            },
+            namedArgs = listOf(
+                SaneQlNamedArg("position", SaneQlInt(position)),
+                SaneQlNamedArg("value", str(value)),
+                SaneQlNamedArg("sequenceName", str(sequenceName)),
+            ),
         )
 }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
@@ -32,6 +32,7 @@ fun mutationProportionsRequest(
     sequenceFilters: Map<String, String> = emptyMap(),
     minProportion: Double? = null,
     fields: List<MutationsField> = emptyList(),
+    orderByFields: OrderBySpec = OrderBySpec.EMPTY,
 ) = MutationProportionsRequest(
     sequenceFilters = sequenceFilters.mapValues { listOf(it.value) },
     nucleotideMutations = emptyList(),
@@ -40,7 +41,7 @@ fun mutationProportionsRequest(
     aminoAcidInsertions = emptyList(),
     fields = fields,
     minProportion = minProportion,
-    orderByFields = OrderBySpec.EMPTY,
+    orderByFields = orderByFields,
 )
 
 fun aggregatedFiltersRequest(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/Helpers.kt
@@ -141,17 +141,17 @@ fun sequenceFiltersRequestWithGenes(
 )
 
 fun mutationData(
-    mutation: String? = null,
     sequenceName: String? = null,
     position: Int? = null,
+    mutationFrom: String? = null,
+    mutationTo: String? = null,
 ) = MutationData(
-    mutation = mutation,
     count = null,
     coverage = null,
     proportion = null,
     sequenceName = sequenceName,
-    mutationFrom = null,
-    mutationTo = null,
+    mutationFrom = mutationFrom,
+    mutationTo = mutationTo,
     position = position,
 )
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/LapisControllerCommonFieldsTest.kt
@@ -487,7 +487,10 @@ class LapisControllerCommonFieldsTest(
                     emptyMap(),
                     emptyList(),
                     emptyList(),
-                    listOf(NucleotideInsertion(123, "ABC", null), NucleotideInsertion(124, "DEF", "other_segment")),
+                    listOf(
+                        NucleotideInsertion(123, "ABC", "other_segment"),
+                        NucleotideInsertion(124, "DEF", "other_segment"),
+                    ),
                     emptyList(),
                     emptyList(),
                     OrderBySpec.EMPTY,
@@ -535,7 +538,10 @@ class LapisControllerCommonFieldsTest(
             siloQueryModelMock.getAggregated(
                 AggregatedFiltersRequest(
                     emptyMap(),
-                    listOf(NucleotideMutation(null, 123, "A"), NucleotideMutation(null, 124, "B")),
+                    listOf(
+                        NucleotideMutation("other_segment", 123, "A"),
+                        NucleotideMutation("other_segment", 124, "B"),
+                    ),
                     emptyList(),
                     emptyList(),
                     emptyList(),
@@ -545,7 +551,9 @@ class LapisControllerCommonFieldsTest(
             )
         } returns Stream.of(AggregationData(5, emptyMap()))
 
-        mockMvc.perform(getSample("$AGGREGATED_ROUTE?nucleotideMutations=123A,124B"))
+        mockMvc.perform(
+            getSample("$AGGREGATED_ROUTE?nucleotideMutations=other_segment:123A,other_segment:124B"),
+        )
             .andExpect(status().isOk)
             .andExpect(jsonPath("\$.data[0].count").value(5))
     }
@@ -754,7 +762,7 @@ class LapisControllerCommonFieldsTest(
             Arguments.of(
                 "GET",
                 getSample(AGGREGATED_ROUTE)
-                    .queryParam("nucleotideInsertions", "ins_123:ABC", "ins_other_segment:124:DEF"),
+                    .queryParam("nucleotideInsertions", "ins_other_segment:123:ABC", "ins_other_segment:124:DEF"),
             ),
             Arguments.of(
                 "POST JSON",
@@ -763,7 +771,7 @@ class LapisControllerCommonFieldsTest(
                         """
                         {
                             "nucleotideInsertions": [
-                                "ins_123:ABC",
+                                "ins_other_segment:123:ABC",
                                 "ins_other_segment:124:DEF"
                             ]
                         }
@@ -774,7 +782,7 @@ class LapisControllerCommonFieldsTest(
             Arguments.of(
                 "POST form encoded",
                 postSample(AGGREGATED_ROUTE)
-                    .param("nucleotideInsertions", "ins_123:ABC", "ins_other_segment:124:DEF")
+                    .param("nucleotideInsertions", "ins_other_segment:123:ABC", "ins_other_segment:124:DEF")
                     .contentType(APPLICATION_FORM_URLENCODED),
             ),
         )

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/MultiSegmentedSequenceControllerTest.kt
@@ -73,6 +73,28 @@ class MultiSegmentedSequenceControllerTest(
     }
 
     @Test
+    fun `GIVEN multi segmented AND nucleotide mutation filter without segment THEN returns bad request`() {
+        mockMvc.perform(
+            postSample("aggregated")
+                .contentType(APPLICATION_JSON)
+                .content("""{"nucleotideMutations": ["A123T"]}"""),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("\$.error.detail", startsWith("The reference genome is multi-segmented")))
+    }
+
+    @Test
+    fun `GIVEN multi segmented AND nucleotide insertion filter without segment THEN returns bad request`() {
+        mockMvc.perform(
+            postSample("aggregated")
+                .contentType(APPLICATION_JSON)
+                .content("""{"nucleotideInsertions": ["ins_123:ABC"]}"""),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("\$.error.detail", startsWith("The reference genome is multi-segmented")))
+    }
+
+    @Test
     fun `GIVEN nucleotide sequences request with dataFormat csv THEN returns not acceptable`() {
         mockMvc
             .perform(

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueriesOverTimeControllerTest.kt
@@ -269,7 +269,7 @@ class NucleotideMutationsOverTimeControllerTest(
                         "filters": {
                             "country":"Switzerland"
                         },
-                        "includeMutations": ["123T", "456G"],
+                        "includeMutations": ["main:123T", "main:456G"],
                         "dateRanges": [{"dateFrom": "2025-01-01", "dateTo": "2025-01-31"}],
                         "dateField": "date"
                     }
@@ -293,10 +293,10 @@ class NucleotideMutationsOverTimeControllerTest(
         verify(exactly = 1) { modelMock.evaluateNucleotideMutations(any(), any(), any(), any()) }
         assertThat(dateFieldSlot.captured, `is`("date"))
         assertThat(mutationsSlot.captured, hasSize(2))
-        assertThat(mutationsSlot.captured[0].sequenceName, `is`(nullValue()))
+        assertThat(mutationsSlot.captured[0].sequenceName, `is`("main"))
         assertThat(mutationsSlot.captured[0].position, `is`(123))
         assertThat(mutationsSlot.captured[0].symbol, `is`("T"))
-        assertThat(mutationsSlot.captured[1].sequenceName, `is`(nullValue()))
+        assertThat(mutationsSlot.captured[1].sequenceName, `is`("main"))
         assertThat(mutationsSlot.captured[1].position, `is`(456))
         assertThat(mutationsSlot.captured[1].symbol, `is`("G"))
         assertThat(dateRangesSlot.captured, hasSize(1))
@@ -321,7 +321,7 @@ class NucleotideMutationsOverTimeControllerTest(
                         "filters": {
                             "country":"Switzerland"
                         },
-                        "includeMutations": ["123T"],
+                        "includeMutations": ["main:123T"],
                         "dateRanges": [{"dateFrom": "2025-01-01", "dateTo": "2025-01-31"}],
                         "dateField": "date",
                         "compression": "zstd",

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/AdvancedQueryFacadeTest.kt
@@ -70,23 +70,23 @@ class AdvancedQueryFacadeTest {
                 3,
                 matchExactly = false,
                 listOf(
-                    NucleotideSymbolEquals(null, 123, "A"),
-                    NucleotideSymbolEquals(null, 234, "T"),
-                    NucleotideSymbolEquals(null, 345, "G"),
+                    NucleotideSymbolEquals("main", 123, "A"),
+                    NucleotideSymbolEquals("main", 234, "T"),
+                    NucleotideSymbolEquals("main", 345, "G"),
                 ),
             ),
             Maybe(
                 Or(
-                    NucleotideSymbolEquals(null, 800, "-"),
-                    NucleotideSymbolEquals(null, 700, "B"),
+                    NucleotideSymbolEquals("main", 800, "-"),
+                    NucleotideSymbolEquals("main", 700, "B"),
                 ),
             ),
-            Not(HasNucleotideMutation(null, 600)),
+            Not(HasNucleotideMutation("main", 600)),
             Or(
-                NucleotideSymbolEquals(null, 500, "B"),
-                NucleotideSymbolEquals(null, 400, "-"),
+                NucleotideSymbolEquals("main", 500, "B"),
+                NucleotideSymbolEquals("main", 400, "-"),
             ),
-            NucleotideSymbolEquals(null, 300, "G"),
+            NucleotideSymbolEquals("main", 300, "G"),
         )
 
         assertThat(result, equalTo(expectedResult))
@@ -109,15 +109,15 @@ class AdvancedQueryFacadeTest {
                         3,
                         matchExactly = false,
                         listOf(
-                            NucleotideSymbolEquals(null, 123, "A"),
-                            NucleotideSymbolEquals(null, 234, "T"),
-                            NucleotideSymbolEquals(null, 345, "G"),
+                            NucleotideSymbolEquals("main", 123, "A"),
+                            NucleotideSymbolEquals("main", 234, "T"),
+                            NucleotideSymbolEquals("main", 345, "G"),
                         ),
                     ),
-                    Not(HasNucleotideMutation(null, 600)),
+                    Not(HasNucleotideMutation("main", 600)),
                     Or(
-                        NucleotideSymbolEquals(null, 800, "-"),
-                        NucleotideSymbolEquals(null, 700, "B"),
+                        NucleotideSymbolEquals("main", 800, "-"),
+                        NucleotideSymbolEquals("main", 700, "B"),
                     ),
                 ),
             ),
@@ -133,8 +133,8 @@ class AdvancedQueryFacadeTest {
         val result = underTest.map(advancedQuery)
 
         val expectedResult = Or(
-            NucleotideSymbolEquals(null, 400, "-"),
-            NucleotideSymbolEquals(null, 300, "G"),
+            NucleotideSymbolEquals("main", 400, "-"),
+            NucleotideSymbolEquals("main", 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
 
@@ -153,10 +153,10 @@ class AdvancedQueryFacadeTest {
 
         val expectedResult = And(
             Or(
-                NucleotideSymbolEquals(null, 500, "G"),
-                NucleotideSymbolEquals(null, 400, "A"),
+                NucleotideSymbolEquals("main", 500, "G"),
+                NucleotideSymbolEquals("main", 400, "A"),
             ),
-            NucleotideSymbolEquals(null, 300, "C"),
+            NucleotideSymbolEquals("main", 300, "C"),
         )
         assertThat(result, equalTo(expectedResult))
 
@@ -177,10 +177,10 @@ class AdvancedQueryFacadeTest {
             3,
             false,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                NucleotideSymbolEquals(null, 234, "T"),
-                NucleotideSymbolEquals(null, 345, "G"),
-                NucleotideSymbolEquals(null, 456, "A"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                NucleotideSymbolEquals("main", 234, "T"),
+                NucleotideSymbolEquals("main", 345, "G"),
+                NucleotideSymbolEquals("main", 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -196,10 +196,10 @@ class AdvancedQueryFacadeTest {
             3,
             true,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                NucleotideSymbolEquals(null, 234, "T"),
-                NucleotideSymbolEquals(null, 345, "G"),
-                NucleotideSymbolEquals(null, 456, "A"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                NucleotideSymbolEquals("main", 234, "T"),
+                NucleotideSymbolEquals("main", 345, "G"),
+                NucleotideSymbolEquals("main", 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -216,10 +216,10 @@ class AdvancedQueryFacadeTest {
             3,
             true,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                Not(NucleotideSymbolEquals(null, 234, "G")),
-                NucleotideSymbolEquals(null, 345, "G"),
-                NucleotideSymbolEquals(null, 456, "A"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                Not(NucleotideSymbolEquals("main", 234, "G")),
+                NucleotideSymbolEquals("main", 345, "G"),
+                NucleotideSymbolEquals("main", 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -236,9 +236,9 @@ class AdvancedQueryFacadeTest {
             3,
             true,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                NucleotideSymbolEquals(null, 234, "T"),
-                NucleotideSymbolEquals(null, 345, "G"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                NucleotideSymbolEquals("main", 234, "T"),
+                NucleotideSymbolEquals("main", 345, "G"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -443,17 +443,17 @@ class AdvancedQueryFacadeTest {
                 ValidTestCase(
                     description = "maybe with a single entry",
                     query = "MAYBE(300G)",
-                    expected = Maybe(NucleotideSymbolEquals(null, 300, "G")),
+                    expected = Maybe(NucleotideSymbolEquals("main", 300, "G")),
                 ),
                 ValidTestCase(
                     description = "mixed case maybe",
                     query = "maYbE(T12C)",
-                    expected = Maybe(NucleotideSymbolEquals(null, 12, "C")),
+                    expected = Maybe(NucleotideSymbolEquals("main", 12, "C")),
                 ),
                 ValidTestCase(
                     description = "lower case maybe",
                     query = "maybe(T12C)",
-                    expected = Maybe(NucleotideSymbolEquals(null, 12, "C")),
+                    expected = Maybe(NucleotideSymbolEquals("main", 12, "C")),
                 ),
             ),
             invalid = listOf(
@@ -470,22 +470,22 @@ class AdvancedQueryFacadeTest {
                 ValidTestCase(
                     description = "textual not",
                     query = "NOT 300G",
-                    expected = Not(NucleotideSymbolEquals(null, 300, "G")),
+                    expected = Not(NucleotideSymbolEquals("main", 300, "G")),
                 ),
                 ValidTestCase(
                     description = "lower case textual not",
                     query = "not 300G",
-                    expected = Not(NucleotideSymbolEquals(null, 300, "G")),
+                    expected = Not(NucleotideSymbolEquals("main", 300, "G")),
                 ),
                 ValidTestCase(
                     description = "mixed case textual not",
                     query = "nOt 300G",
-                    expected = Not(NucleotideSymbolEquals(null, 300, "G")),
+                    expected = Not(NucleotideSymbolEquals("main", 300, "G")),
                 ),
                 ValidTestCase(
                     description = "not symbol",
                     query = "!300G",
-                    expected = Not(NucleotideSymbolEquals(null, 300, "G")),
+                    expected = Not(NucleotideSymbolEquals("main", 300, "G")),
                 ),
                 ValidTestCase(
                     description = "not on metadata",
@@ -502,50 +502,50 @@ class AdvancedQueryFacadeTest {
                     description = "symbol and",
                     query = "300G & 400-",
                     expected = And(
-                        NucleotideSymbolEquals(null, 400, "-"),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 400, "-"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                     ),
                 ),
                 ValidTestCase(
                     description = "textual and",
                     query = "300G AND 400-",
                     expected = And(
-                        NucleotideSymbolEquals(null, 400, "-"),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 400, "-"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                     ),
                 ),
                 ValidTestCase(
                     description = "textual and in mixed case",
                     query = "300G aNd 400-",
                     expected = And(
-                        NucleotideSymbolEquals(null, 400, "-"),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 400, "-"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                     ),
                 ),
                 ValidTestCase(
                     description = "textual and in lower case",
                     query = "300G and 400-",
                     expected = And(
-                        NucleotideSymbolEquals(null, 400, "-"),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 400, "-"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                     ),
                 ),
                 ValidTestCase(
                     description = "two symbol ands",
                     query = "300G & 400- & 500B",
                     expected = And(
-                        NucleotideSymbolEquals(null, 500, "B"),
-                        NucleotideSymbolEquals(null, 400, "-"),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 500, "B"),
+                        NucleotideSymbolEquals("main", 400, "-"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                     ),
                 ),
                 ValidTestCase(
                     description = "two ands with symbol and textual",
                     query = "300G & 400- and 500B",
                     expected = And(
-                        NucleotideSymbolEquals(null, 500, "B"),
-                        NucleotideSymbolEquals(null, 400, "-"),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 500, "B"),
+                        NucleotideSymbolEquals("main", 400, "-"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                     ),
                 ),
                 ValidTestCase(
@@ -560,7 +560,7 @@ class AdvancedQueryFacadeTest {
                     description = "and on metadata and mutation",
                     query = "some_metadata = value1 AND 300G",
                     expected = And(
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                         StringEquals("some_metadata", "value1"),
                     ),
                 ),
@@ -572,7 +572,7 @@ class AdvancedQueryFacadeTest {
                             Not(AminoAcidSymbolEquals("S", 501, "Y")),
                             StringSearch("some_metadata", "BANGAL"),
                         ),
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                         StringEquals("some_metadata", "Turks and Caicos"),
                     ),
                 ),
@@ -580,7 +580,7 @@ class AdvancedQueryFacadeTest {
                     description = "and on metadata where metadata value is also 'and'",
                     query = "(NOT Some_metadata=and) & 300G",
                     expected = And(
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("main", 300, "G"),
                         Not(StringEquals("some_metadata", "and")),
                     ),
                 ),
@@ -823,28 +823,28 @@ class AdvancedQueryFacadeTest {
                     ValidTestCase(
                         description = "nucleotide mutation with symbol '$base'",
                         query = "${base}300$base",
-                        expected = NucleotideSymbolEquals(null, 300, "$base"),
+                        expected = NucleotideSymbolEquals("main", 300, "$base"),
                     )
                 }.toTypedArray(),
                 ValidTestCase(
                     description = "nucleotide mutation with symbol '-'",
                     query = "A300-",
-                    expected = NucleotideSymbolEquals(null, 300, "-"),
+                    expected = NucleotideSymbolEquals("main", 300, "-"),
                 ),
                 ValidTestCase(
                     description = "nucleotide mutation with symbol '.'",
                     query = "A300.",
-                    expected = NucleotideSymbolEquals(null, 300, "."),
+                    expected = NucleotideSymbolEquals("main", 300, "."),
                 ),
                 ValidTestCase(
                     description = "nucleotide mutation without 'from'",
                     query = "A300G",
-                    expected = NucleotideSymbolEquals(null, 300, "G"),
+                    expected = NucleotideSymbolEquals("main", 300, "G"),
                 ),
                 ValidTestCase(
                     description = "nucleotide mutation with position only",
                     query = "400",
-                    expected = HasNucleotideMutation(null, 400),
+                    expected = HasNucleotideMutation("main", 400),
                 ),
                 *(aaSymbols + ambiguousAaSymbols).map { base ->
                     ValidTestCase(
@@ -924,7 +924,7 @@ class AdvancedQueryFacadeTest {
                 ValidTestCase(
                     description = "nucleotide insertion with all allowed symbols",
                     query = "ins_1234:$allAllowedNucleotideSymbols",
-                    expected = NucleotideInsertionContains(1234, allAllowedNucleotideSymbols, null),
+                    expected = NucleotideInsertionContains(1234, allAllowedNucleotideSymbols, "main"),
                 ),
                 ValidTestCase(
                     description = "amino acid insertion with all allowed symbols",
@@ -934,17 +934,17 @@ class AdvancedQueryFacadeTest {
                 ValidTestCase(
                     description = "nucleotide insertion with lower case symbols",
                     query = "ins_1234:gAG",
-                    expected = NucleotideInsertionContains(1234, "GAG", null),
+                    expected = NucleotideInsertionContains(1234, "GAG", "main"),
                 ),
                 ValidTestCase(
                     description = "insertion with mixed case ins_ prefix",
                     query = "iNs_1234:gAG",
-                    expected = NucleotideInsertionContains(1234, "GAG", null),
+                    expected = NucleotideInsertionContains(1234, "GAG", "main"),
                 ),
                 ValidTestCase(
                     description = "insertion with wildcard symbols",
                     query = "ins_1234:G?A?G",
-                    expected = NucleotideInsertionContains(1234, "G.*A.*G", null),
+                    expected = NucleotideInsertionContains(1234, "G.*A.*G", "main"),
                 ),
                 ValidTestCase(
                     description = "amino acid insertion with stop codon",

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloFilterExpressionMapperTest.kt
@@ -56,7 +56,12 @@ class SiloFilterExpressionMapperTest {
     private val advancedQueryFacade = AdvancedQueryFacade(dummyReferenceGenomeSchema, dummyDatabaseConfig)
 
     private val underTest =
-        SiloFilterExpressionMapper(dummySequenceFilterFields, variantQueryFacade, advancedQueryFacade)
+        SiloFilterExpressionMapper(
+            dummySequenceFilterFields,
+            variantQueryFacade,
+            advancedQueryFacade,
+            dummyReferenceGenomeSchema,
+        )
 
     @ParameterizedTest(name = "GIVEN {0} THEN throws exception")
     @MethodSource("getInvalidFilterScenarios")
@@ -124,7 +129,7 @@ class SiloFilterExpressionMapperTest {
         val result = underTest.map(filterParameter)
 
         val expected = And(
-            Maybe(NucleotideSymbolEquals(null, 123, "B")),
+            Maybe(NucleotideSymbolEquals("sequenceName", 123, "B")),
             NucleotideSymbolEquals("sequenceName", 999, "A"),
         )
         assertThat(result, equalTo(expected))
@@ -143,7 +148,7 @@ class SiloFilterExpressionMapperTest {
         val result = underTest.map(filterParameter)
 
         val expected = And(
-            HasNucleotideMutation(null, 123),
+            HasNucleotideMutation("sequenceName", 123),
             HasNucleotideMutation("sequenceName", 999),
         )
         assertThat(result, equalTo(expected))
@@ -191,7 +196,7 @@ class SiloFilterExpressionMapperTest {
     }
 
     @Test
-    fun `given nucleotide insertion it is mapped to NucleotideInsertionContains without using the segment`() {
+    fun `given nucleotide insertion without segment THEN defaults to the single segment name`() {
         val filterParameter = DummySequenceFilters(
             emptyMap(),
             emptyList(),
@@ -203,7 +208,10 @@ class SiloFilterExpressionMapperTest {
         val result = underTest.map(filterParameter)
 
         val expected =
-            And(NucleotideInsertionContains(123, "ABCD", "segment"), NucleotideInsertionContains(999, "DEF", null))
+            And(
+                NucleotideInsertionContains(123, "ABCD", "segment"),
+                NucleotideInsertionContains(999, "DEF", "sequenceName"),
+            )
         assertThat(result, equalTo(expected))
     }
 
@@ -836,8 +844,8 @@ class SiloFilterExpressionMapperTest {
                     ),
                     And(
                         And(
-                            NucleotideSymbolEquals(null, 400, "A"),
-                            NucleotideSymbolEquals(null, 300, "G"),
+                            NucleotideSymbolEquals("sequenceName", 400, "A"),
+                            NucleotideSymbolEquals("sequenceName", 300, "G"),
                         ),
                     ),
                 ),
@@ -847,7 +855,7 @@ class SiloFilterExpressionMapperTest {
                         "some_metadata" to listOf("ABC"),
                     ),
                     And(
-                        NucleotideSymbolEquals(null, 300, "G"),
+                        NucleotideSymbolEquals("sequenceName", 300, "G"),
                         Or(StringEquals("some_metadata", "ABC")),
                     ),
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.Test
 import java.util.stream.Stream
 
 private val someMutationData = MutationData(
-    mutation = "A1234B",
     count = 1234,
     coverage = 2345,
     proportion = 0.1234,
@@ -55,7 +54,6 @@ private val someMutationData = MutationData(
 
 val someInsertionData = InsertionData(
     count = 42,
-    insertion = "ins_sequenceName:1234:ABCD",
     insertedSymbols = "ABCD",
     position = 1234,
     sequenceName = "sequenceName",
@@ -288,8 +286,10 @@ class SiloQueryModelTest {
             )
         } returns Stream.of(
             mutationData(
-                mutation = "A1234B",
                 sequenceName = "sequenceName",
+                position = 1234,
+                mutationFrom = "A",
+                mutationTo = "B",
             ),
         )
         every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
@@ -369,8 +369,10 @@ class SiloQueryModelTest {
             )
         } returns Stream.of(
             mutationData(
-                mutation = "A1234B",
                 sequenceName = "sequenceName",
+                position = 1234,
+                mutationFrom = "A",
+                mutationTo = "B",
             ),
         )
         every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
@@ -410,7 +412,7 @@ class SiloQueryModelTest {
         ).toList()
 
         val expectedInsertion = InsertionResponse(
-            insertion = "ins_sequenceName:1234:ABCD",
+            insertion = "ins_1234:ABCD",
             count = 42,
             insertedSymbols = "ABCD",
             position = 1234,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/SiloQueryModelTest.kt
@@ -3,6 +3,7 @@ package org.genspectrum.lapis.model
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.slot
 import io.mockk.verify
 import org.genspectrum.lapis.config.DatabaseMetadata
 import org.genspectrum.lapis.config.MetadataType
@@ -419,6 +420,91 @@ class SiloQueryModelTest {
             sequenceName = null,
         )
         assertThat(result, equalTo(listOf(expectedInsertion)))
+    }
+
+    @Test
+    fun `getNucleotideInsertions includes the segment name if the nucleotide sequence has multiple segments`() {
+        every { siloClientMock.sendQuery(any<SiloQuery<InsertionData>>()) } returns Stream.of(someInsertionData)
+        every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
+        every { referenceGenomeSchemaMock.isSingleSegmented() } returns false
+
+        val result = underTest.getNucleotideInsertions(
+            SequenceFiltersRequest(
+                emptyMap(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                OrderBySpec.EMPTY,
+            ),
+        ).toList()
+
+        val expectedInsertion = InsertionResponse(
+            insertion = "ins_sequenceName:1234:ABCD",
+            count = 42,
+            insertedSymbols = "ABCD",
+            position = 1234,
+            sequenceName = "sequenceName",
+        )
+        assertThat(result, equalTo(listOf(expectedInsertion)))
+    }
+
+    @Test
+    fun `GIVEN orderBy mutation WHEN computing nuc mutations THEN expands to component fields in order`() {
+        val querySlot = slot<SiloQuery<MutationData>>()
+        every { siloClientMock.sendQuery(capture(querySlot)) } returns Stream.empty()
+        every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
+        every { referenceGenomeSchemaMock.isSingleSegmented() } returns true
+
+        underTest.computeNucleotideMutationProportions(
+            mutationProportionsRequest(
+                orderByFields = listOf(OrderByField("mutation", Order.ASCENDING)).toOrderBySpec(),
+            ),
+        ).toList()
+
+        val action = querySlot.captured.action as SiloAction.MutationsAction
+        assertThat(
+            action.orderByFields,
+            equalTo(
+                listOf(
+                    OrderByField("sequenceName", Order.ASCENDING),
+                    OrderByField("mutationFrom", Order.ASCENDING),
+                    OrderByField("position", Order.ASCENDING),
+                    OrderByField("mutationTo", Order.ASCENDING),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN orderBy insertion WHEN computing nuc insertions THEN expands to component fields in order`() {
+        val querySlot = slot<SiloQuery<InsertionData>>()
+        every { siloClientMock.sendQuery(capture(querySlot)) } returns Stream.empty()
+        every { siloFilterExpressionMapperMock.map(any<CommonSequenceFilters>()) } returns True
+        every { referenceGenomeSchemaMock.isSingleSegmented() } returns true
+
+        underTest.getNucleotideInsertions(
+            SequenceFiltersRequest(
+                emptyMap(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                emptyList(),
+                listOf(OrderByField("insertion", Order.DESCENDING)).toOrderBySpec(),
+            ),
+        ).toList()
+
+        val action = querySlot.captured.action as SiloAction.NucleotideInsertionsAction
+        assertThat(
+            action.orderByFields,
+            equalTo(
+                listOf(
+                    OrderByField("sequenceName", Order.DESCENDING),
+                    OrderByField("position", Order.DESCENDING),
+                    OrderByField("insertedSymbols", Order.DESCENDING),
+                ),
+            ),
+        )
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/VariantQueryFacadeTest.kt
@@ -51,23 +51,23 @@ class VariantQueryFacadeTest {
                     3,
                     matchExactly = false,
                     listOf(
-                        NucleotideSymbolEquals(null, 123, "A"),
-                        NucleotideSymbolEquals(null, 234, "T"),
-                        NucleotideSymbolEquals(null, 345, "G"),
+                        NucleotideSymbolEquals("main", 123, "A"),
+                        NucleotideSymbolEquals("main", 234, "T"),
+                        NucleotideSymbolEquals("main", 345, "G"),
                     ),
                 ),
                 Maybe(
                     Or(
-                        NucleotideSymbolEquals(null, 800, "-"),
-                        NucleotideSymbolEquals(null, 700, "B"),
+                        NucleotideSymbolEquals("main", 800, "-"),
+                        NucleotideSymbolEquals("main", 700, "B"),
                     ),
                 ),
-                Not(HasNucleotideMutation(null, 600)),
+                Not(HasNucleotideMutation("main", 600)),
                 Or(
-                    NucleotideSymbolEquals(null, 500, "B"),
-                    NucleotideSymbolEquals(null, 400, "-"),
+                    NucleotideSymbolEquals("main", 500, "B"),
+                    NucleotideSymbolEquals("main", 400, "-"),
                 ),
-                NucleotideSymbolEquals(null, 300, "G"),
+                NucleotideSymbolEquals("main", 300, "G"),
             )
 
         assertThat(result, equalTo(expectedResult))
@@ -79,7 +79,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        val expectedResult = NucleotideSymbolEquals(null, 300, "G")
+        val expectedResult = NucleotideSymbolEquals("main", 300, "G")
         assertThat(result, equalTo(expectedResult))
     }
 
@@ -89,7 +89,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(HasNucleotideMutation(null, 400)))
+        assertThat(result, equalTo(HasNucleotideMutation("main", 400)))
     }
 
     @Test
@@ -99,8 +99,8 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = And(
-            NucleotideSymbolEquals(null, 400, "-"),
-            NucleotideSymbolEquals(null, 300, "G"),
+            NucleotideSymbolEquals("main", 400, "-"),
+            NucleotideSymbolEquals("main", 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -112,9 +112,9 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = And(
-            NucleotideSymbolEquals(null, 500, "B"),
-            NucleotideSymbolEquals(null, 400, "-"),
-            NucleotideSymbolEquals(null, 300, "G"),
+            NucleotideSymbolEquals("main", 500, "B"),
+            NucleotideSymbolEquals("main", 400, "-"),
+            NucleotideSymbolEquals("main", 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -125,7 +125,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        val expectedResult = Not(NucleotideSymbolEquals(null, 300, "G"))
+        val expectedResult = Not(NucleotideSymbolEquals("main", 300, "G"))
         assertThat(result, equalTo(expectedResult))
     }
 
@@ -136,8 +136,8 @@ class VariantQueryFacadeTest {
         val result = underTest.map(variantQuery)
 
         val expectedResult = Or(
-            NucleotideSymbolEquals(null, 400, "-"),
-            NucleotideSymbolEquals(null, 300, "G"),
+            NucleotideSymbolEquals("main", 400, "-"),
+            NucleotideSymbolEquals("main", 300, "G"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -150,10 +150,10 @@ class VariantQueryFacadeTest {
 
         val expectedResult = And(
             Or(
-                NucleotideSymbolEquals(null, 500, "G"),
-                NucleotideSymbolEquals(null, 400, "A"),
+                NucleotideSymbolEquals("main", 500, "G"),
+                NucleotideSymbolEquals("main", 400, "A"),
             ),
-            NucleotideSymbolEquals(null, 300, "C"),
+            NucleotideSymbolEquals("main", 300, "C"),
         )
         assertThat(result, equalTo(expectedResult))
     }
@@ -164,7 +164,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        val expectedResult = Maybe(NucleotideSymbolEquals(null, 300, "G"))
+        val expectedResult = Maybe(NucleotideSymbolEquals("main", 300, "G"))
         assertThat(result, equalTo(expectedResult))
     }
 
@@ -174,7 +174,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        val expectedResult = Maybe(NucleotideSymbolEquals(null, 12, "C"))
+        val expectedResult = Maybe(NucleotideSymbolEquals("main", 12, "C"))
         assertThat(result, equalTo(expectedResult))
     }
 
@@ -231,10 +231,10 @@ class VariantQueryFacadeTest {
             3,
             false,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                NucleotideSymbolEquals(null, 234, "T"),
-                NucleotideSymbolEquals(null, 345, "G"),
-                NucleotideSymbolEquals(null, 456, "A"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                NucleotideSymbolEquals("main", 234, "T"),
+                NucleotideSymbolEquals("main", 345, "G"),
+                NucleotideSymbolEquals("main", 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -250,10 +250,10 @@ class VariantQueryFacadeTest {
             3,
             true,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                NucleotideSymbolEquals(null, 234, "T"),
-                NucleotideSymbolEquals(null, 345, "G"),
-                NucleotideSymbolEquals(null, 456, "A"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                NucleotideSymbolEquals("main", 234, "T"),
+                NucleotideSymbolEquals("main", 345, "G"),
+                NucleotideSymbolEquals("main", 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -270,10 +270,10 @@ class VariantQueryFacadeTest {
             3,
             true,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                Not(NucleotideSymbolEquals(null, 234, "G")),
-                NucleotideSymbolEquals(null, 345, "G"),
-                NucleotideSymbolEquals(null, 456, "A"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                Not(NucleotideSymbolEquals("main", 234, "G")),
+                NucleotideSymbolEquals("main", 345, "G"),
+                NucleotideSymbolEquals("main", 456, "A"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -290,9 +290,9 @@ class VariantQueryFacadeTest {
             3,
             true,
             listOf(
-                NucleotideSymbolEquals(null, 123, "A"),
-                NucleotideSymbolEquals(null, 234, "T"),
-                NucleotideSymbolEquals(null, 345, "G"),
+                NucleotideSymbolEquals("main", 123, "A"),
+                NucleotideSymbolEquals("main", 234, "T"),
+                NucleotideSymbolEquals("main", 345, "G"),
             ),
         )
         assertThat(result, equalTo(expectedResult))
@@ -304,7 +304,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(NucleotideInsertionContains(1234, "GAG", null)))
+        assertThat(result, equalTo(NucleotideInsertionContains(1234, "GAG", "main")))
     }
 
     @Test
@@ -321,7 +321,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(NucleotideInsertionContains(1234, "GAG", null)))
+        assertThat(result, equalTo(NucleotideInsertionContains(1234, "GAG", "main")))
     }
 
     @Test
@@ -330,7 +330,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(NucleotideInsertionContains(1234, "GAG", null)))
+        assertThat(result, equalTo(NucleotideInsertionContains(1234, "GAG", "main")))
     }
 
     @Test
@@ -339,7 +339,7 @@ class VariantQueryFacadeTest {
 
         val result = underTest.map(variantQuery)
 
-        assertThat(result, equalTo(NucleotideInsertionContains(1234, "G.*A.*G", null)))
+        assertThat(result, equalTo(NucleotideInsertionContains(1234, "G.*A.*G", "main")))
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/AminoAcidMutationsOverTimeModelTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenome
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.model.AdvancedQueryFacade
 import org.genspectrum.lapis.model.SiloFilterExpressionMapper
@@ -45,6 +46,9 @@ AminoAcidMutationsOverTimeModelTest {
     private lateinit var referenceGenome: ReferenceGenome
 
     @Autowired
+    private lateinit var referenceGenomeSchema: ReferenceGenomeSchema
+
+    @Autowired
     private lateinit var dataVersion: DataVersion
 
     @Autowired
@@ -62,6 +66,7 @@ AminoAcidMutationsOverTimeModelTest {
             siloClient = siloQueryClient,
             siloFilterExpressionMapper = siloFilterExpressionMapper,
             referenceGenome = referenceGenome,
+            referenceGenomeSchema = referenceGenomeSchema,
             dataVersion = dataVersion,
             advancedQueryFacade = advancedQueryFacade,
             config = config,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenome
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.model.AdvancedQueryFacade
 import org.genspectrum.lapis.model.SiloFilterExpressionMapper
@@ -29,8 +30,8 @@ import java.util.stream.Stream
 
 private val DUMMY_MUTATION1 = NucleotideMutation(null, 1, "T")
 private val DUMMY_MUTATION2 = NucleotideMutation(null, 2, "G")
-private val DUMMY_MUTATION_EQUALS1 = NucleotideSymbolEquals(null, 1, "T")
-private val DUMMY_MUTATION_EQUALS2 = NucleotideSymbolEquals(null, 2, "G")
+private val DUMMY_MUTATION_EQUALS1 = NucleotideSymbolEquals("main", 1, "T")
+private val DUMMY_MUTATION_EQUALS2 = NucleotideSymbolEquals("main", 2, "G")
 
 @SpringBootTest
 class NucleotideMutationsOverTimeModelTest {
@@ -42,6 +43,9 @@ class NucleotideMutationsOverTimeModelTest {
 
     @Autowired
     private lateinit var referenceGenome: ReferenceGenome
+
+    @Autowired
+    private lateinit var referenceGenomeSchema: ReferenceGenomeSchema
 
     @Autowired
     private lateinit var dataVersion: DataVersion
@@ -61,6 +65,7 @@ class NucleotideMutationsOverTimeModelTest {
             siloClient = siloQueryClient,
             siloFilterExpressionMapper = siloFilterExpressionMapper,
             referenceGenome = referenceGenome,
+            referenceGenomeSchema = referenceGenomeSchema,
             dataVersion = dataVersion,
             advancedQueryFacade = advancedQueryFacade,
             config = config,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/NucleotideMutationsOverTimeModelTest.kt
@@ -133,7 +133,7 @@ class NucleotideMutationsOverTimeModelTest {
         )
         mockSiloNucleotideCoverageQuery(
             siloQueryClient,
-            null,
+            "main",
             1,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
@@ -143,7 +143,7 @@ class NucleotideMutationsOverTimeModelTest {
         )
         mockSiloNucleotideCoverageQuery(
             siloQueryClient,
-            null,
+            "main",
             2,
             DUMMY_DATE_BETWEEN_ALL,
             Stream.of(
@@ -216,7 +216,7 @@ class NucleotideMutationsOverTimeModelTest {
     @Test
     fun `given a list of mutations and date ranges and no data for a mutation, then it returns zero`() {
         mockSiloCountQuery(siloQueryClient, DUMMY_MUTATION_EQUALS1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
-        mockSiloNucleotideCoverageQuery(siloQueryClient, null, 1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
+        mockSiloNucleotideCoverageQuery(siloQueryClient, "main", 1, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
         mockSiloTotalCountQuery(siloQueryClient, DUMMY_DATE_BETWEEN_ALL, Stream.empty())
 
         val mutations = listOf(DUMMY_MUTATION1)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModelTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModelTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import org.genspectrum.lapis.config.DatabaseConfig
 import org.genspectrum.lapis.config.ReferenceGenome
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
 import org.genspectrum.lapis.controller.BadRequestException
 import org.genspectrum.lapis.model.AdvancedQueryFacade
 import org.genspectrum.lapis.model.SiloFilterExpressionMapper
@@ -61,6 +62,9 @@ class QueriesOverTimeModelTest {
     private lateinit var referenceGenome: ReferenceGenome
 
     @Autowired
+    private lateinit var referenceGenomeSchema: ReferenceGenomeSchema
+
+    @Autowired
     private lateinit var dataVersion: DataVersion
 
     @Autowired
@@ -78,6 +82,7 @@ class QueriesOverTimeModelTest {
             siloClient = siloQueryClient,
             siloFilterExpressionMapper = siloFilterExpressionMapper,
             referenceGenome = referenceGenome,
+            referenceGenomeSchema = referenceGenomeSchema,
             dataVersion = dataVersion,
             advancedQueryFacade = advancedQueryFacade,
             config = config,

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/AggregatedFiltersRequestTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/AggregatedFiltersRequestTest.kt
@@ -123,13 +123,16 @@ class AggregatedFiltersRequestTest {
                 Arguments.of(
                     """
                     {
-                        "nucleotideMutations": ["T1-", "A23062T"],
+                        "nucleotideMutations": ["other_segment:T1-", "other_segment:A23062T"],
                         "fields": ["date", "country"]
                     }
                     """,
                     AggregatedFiltersRequest(
                         emptyMap(),
-                        listOf(NucleotideMutation(null, 1, "-"), NucleotideMutation(null, 23062, "T")),
+                        listOf(
+                            NucleotideMutation("other_segment", 1, "-"),
+                            NucleotideMutation("other_segment", 23062, "T"),
+                        ),
                         emptyList(),
                         emptyList(),
                         emptyList(),
@@ -155,7 +158,7 @@ class AggregatedFiltersRequestTest {
                 Arguments.of(
                     """
                     {
-                        "nucleotideInsertions": ["ins_other_segment:501:Y", "ins_12:ABCD"],
+                        "nucleotideInsertions": ["ins_other_segment:501:Y", "ins_other_segment:12:ABCD"],
                         "fields": ["date", "country"]
                     }
                     """,
@@ -165,7 +168,7 @@ class AggregatedFiltersRequestTest {
                         emptyList(),
                         listOf(
                             NucleotideInsertion(501, "Y", "other_segment"),
-                            NucleotideInsertion(12, "ABCD", null),
+                            NucleotideInsertion(12, "ABCD", "other_segment"),
                         ),
                         emptyList(),
                         listOf(PlainField("date"), PlainField("country")),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/MutationProportionsRequestTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/MutationProportionsRequestTest.kt
@@ -81,14 +81,14 @@ class MutationProportionsRequestTest {
                 Arguments.of(
                     """
                     {
-                        "nucleotideMutations": ["T1-", "A23062T"]
+                        "nucleotideMutations": ["other_segment:T1-", "other_segment:A23062T"]
                     }
                     """,
                     MutationProportionsRequest(
                         sequenceFilters = emptyMap(),
                         nucleotideMutations = listOf(
-                            NucleotideMutation(null, 1, "-"),
-                            NucleotideMutation(null, 23062, "T"),
+                            NucleotideMutation("other_segment", 1, "-"),
+                            NucleotideMutation("other_segment", 23062, "T"),
                         ),
                         aminoAcidMutations = emptyList(),
                         nucleotideInsertions = emptyList(),
@@ -119,7 +119,7 @@ class MutationProportionsRequestTest {
                 Arguments.of(
                     """
                     {
-                        "nucleotideInsertions": ["ins_other_segment:501:Y", "ins_12:ABCD"]
+                        "nucleotideInsertions": ["ins_other_segment:501:Y", "ins_other_segment:12:ABCD"]
                     }
                     """,
                     MutationProportionsRequest(
@@ -128,7 +128,7 @@ class MutationProportionsRequestTest {
                         aminoAcidMutations = emptyList(),
                         nucleotideInsertions = listOf(
                             NucleotideInsertion(501, "Y", "other_segment"),
-                            NucleotideInsertion(12, "ABCD", null),
+                            NucleotideInsertion(12, "ABCD", "other_segment"),
                         ),
                         aminoAcidInsertions = emptyList(),
                         fields = emptyList(),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideInsertionTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideInsertionTest.kt
@@ -1,5 +1,7 @@
 package org.genspectrum.lapis.request
 
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.config.ReferenceSequenceSchema
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -7,113 +9,87 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import tools.jackson.databind.ObjectMapper
-import tools.jackson.module.kotlin.readValue
 
-@SpringBootTest
 class NucleotideInsertionTest {
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
     @ParameterizedTest
-    @MethodSource("getNucleotideInsertionWithValidSyntax")
-    fun `NucleotideInsertion is correctly deserialized from JSON`(
+    @MethodSource("getBareInsertionsWithValidSyntax")
+    fun `GIVEN single segmented THEN bare nucleotide insertion is parsed`(
         underTest: String,
         expected: NucleotideInsertion,
     ) {
-        val result = objectMapper.readValue<NucleotideInsertion>(underTest)
+        assertThat(NucleotideInsertion.fromString(underTest, SINGLE_SEGMENTED), equalTo(expected))
+    }
 
-        assertThat(result, equalTo(expected))
+    @ParameterizedTest
+    @MethodSource("getSegmentedInsertionsWithValidSyntax")
+    fun `GIVEN multi segmented THEN nucleotide insertion with segment is parsed`(
+        underTest: String,
+        expected: NucleotideInsertion,
+    ) {
+        assertThat(NucleotideInsertion.fromString(underTest, MULTI_SEGMENTED), equalTo(expected))
+    }
+
+    @ParameterizedTest
+    @MethodSource("getBareInsertionsWithValidSyntax")
+    fun `GIVEN multi segmented WHEN nucleotide insertion without segment THEN throws`(
+        underTest: String,
+        @Suppress("UNUSED_PARAMETER") expected: NucleotideInsertion,
+    ) {
+        assertThrows(BadRequestException::class.java) {
+            NucleotideInsertion.fromString(underTest, MULTI_SEGMENTED)
+        }
     }
 
     @ParameterizedTest
     @MethodSource("getNucleotideInsertionWithWrongSyntax")
     fun `Given invalid NucleotideInsertion then should throw an error`(input: String) {
         assertThrows(BadRequestException::class.java) {
-            objectMapper.readValue<NucleotideInsertion>(input)
+            NucleotideInsertion.fromString(input, MULTI_SEGMENTED)
         }
     }
 
     companion object {
+        private val SINGLE_SEGMENTED = ReferenceGenomeSchema(listOf(ReferenceSequenceSchema("main")), emptyList())
+        private val MULTI_SEGMENTED = ReferenceGenomeSchema(
+            listOf(ReferenceSequenceSchema("main"), ReferenceSequenceSchema("other_segment")),
+            emptyList(),
+        )
+
         @JvmStatic
-        fun getNucleotideInsertionWithValidSyntax() =
+        fun getBareInsertionsWithValidSyntax() =
             listOf(
-                Arguments.of(
-                    "\"ins_other_segment:123:ABCD\"",
-                    NucleotideInsertion(123, "ABCD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:A\"",
-                    NucleotideInsertion(123, "A", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_123:ABCD\"",
-                    NucleotideInsertion(123, "ABCD", null),
-                ),
-                Arguments.of(
-                    "\"ins_123:AB?CD\"",
-                    NucleotideInsertion(123, "AB.*CD", null),
-                ),
-                Arguments.of(
-                    "\"ins_123:???\"",
-                    NucleotideInsertion(123, ".*.*.*", null),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:?\"",
-                    NucleotideInsertion(123, ".*", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:AB.*CD\"",
-                    NucleotideInsertion(123, "AB.*CD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:.*CD\"",
-                    NucleotideInsertion(123, ".*CD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:AB.*.*\"",
-                    NucleotideInsertion(123, "AB.*.*", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:?CD\"",
-                    NucleotideInsertion(123, ".*CD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:AB??\"",
-                    NucleotideInsertion(123, "AB.*.*", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:AB.*?CD\"",
-                    NucleotideInsertion(123, "AB.*.*CD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_other_segment:123:abCd\"",
-                    NucleotideInsertion(123, "ABCD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"ins_oTher_segmenT:123:ABCD\"",
-                    NucleotideInsertion(123, "ABCD", "other_segment"),
-                ),
-                Arguments.of(
-                    "\"INs_123:AcCD\"",
-                    NucleotideInsertion(123, "ACCD", null),
-                ),
+                Arguments.of("ins_123:ABCD", NucleotideInsertion(123, "ABCD", null)),
+                Arguments.of("ins_123:AB?CD", NucleotideInsertion(123, "AB.*CD", null)),
+                Arguments.of("ins_123:???", NucleotideInsertion(123, ".*.*.*", null)),
+                Arguments.of("INs_123:AcCD", NucleotideInsertion(123, "ACCD", null)),
+            )
+
+        @JvmStatic
+        fun getSegmentedInsertionsWithValidSyntax() =
+            listOf(
+                Arguments.of("ins_other_segment:123:ABCD", NucleotideInsertion(123, "ABCD", "other_segment")),
+                Arguments.of("ins_other_segment:123:A", NucleotideInsertion(123, "A", "other_segment")),
+                Arguments.of("ins_other_segment:123:?", NucleotideInsertion(123, ".*", "other_segment")),
+                Arguments.of("ins_other_segment:123:AB.*CD", NucleotideInsertion(123, "AB.*CD", "other_segment")),
+                Arguments.of("ins_other_segment:123:.*CD", NucleotideInsertion(123, ".*CD", "other_segment")),
+                Arguments.of("ins_other_segment:123:AB.*.*", NucleotideInsertion(123, "AB.*.*", "other_segment")),
+                Arguments.of("ins_other_segment:123:?CD", NucleotideInsertion(123, ".*CD", "other_segment")),
+                Arguments.of("ins_other_segment:123:AB??", NucleotideInsertion(123, "AB.*.*", "other_segment")),
+                Arguments.of("ins_other_segment:123:AB.*?CD", NucleotideInsertion(123, "AB.*.*CD", "other_segment")),
+                Arguments.of("ins_other_segment:123:abCd", NucleotideInsertion(123, "ABCD", "other_segment")),
+                Arguments.of("ins_oTher_segmenT:123:ABCD", NucleotideInsertion(123, "ABCD", "other_segment")),
             )
 
         @JvmStatic
         fun getNucleotideInsertionWithWrongSyntax() =
             listOf(
-                Arguments.of("\"ins_::123:G\""),
-                Arguments.of("\"ins_:123:\""),
-                Arguments.of("\"ins_other_segment:123:\""),
-                Arguments.of("\"ins_other_segment:other_segment:123:ABC\""),
-                Arguments.of("\"ins_other_segmentWithDotWithoutStar:123:AB.C\""),
-                Arguments.of("\"ins_segment\$name&with/invalid)chars:123:A\""),
-                Arguments.of(
-                    "\"ins_segmentNotInReference:123:ABCD\"",
-                ),
+                Arguments.of("ins_::123:G"),
+                Arguments.of("ins_:123:"),
+                Arguments.of("ins_other_segment:123:"),
+                Arguments.of("ins_other_segment:other_segment:123:ABC"),
+                Arguments.of("ins_other_segmentWithDotWithoutStar:123:AB.C"),
+                Arguments.of("ins_segment\$name&with/invalid)chars:123:A"),
+                Arguments.of("ins_segmentNotInReference:123:ABCD"),
             )
     }
 }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideMutationTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/request/NucleotideMutationTest.kt
@@ -1,5 +1,7 @@
 package org.genspectrum.lapis.request
 
+import org.genspectrum.lapis.config.ReferenceGenomeSchema
+import org.genspectrum.lapis.config.ReferenceSequenceSchema
 import org.genspectrum.lapis.controller.BadRequestException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -7,116 +9,95 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import tools.jackson.databind.ObjectMapper
-import tools.jackson.module.kotlin.readValue
 
-@SpringBootTest
 class NucleotideMutationTest {
-    @Autowired
-    private lateinit var objectMapper: ObjectMapper
-
     @ParameterizedTest
-    @MethodSource("getMutationWithValidSyntax")
-    fun `NucleotideMutation is correctly deserialized from JSON`(
+    @MethodSource("getBareMutationsWithValidSyntax")
+    fun `GIVEN single segmented THEN bare nucleotide mutation is parsed`(
         underTest: String,
         expected: NucleotideMutation,
     ) {
-        val result = objectMapper.readValue<NucleotideMutation>(underTest)
+        assertThat(NucleotideMutation.fromString(underTest, SINGLE_SEGMENTED), equalTo(expected))
+    }
 
-        assertThat(result, equalTo(expected))
+    @ParameterizedTest
+    @MethodSource("getSegmentedMutationsWithValidSyntax")
+    fun `GIVEN multi segmented THEN nucleotide mutation with segment is parsed`(
+        underTest: String,
+        expected: NucleotideMutation,
+    ) {
+        assertThat(NucleotideMutation.fromString(underTest, MULTI_SEGMENTED), equalTo(expected))
+    }
+
+    @ParameterizedTest
+    @MethodSource("getBareMutationsWithValidSyntax")
+    fun `GIVEN multi segmented WHEN nucleotide mutation without segment THEN throws`(
+        underTest: String,
+        @Suppress("UNUSED_PARAMETER") expected: NucleotideMutation,
+    ) {
+        assertThrows(BadRequestException::class.java) {
+            NucleotideMutation.fromString(underTest, MULTI_SEGMENTED)
+        }
     }
 
     @ParameterizedTest
     @MethodSource("getNucleotideMutationWithWrongSyntax")
     fun `Given invalid NucleotideMutation then should throw an error`(input: String) {
         assertThrows(BadRequestException::class.java) {
-            objectMapper.readValue<NucleotideMutation>(input)
+            NucleotideMutation.fromString(input, MULTI_SEGMENTED)
         }
     }
 
     companion object {
+        private val SINGLE_SEGMENTED = ReferenceGenomeSchema(listOf(ReferenceSequenceSchema("main")), emptyList())
+        private val MULTI_SEGMENTED = ReferenceGenomeSchema(
+            listOf(ReferenceSequenceSchema("main"), ReferenceSequenceSchema("other_segment")),
+            emptyList(),
+        )
+
         @JvmStatic
-        fun getMutationWithValidSyntax() =
+        fun getBareMutationsWithValidSyntax() =
             listOf(
+                Arguments.of("G123A", NucleotideMutation(null, 123, "A")),
+                Arguments.of("123A", NucleotideMutation(null, 123, "A")),
+                Arguments.of("123.", NucleotideMutation(null, 123, ".")),
+                Arguments.of("123-", NucleotideMutation(null, 123, "-")),
+                Arguments.of("123", NucleotideMutation(null, 123, null)),
+                Arguments.of("A123", NucleotideMutation(null, 123, null)),
+                Arguments.of("g123A", NucleotideMutation(null, 123, "A")),
+                Arguments.of("G123a", NucleotideMutation(null, 123, "A")),
+                Arguments.of("g123a", NucleotideMutation(null, 123, "A")),
+                Arguments.of("MAYBE(123X)", NucleotideMutation(null, 123, "X", maybe = true)),
+                Arguments.of("maybe(123X)", NucleotideMutation(null, 123, "X", maybe = true)),
+                Arguments.of("maYbE(123X)", NucleotideMutation(null, 123, "X", maybe = true)),
+            )
+
+        @JvmStatic
+        fun getSegmentedMutationsWithValidSyntax() =
+            listOf(
+                Arguments.of("other_segment:123X", NucleotideMutation("other_segment", 123, "X")),
+                Arguments.of("othER_SegmENt:123X", NucleotideMutation("other_segment", 123, "X")),
                 Arguments.of(
-                    "\"G123A\"",
-                    NucleotideMutation(null, 123, "A"),
-                ),
-                Arguments.of(
-                    "\"123A\"",
-                    NucleotideMutation(null, 123, "A"),
-                ),
-                Arguments.of(
-                    "\"123.\"",
-                    NucleotideMutation(null, 123, "."),
-                ),
-                Arguments.of(
-                    "\"123-\"",
-                    NucleotideMutation(null, 123, "-"),
-                ),
-                Arguments.of(
-                    "\"123\"",
-                    NucleotideMutation(null, 123, null),
-                ),
-                Arguments.of(
-                    "\"A123\"",
-                    NucleotideMutation(null, 123, null),
-                ),
-                Arguments.of(
-                    "\"other_segment:123X\"",
-                    NucleotideMutation("other_segment", 123, "X"),
-                ),
-                Arguments.of(
-                    "\"g123A\"",
-                    NucleotideMutation(null, 123, "A"),
-                ),
-                Arguments.of(
-                    "\"G123a\"",
-                    NucleotideMutation(null, 123, "A"),
-                ),
-                Arguments.of(
-                    "\"g123a\"",
-                    NucleotideMutation(null, 123, "A"),
-                ),
-                Arguments.of(
-                    "\"othER_SegmENt:123X\"",
-                    NucleotideMutation("other_segment", 123, "X"),
-                ),
-                Arguments.of(
-                    "\"MAYBE(other_segment:123X)\"",
+                    "MAYBE(other_segment:123X)",
                     NucleotideMutation("other_segment", 123, "X", maybe = true),
-                ),
-                Arguments.of(
-                    "\"MAYBE(123X)\"",
-                    NucleotideMutation(null, 123, "X", maybe = true),
-                ),
-                Arguments.of(
-                    "\"maybe(123X)\"",
-                    NucleotideMutation(null, 123, "X", maybe = true),
-                ),
-                Arguments.of(
-                    "\"maYbE(123X)\"",
-                    NucleotideMutation(null, 123, "X", maybe = true),
                 ),
             )
 
         @JvmStatic
         fun getNucleotideMutationWithWrongSyntax() =
             listOf(
-                Arguments.of("\"AA123\""),
-                Arguments.of("\"123AA\""),
-                Arguments.of("\"\""),
-                Arguments.of("\"AA123A\""),
-                Arguments.of("\"A\""),
-                Arguments.of("\":123A\""),
-                Arguments.of("\"sequence\$name&with/invalid)chars:G123A\""),
-                Arguments.of("\"segmentNotInReferenceGenome:G123A\""),
-                Arguments.of("\"MAYBE()\""),
-                Arguments.of("\"MAYBE(notAMutation)\""),
-                Arguments.of("\"MAYBE(123A))\""),
-                Arguments.of("\"MAYBE((123A)\""),
+                Arguments.of("AA123"),
+                Arguments.of("123AA"),
+                Arguments.of(""),
+                Arguments.of("AA123A"),
+                Arguments.of("A"),
+                Arguments.of(":123A"),
+                Arguments.of("sequence\$name&with/invalid)chars:G123A"),
+                Arguments.of("segmentNotInReferenceGenome:G123A"),
+                Arguments.of("MAYBE()"),
+                Arguments.of("MAYBE(notAMutation)"),
+                Arguments.of("MAYBE(123A))"),
+                Arguments.of("MAYBE((123A)"),
             )
     }
 }

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -119,7 +119,6 @@ class SiloClientTest(
                     buildArrowIpcStream(
                         listOf(
                             mapOf(
-                                "mutation" to "C3037T",
                                 "mutationFrom" to "C",
                                 "mutationTo" to "T",
                                 "sequenceName" to "main",
@@ -129,7 +128,6 @@ class SiloClientTest(
                                 "count" to 51,
                             ),
                             mapOf(
-                                "mutation" to "C14408T",
                                 "mutationFrom" to "C",
                                 "mutationTo" to "T",
                                 "sequenceName" to "main",
@@ -151,7 +149,6 @@ class SiloClientTest(
             result,
             containsInAnyOrder(
                 MutationData(
-                    mutation = "C3037T",
                     count = 51,
                     proportion = 1.0,
                     sequenceName = "main",
@@ -161,7 +158,6 @@ class SiloClientTest(
                     coverage = 100,
                 ),
                 MutationData(
-                    mutation = "C14408T",
                     count = 52,
                     proportion = 1.0,
                     sequenceName = "main",
@@ -421,14 +417,12 @@ class SiloClientTest(
                                 "count" to 1,
                                 "insertedSymbols" to "SGE",
                                 "position" to 143,
-                                "insertion" to "ins_S:247:SGE",
                                 "sequenceName" to "S",
                             ),
                             mapOf(
                                 "count" to 2,
                                 "insertedSymbols" to "EPE",
                                 "position" to 214,
-                                "insertion" to "ins_S:214:EPE",
                                 "sequenceName" to "S",
                             ),
                         ),
@@ -445,14 +439,12 @@ class SiloClientTest(
             containsInAnyOrder(
                 InsertionData(
                     1,
-                    "ins_S:247:SGE",
                     "SGE",
                     143,
                     "S",
                 ),
                 InsertionData(
                     2,
-                    "ins_S:214:EPE",
                     "EPE",
                     214,
                     "S",

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -506,16 +506,6 @@ class SiloQueryTest {
                     """,
                 ),
                 Arguments.of(
-                    NucleotideSymbolEquals(null, 1234, "A"),
-                    """
-                        {
-                            "type": "NucleotideEquals",
-                            "position": 1234,
-                            "symbol": "A"
-                        }
-                    """,
-                ),
-                Arguments.of(
                     NucleotideSymbolEquals("sequence name", 1234, "A"),
                     """
                         {
@@ -532,15 +522,6 @@ class SiloQueryTest {
                         {
                             "type": "HasNucleotideMutation",
                             "sequenceName": "sequence name",
-                            "position": 1234
-                        }
-                    """,
-                ),
-                Arguments.of(
-                    HasNucleotideMutation(null, 1234),
-                    """
-                        {
-                            "type": "HasNucleotideMutation",
                             "position": 1234
                         }
                     """,
@@ -574,16 +555,6 @@ class SiloQueryTest {
                             "position": 1234,
                             "value": "A",
                             "sequenceName":"segment"
-                        }
-                    """,
-                ),
-                Arguments.of(
-                    NucleotideInsertionContains(1234, "A", null),
-                    """
-                        {
-                            "type": "InsertionContains",
-                            "position": 1234,
-                            "value": "A"
                         }
                     """,
                 ),

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryToSaneQlTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryToSaneQlTest.kt
@@ -419,10 +419,6 @@ class SiloQueryToSaneQlTest {
                 ),
                 // NucleotideSymbolEquals
                 Arguments.of(
-                    NucleotideSymbolEquals(null, 1234, "A"),
-                    "nucleotideEquals(position:=1234, symbol:='A')",
-                ),
-                Arguments.of(
                     NucleotideSymbolEquals("sequence name", 1234, "A"),
                     "nucleotideEquals(position:=1234, symbol:='A', sequenceName:='sequence name')",
                 ),
@@ -430,10 +426,6 @@ class SiloQueryToSaneQlTest {
                 Arguments.of(
                     HasNucleotideMutation("sequence name", 1234),
                     "hasMutation(position:=1234, sequenceName:='sequence name')",
-                ),
-                Arguments.of(
-                    HasNucleotideMutation(null, 1234),
-                    "hasMutation(position:=1234)",
                 ),
                 // AminoAcidSymbolEquals
                 Arguments.of(
@@ -449,10 +441,6 @@ class SiloQueryToSaneQlTest {
                 Arguments.of(
                     NucleotideInsertionContains(1234, "A", "segment"),
                     "insertionContains(position:=1234, value:='A', sequenceName:='segment')",
-                ),
-                Arguments.of(
-                    NucleotideInsertionContains(1234, "A", null),
-                    "insertionContains(position:=1234, value:='A')",
                 ),
                 // AminoAcidInsertionContains
                 Arguments.of(


### PR DESCRIPTION
resolves #1797

### Summary

SILO dropped the assembled `insertion` and `mutation` fields from its responses. This restores them by assembling them in LAPIS, keeping the API contract unchanged.

SILO also dropped the concept of a "default" sequence, making the `sequenceName' field in insertion and mutation filters mandatory.

## PR Checklist
~~- [ ] All necessary documentation has been adapted.~~
~~- [ ] All necessary changes are explained in the `llms.txt`.~~
- [x] The implemented feature is covered by an appropriate test.
