### PR TITLE
fix(lapis): give each SILO callInfo caller per-case timeout

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
@@ -7,6 +7,9 @@ import org.springframework.boot.health.contributor.Health
 import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.health.contributor.Status
 import org.springframework.stereotype.Component
+import java.time.Duration
+
+private val HEALTH_CHECK_TIMEOUT = Duration.ofMillis(100)
 
 @Component
 class SiloHealthIndicator(
@@ -17,7 +20,7 @@ class SiloHealthIndicator(
             .up() // LAPIS should always be "up", independent of SILO.
             .let {
                 try {
-                    val info = cachedSiloClient.callInfo()
+                    val info = cachedSiloClient.callInfo(HEALTH_CHECK_TIMEOUT)
                     it
                         .withDetail("siloStatus", Status.UP)
                         .withDetail("dataVersion", info.dataVersion)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
@@ -9,6 +9,10 @@ import org.genspectrum.lapis.silo.SiloException
 import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.genspectrum.lapis.silo.SiloQuery
 import org.springframework.stereotype.Component
+import java.time.Duration
+
+// only sets a response header, and failure is ignored below - don't stall a request on it
+private val DATA_VERSION_TIMEOUT = Duration.ofSeconds(1)
 
 @Component
 class QueryParseModel(
@@ -20,7 +24,7 @@ class QueryParseModel(
         doFullValidation: Boolean = false,
     ): List<ParsedQueryResult> {
         try {
-            siloClient.callInfo() // populates dataVersion.dataVersion
+            siloClient.callInfo(DATA_VERSION_TIMEOUT) // populates dataVersion.dataVersion
         } catch (_: Exception) {
             // If callInfo fails, log it and continue with null dataVersion
             log.warn { "Could not get current SILO data version" }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -31,12 +31,16 @@ import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.genspectrum.lapis.silo.SiloQuery
 import org.genspectrum.lapis.silo.WithDataVersion
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.LocalDate
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val QUERY_TIMEOUT_SECONDS = 60L
+
+// only sets a response header on an otherwise empty result - don't stall a request on it
+private val DATA_VERSION_TIMEOUT = Duration.ofSeconds(1)
 
 @Schema(
     description = "The result in tabular format with mutations as rows (outer array) and date ranges as " +
@@ -262,7 +266,7 @@ class QueriesOverTimeModel(
         remainingRetries: Int = 1,
     ): QueriesOverTimeResult {
         if (queryItems.isEmpty() || dateRanges.isEmpty()) {
-            siloClient.callInfo() // populates dataVersion.dataVersion
+            siloClient.callInfo(DATA_VERSION_TIMEOUT) // populates dataVersion.dataVersion
             return QueriesOverTimeResult(
                 queries = queryItems.map { it.displayLabel },
                 dateRanges = dateRanges,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
@@ -9,7 +9,11 @@ import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.util.concurrent.TimeUnit
+
+// polls once a second on the single scheduler thread - one hung call must not stall all scheduled work
+private val INFO_TIMEOUT = Duration.ofSeconds(2)
 
 @Component
 class DataVersionCacheInvalidator(
@@ -25,7 +29,7 @@ class DataVersionCacheInvalidator(
         log.debug { "checking for data version change" }
 
         val info = try {
-            cachedSiloClient.callInfo()
+            cachedSiloClient.callInfo(INFO_TIMEOUT)
         } catch (e: SiloUnavailableException) {
             log.debug { "Caught ${SiloUnavailableException::class.java} $e" }
             InfoData(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -65,10 +65,10 @@ class SiloClient(
     /**
      * returns the info object and sets the dataVersion.dataVersion.
      */
-    fun callInfo(): InfoData {
+    fun callInfo(timeout: Duration? = null): InfoData {
         log.info { "Calling SILO info" }
 
-        val info = cachedSiloClient.callInfo()
+        val info = cachedSiloClient.callInfo(timeout)
         dataVersion.dataVersion = info.dataVersion
         return info
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -170,13 +170,15 @@ open class CachedSiloClient(
             }
     }
 
-    fun callInfo(): InfoData {
+    fun callInfo(timeout: Duration? = null): InfoData {
         val response = send(
             uri = siloUris.info,
             bodyHandler = BodyHandlers.ofString(),
             tryToReadSiloErrorFromBody = ::tryToReadSiloErrorFromString,
         ) {
-            it.timeout(Duration.ofMillis(100)) // this should never take long, make sure we don't block anything else
+            if (timeout != null) {
+                it.timeout(timeout)
+            }
             it.GET()
         }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueryControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueryControllerTest.kt
@@ -39,7 +39,7 @@ class QueryControllerTest(
     @BeforeEach
     fun setup() {
         every {
-            siloClient.callInfo()
+            siloClient.callInfo(any())
         } answers {
             dataVersion.dataVersion = "1234"
             InfoData("1234", null)
@@ -205,7 +205,7 @@ class QueryControllerTest(
             .andExpect(jsonPath("$.data[0].type").value("success"))
 
         verify(exactly = 0) { siloClient.sendQuery(query = any<SiloQuery<AggregationData>>(), any()) }
-        verify(exactly = 1) { siloClient.callInfo() }
+        verify(exactly = 1) { siloClient.callInfo(any()) }
     }
 
     @Test
@@ -219,7 +219,7 @@ class QueryControllerTest(
             .andExpect(jsonPath("$.data[0].type").value("success"))
 
         verify(exactly = 0) { siloClient.sendQuery(query = any<SiloQuery<AggregationData>>(), any()) }
-        verify(exactly = 1) { siloClient.callInfo() }
+        verify(exactly = 1) { siloClient.callInfo(any()) }
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/Helpers.kt
@@ -56,7 +56,7 @@ fun mockSiloCallInfo(
     dataVersion: DataVersion,
 ) {
     every {
-        siloClient.callInfo()
+        siloClient.callInfo(any())
     } answers {
         dataVersion.dataVersion = DUMMY_DATA_VERSION
         InfoData(DUMMY_DATA_VERSION, null)


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #1868 — please merge that one first.**
> This branch is based on #1868's head, so the diff here currently contains its commit too.
> The actual change in this PR is the second commit, 62629e93767a9399ca5c3b443fe40c6b1cd9544a
> (+21/−9). Once #1868 merges, this diff narrows to that commit on its own.
>
> To see **only** this PR's change, diffed against the branch it is stacked on:
> https://github.com/corneliusroemer-agent/LAPIS/compare/feat/health-check-owns-silo-timeout...silo-info-timeouts

## Why

#1868 turns the `/info` timeout into a parameter of `CachedSiloClient.callInfo` and sets it for the health check. This restores pre-PR behavior but some other callers might want their own timeouts (though with different durations per use case).

## What

Mirror the parameter one level up, on `SiloClient.callInfo`, so the callers above the cache boundary can set a budget too. Then give each caller one matched to how much it actually cares:

| caller | timeout | reasoning |
| --- | --- | --- |
| `SiloHealthIndicator` | 100 ms | unchanged from #1868, also unchanged to current main |
| `QueryParseModel` | 1 s | best-effort, failure already ignored, only effect of timeout is lack of dataVersion header |
| `QueriesOverTimeModel` | 1 s | best-effort, on the empty-result error |
| `DataVersionCacheInvalidator` | 2 s | polls at 1 Hz on the single scheduler thread: don't want to block forever, no harm timing out |
| `SiloQueryModel.getInfo()` → `/sample/info` | **none** | clients can set the timeout they want, unchanged from #1868|

The poller matters most: nothing configures a `TaskScheduler`, so Spring Boot's default pool size of 1 applies, and one hung call would stall *all* scheduled work. It also runs `@Synchronized` at `fixedRate = 1s`, so waiting much longer than the interval buys nothing.

`/sample/info` deliberately gets **no** timeout. It's user-facing and should take however long SILO takes rather than manufacturing an error of its own. It is also what Loculus points its readiness probe at, where the old 100 ms budget caused spurious probe failures and pod evictions while SILO was healthy; with no LAPIS-side bound, the kubelet's own `timeoutSeconds` becomes the only limit.

## Note for review

6 of the changed lines are test churn, not behaviour: MockK stubs written as `siloClient.callInfo()` argument-match `null` and reject a `Duration`, so they become `callInfo(any())` in `QueryControllerTest.kt` and `mutationsOverTime/Helpers.kt`. Those tests aren't about the timeout, so `any()` is the right specificity.

https://claude.ai/code/session_0164mSDmZH2xfds5wZr3VVLx
