### PR TITLE
fix(lapis): only timeout /sample/info calls in SILO health indicator's calls

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
@@ -7,6 +7,9 @@ import org.springframework.boot.health.contributor.Health
 import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.health.contributor.Status
 import org.springframework.stereotype.Component
+import java.time.Duration
+
+private val HEALTH_CHECK_TIMEOUT = Duration.ofMillis(100)
 
 @Component
 class SiloHealthIndicator(
@@ -17,7 +20,7 @@ class SiloHealthIndicator(
             .up() // LAPIS should always be "up", independent of SILO.
             .let {
                 try {
-                    val info = cachedSiloClient.callInfo()
+                    val info = cachedSiloClient.callInfo(HEALTH_CHECK_TIMEOUT)
                     it
                         .withDetail("siloStatus", Status.UP)
                         .withDetail("dataVersion", info.dataVersion)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -170,13 +170,15 @@ open class CachedSiloClient(
             }
     }
 
-    fun callInfo(): InfoData {
+    fun callInfo(timeout: Duration? = null): InfoData {
         val response = send(
             uri = siloUris.info,
             bodyHandler = BodyHandlers.ofString(),
             tryToReadSiloErrorFromBody = ::tryToReadSiloErrorFromString,
         ) {
-            it.timeout(Duration.ofMillis(100)) // this should never take long, make sure we don't block anything else
+            if (timeout != null) {
+                it.timeout(timeout)
+            }
             it.GET()
         }
 


### PR DESCRIPTION
#1593 added a 100ms timeout for all calls to SILO's `/sample/info` because the silo health indicator which is used by by general health endpoint started using that function and health response shouldn't block indefinitely on the SILO call.

This fix had unintended side effects: all other users of that function now have the same very short timeout limitation of 100ms even if they don't mind waiting: they suddenly get a SILO unreachable exception even if SILO is healthy just a bit slow.

Loculus is affected by this (unintended) side effect: /sample/info starts randomly failing when there's high load.

This PR preserves the intent of #1593 while removing the unintended side effects: only the health endpoint sets a timeout.

Whether or not other callers to `/sample/info` should use a timeout and what that timeout should be can be decided separately. 
