### PR TITLE
fix(lapis): expire siloQueryCache entries 30h after last access

### DIFF
--- a/lapis/src/main/resources/application.properties
+++ b/lapis/src/main/resources/application.properties
@@ -4,7 +4,9 @@ springdoc.swagger-ui.operationsSorter=alpha
 server.forward-headers-strategy=framework
 
 spring.cache.cache-names=siloQueryCache
-spring.cache.caffeine.spec=maximumSize=50000,softValues
+# expireAfterAccess releases memory held by one-off queries; the cache is otherwise only
+# cleared on a SILO data version change, which can be days apart.
+spring.cache.caffeine.spec=maximumSize=50000,softValues,expireAfterAccess=30h
 
 server.error.whitelabel.enabled=false
 server.error.include-message=always

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryCacheConfigurationTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloQueryCacheConfigurationTest.kt
@@ -1,0 +1,26 @@
+package org.genspectrum.lapis.silo
+
+import com.github.benmanes.caffeine.cache.Cache
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cache.CacheManager
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+class SiloQueryCacheConfigurationTest(
+    @param:Autowired private val cacheManager: CacheManager,
+) {
+    @Test
+    fun `siloQueryCache entries expire after access`() {
+        @Suppress("UNCHECKED_CAST")
+        val nativeCache = cacheManager.getCache(SILO_QUERY_CACHE_NAME)!!.nativeCache as Cache<Any, Any>
+
+        assertThat(
+            nativeCache.policy().expireAfterAccess().get().getExpiresAfter(TimeUnit.HOURS),
+            equalTo(30L),
+        )
+    }
+}


### PR DESCRIPTION
The query cache was only ever cleared on a SILO data version change, which can be days apart. Add a 30h idle expiry so heap held by one-off queries (e.g. an analytics script sweeping many filter combinations) is released instead of lingering until the next data update.

This is a minimal, low-risk step. Bounding the cache by the memory size of its entries instead of by entry count is tracked separately.

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] All necessary changes are explained in the `llms.txt`.
- [ ] The implemented feature is covered by an appropriate test.
