### PR TITLE
feat(lapis): distinguish a SILO timeout from SILO being unreachable

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.genspectrum.lapis.response.LapisErrorResponse
 import org.genspectrum.lapis.response.LapisInfoFactory
 import org.genspectrum.lapis.silo.SiloException
 import org.genspectrum.lapis.silo.SiloNotReachableException
+import org.genspectrum.lapis.silo.SiloTimeoutException
 import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.boot.autoconfigure.web.WebProperties
 import org.springframework.boot.webmvc.autoconfigure.error.BasicErrorController
@@ -79,6 +80,14 @@ class ExceptionHandler(
     @ExceptionHandler(SiloNotReachableException::class)
     fun handleSiloNotReachableException(e: SiloNotReachableException): ErrorResponse {
         log.warn { "Caught SiloNotReachableException: ${e.message}" } // don't log stack trace for this common case
+
+        return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message)
+    }
+
+    @ExceptionHandler(SiloTimeoutException::class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    fun handleSiloTimeoutException(e: SiloTimeoutException): ErrorResponse {
+        log.warn { "Caught SiloTimeoutException: ${e.message}" } // don't log stack trace for this common case
 
         return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message)
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -21,11 +21,16 @@ import tools.jackson.module.kotlin.readValue
 import java.io.IOException
 import java.io.InputStream
 import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.PortUnreachableException
 import java.net.URI
+import java.net.UnknownHostException
 import java.net.http.HttpClient
+import java.net.http.HttpConnectTimeoutException
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandlers
+import java.net.http.HttpTimeoutException
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.stream.Stream
@@ -229,6 +234,8 @@ open class CachedSiloClient(
             }
             .build()
 
+        val startedAtNanos = System.nanoTime()
+
         val response = try {
             try {
                 httpClient.send(request, bodyHandler)
@@ -243,12 +250,20 @@ open class CachedSiloClient(
                     throw ioException
                 }
             }
-        } catch (connectException: ConnectException) {
-            val message = "Could not connect to silo: ${connectException::class} ${connectException.message}"
-            throw SiloNotReachableException(message)
         } catch (exception: Exception) {
-            val message = "Could not connect to silo: ${exception::class} ${exception.message}"
-            throw RuntimeException(message, exception)
+            throw when (exception) {
+                is HttpTimeoutException -> SiloTimeoutException(siloTimeoutMessage(uri, startedAtNanos, exception))
+
+                // none of these is a ConnectException, and a timeout is not unreachability at all
+                is ConnectException,
+                is UnknownHostException,
+                is NoRouteToHostException,
+                is PortUnreachableException,
+                -> SiloNotReachableException(siloNotReachableMessage(uri, exception))
+
+                // we don't know what went wrong here, so don't claim that we couldn't connect
+                else -> RuntimeException(siloErrorMessage(uri, exception), exception)
+            }
         }
 
         if (!uri.toString().endsWith("info")) {
@@ -274,6 +289,28 @@ open class CachedSiloClient(
         }
 
         return response
+    }
+
+    private fun siloNotReachableMessage(
+        uri: URI,
+        exception: Exception,
+    ) = "Could not connect to silo at $uri: ${exception::class} ${exception.message}"
+
+    private fun siloErrorMessage(
+        uri: URI,
+        exception: Exception,
+    ) = "Error talking to silo at $uri: ${exception::class} ${exception.message}"
+
+    private fun siloTimeoutMessage(
+        uri: URI,
+        startedAtNanos: Long,
+        exception: HttpTimeoutException,
+    ): String {
+        val elapsedMillis = (System.nanoTime() - startedAtNanos) / 1_000_000
+        return when (exception) {
+            is HttpConnectTimeoutException -> "Timed out connecting to silo at $uri after ${elapsedMillis}ms"
+            else -> "Timed out waiting for a response from silo at $uri after ${elapsedMillis}ms"
+        }
     }
 
     private fun tryToReadSiloErrorFromString(responseBody: String) =
@@ -308,6 +345,14 @@ class SiloException(
 class SiloUnavailableException(
     override val message: String,
     val retryAfter: String?,
+) : Exception(message)
+
+/**
+ * Indicates that SILO did not answer within the timeout that LAPIS set for the request.
+ * SILO may well be reachable and healthy - the request simply outlived its budget.
+ */
+class SiloTimeoutException(
+    override val message: String,
 ) : Exception(message)
 
 /**

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -43,6 +43,7 @@ import tools.jackson.databind.node.IntNode
 import tools.jackson.databind.node.NullNode
 import tools.jackson.databind.node.StringNode
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 private const val MOCK_SERVER_PORT = 1080
 
@@ -834,6 +835,25 @@ class SiloClientAndCacheInvalidatorTest(
 
         val exception = assertThrows<SiloException> { siloClient.sendQuery(someQuery).toList() }
         assertThat(exception.message, containsString(errorMessage))
+    }
+
+    @Test
+    fun `GIVEN silo answers info too slowly THEN throws SiloTimeoutException naming the timeout`() {
+        MockServerClient("localhost", MOCK_SERVER_PORT)
+            .`when`(request().withMethod("GET").withPath("/info"))
+            .respond(
+                response()
+                    .withStatusCode(200)
+                    .withHeader(DATA_VERSION_HEADER, "1234")
+                    .withBody("""{"version": "1.2.3"}""")
+                    // must stay longer than the timeout that callInfo() sets on the request
+                    .withDelay(TimeUnit.MILLISECONDS, 500),
+            )
+
+        val exception = assertThrows<SiloTimeoutException> { siloClient.callInfo() }
+
+        assertThat(exception.message, containsString("Timed out"))
+        assertThat(exception.message, containsString("/info"))
     }
 
     private fun expectInfoCallThatReturnsSiloUnavailable() {


### PR DESCRIPTION
A timeout was reported as "Could not connect to silo", which is wrong and misleads whoever reads it. HttpTimeoutException means LAPIS did connect, sent the request and gave up waiting - SILO is reachable and may be answering other callers perfectly well. Only ConnectException means not reachable.

Related to #1866 in that the misleading exception came up while figuring out what caused info to return silo connection error.

SiloTimeoutException maps to 503, the same status the other SILO-unavailable paths use.

Also edits the message for an uncaught silo exception: the problem isn't necessarily connection failure, could be anything so message shouldn't assume.

## PR Checklist
- [x] All necessary documentation has been adapted.
- [x] All necessary changes are explained in the `llms.txt`.
- [x] The implemented feature is covered by an appropriate test.
