### PR TITLE
fix(lapis): exit the JVM on OutOfMemoryError

### DIFF
--- a/lapis/entrypoint.sh
+++ b/lapis/entrypoint.sh
@@ -7,16 +7,16 @@ ARGS="${*}"
 # See https://github.com/apache/arrow-java/?tab=readme-ov-file#java-properties
 ARROW_OPTS="-Dio.netty.tryReflectionSetAccessible=true --add-opens=java.base/java.nio=ALL-UNNAMED"
 
+# Terminate the JVM on OutOfMemoryError instead of leaving it in a degraded, GC-thrashing
+# state, so that the orchestrator restarts the container. Override via JVM_OPTS if needed.
+DEFAULT_JVM_OPTS="-XX:+ExitOnOutOfMemoryError"
+
 GENERAL_OPTS="$ARROW_OPTS -jar app.jar \
     --spring.profiles.active=docker \
     --referenceGenomeFilename=./reference_genomes.json \
     $ARGS"
 
-if [ -n "$JVM_OPTS" ]; then
-    CMD="java $JVM_OPTS $GENERAL_OPTS"
-else
-    CMD="java $GENERAL_OPTS"
-fi
+CMD="java $DEFAULT_JVM_OPTS $JVM_OPTS $GENERAL_OPTS"
 echo Running application with command:
 echo "$CMD"
 $CMD


### PR DESCRIPTION
Add `-XX:+ExitOnOutOfMemoryError` as a default JVM option in the container entrypoint. On OOM the JVM otherwise stays up in a degraded, GC-thrashing state and keeps failing requests until someone restarts it manually (a recent incident left an instance unresponsive for ~19 hours). Exiting lets the orchestrator restart the container.

The option is still overridable through the JVM_OPTS environment variable.

resolves #1848 

## PR Checklist
- [ ] All necessary documentation has been adapted.
- [ ] All necessary changes are explained in the `llms.txt`.
- [ ] The implemented feature is covered by an appropriate test.
