### PR TITLE
feat(lapis): make the SILO info timeout configurable

### DIFF
--- a/lapis-docs/src/content/docs/maintainer-docs/references/starting-silo-and-lapis.mdx
+++ b/lapis-docs/src/content/docs/maintainer-docs/references/starting-silo-and-lapis.mdx
@@ -90,6 +90,9 @@ LAPIS provides the following optional parameters:
   If set, the landing page (`/`) will show a "Documentation" link to the provided value.
   It is meant to point to your self-hosted version of this LAPIS documentation.
   If not set, the "Documentation" link on the landing page (`/`) will not be shown.
+- `--silo.infoTimeout`:
+  How long LAPIS waits when it asks SILO for its info (data version and SILO version),
+  e.g. `100ms`, `1s`. Defaults to `100ms`.
 
 #### Starting LAPIS with Docker
 

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -10,6 +10,7 @@ import org.genspectrum.lapis.logging.RequestContext
 import org.genspectrum.lapis.logging.RequestIdContext
 import org.genspectrum.lapis.response.InfoData
 import org.genspectrum.lapis.util.YamlObjectMapper
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -92,6 +93,7 @@ open class CachedSiloClient(
     private val requestContext: RequestContext,
     private val config: DatabaseConfig,
     private val rootAllocator: RootAllocator,
+    @param:Value("\${silo.infoTimeout:100ms}") private val infoTimeout: Duration,
 ) {
     private val httpClient = HttpClient.newBuilder()
         // Create our own thread pool explicitly to not use the ForkJoinPool.commonPool()
@@ -176,7 +178,7 @@ open class CachedSiloClient(
             bodyHandler = BodyHandlers.ofString(),
             tryToReadSiloErrorFromBody = ::tryToReadSiloErrorFromString,
         ) {
-            it.timeout(Duration.ofMillis(100)) // this should never take long, make sure we don't block anything else
+            it.timeout(infoTimeout)
             it.GET()
         }
 


### PR DESCRIPTION
callInfo() has had a hard-coded 100 ms request timeout since #1593, picked so that the health endpoint cannot block when SILO does not respond. That same budget governs /sample/info, so a SILO that is merely a little slow (takes longer than 100ms) rather than down makes LAPIS return a 500. Users would not mind at all waiting say 200ms.

Rather than making a new judgment on what the timeout should be (there's a tradeoff between how long health can take if unhealthy and how slow silo can be before lapis returns 500) I propose to make the timeout configurable. So nothing changes unless users override.

Loculus would use this override to avoid flakes when SILO is just a bit slow (related to https://github.com/loculus-project/loculus/pull/7298)

There's a separate issue about why info is sometimes slow: https://github.com/GenSpectrum/LAPIS/issues/682 - if that's still the case then 100ms is definitely too short and the default should be raised.

Claude-Session: https://claude.ai/code/session_01PRvw1U8cSHWotT9kL5r8FC