### PR TITLE
fix(lapis): do not cache aggregations with many group by fields

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloQuery.kt
@@ -37,6 +37,15 @@ interface CommonActionFields {
 
 const val ORDER_BY_RANDOM_FIELD_NAME = "random"
 
+/**
+ * Aggregations that group by more than this many columns (plain fields plus sequence-position fields)
+ * are not cached. Their result cardinality grows roughly with the number of matching sequences, so
+ * materializing the full result into a `List` to store it in the cache can exhaust the heap, while
+ * the cache hit rate for such queries is close to zero anyway. Non-cacheable queries are streamed
+ * straight through instead (see [SiloClient.sendQueryAndGetDataVersion]).
+ */
+const val MAX_CACHEABLE_GROUP_BY_FIELD_COUNT = 20
+
 sealed class SiloAction<ResponseType>(
     @JsonIgnore val arrowConverter: ArrowRowConverter<ResponseType>,
     @JsonIgnore val cacheable: Boolean,
@@ -234,7 +243,7 @@ sealed class SiloAction<ResponseType>(
         override val offset: Int? = null,
     ) : SiloAction<AggregationData>(
             arrowConverter = AGGREGATION_DATA_ARROW_CONVERTER,
-            cacheable = true,
+            cacheable = groupByFields.size + sequencePositionFields.size <= MAX_CACHEABLE_GROUP_BY_FIELD_COUNT,
         ) {
         val type: String = "Aggregated"
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -5,6 +5,7 @@ import org.genspectrum.lapis.logging.RequestIdContext
 import org.genspectrum.lapis.request.Order
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
+import org.genspectrum.lapis.request.SequencePositionField
 import org.genspectrum.lapis.request.toOrderBySpec
 import org.genspectrum.lapis.response.AggregationData
 import org.genspectrum.lapis.response.DetailsData
@@ -731,6 +732,13 @@ class SiloClientTest(
             SiloQuery(SiloAction.details(), True),
             SiloQuery(SiloAction.genomicSequence(SequenceType.ALIGNED, listOf("sequenceName")), True),
             SiloQuery(SiloAction.genomicSequence(SequenceType.UNALIGNED, listOf("sequenceName")), True),
+            SiloQuery(
+                SiloAction.aggregated(
+                    groupByFields = listOf("date"),
+                    sequencePositionFields = (1..420).map { SequencePositionField("main", it) },
+                ),
+                True,
+            ),
         )
 
         @JvmStatic

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryTest.kt
@@ -3,6 +3,7 @@ package org.genspectrum.lapis.silo
 import org.genspectrum.lapis.request.Order
 import org.genspectrum.lapis.request.OrderByField
 import org.genspectrum.lapis.request.OrderBySpec
+import org.genspectrum.lapis.request.SequencePositionField
 import org.genspectrum.lapis.request.toOrderBySpec
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -51,6 +52,26 @@ class SiloQueryTest {
         val result = objectMapper.writeValueAsString(underTest)
 
         assertThat(objectMapper.readTree(result), equalTo(objectMapper.readTree(expected)))
+    }
+
+    @Test
+    fun `GIVEN an aggregation with few group by fields THEN it is cacheable`() {
+        val action = SiloAction.aggregated(
+            groupByFields = (1..10).map { "field$it" },
+            sequencePositionFields = (1..10).map { SequencePositionField("main", it) },
+        )
+
+        assertThat(action.cacheable, equalTo(true))
+    }
+
+    @Test
+    fun `GIVEN an aggregation with more than 20 group by fields THEN it is not cacheable`() {
+        val action = SiloAction.aggregated(
+            groupByFields = listOf("date"),
+            sequencePositionFields = (1..420).map { SequencePositionField("main", it) },
+        )
+
+        assertThat(action.cacheable, equalTo(false))
     }
 
     @ParameterizedTest(name = "Test SiloFilterExpression {1}")


### PR DESCRIPTION
resolves #1849

Aggregations that group by more than 20 columns (plain fields plus sequence-position fields) are no longer cached. The cache materializes the full result into a List to store it; for high-cardinality group-bys this can exhaust the heap (and did, causing a LAPIS outage). Such queries are now streamed straight through instead. Their cache hit rate is close to zero anyway since each filter combination is unique.

## PR Checklist
- [x] All necessary documentation has been adapted.
- ~~All necessary changes are explained in the `llms.txt`.~~
- [x] The implemented feature is covered by an appropriate test.
