### PR TITLE
feat(lapis): more informative SILO exception handling and error messages

### DIFF
--- a/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/controller/ExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.genspectrum.lapis.response.LapisErrorResponse
 import org.genspectrum.lapis.response.LapisInfoFactory
 import org.genspectrum.lapis.silo.SiloException
 import org.genspectrum.lapis.silo.SiloNotReachableException
+import org.genspectrum.lapis.silo.SiloTimeoutException
 import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.boot.autoconfigure.web.WebProperties
 import org.springframework.boot.webmvc.autoconfigure.error.BasicErrorController
@@ -79,6 +80,14 @@ class ExceptionHandler(
     @ExceptionHandler(SiloNotReachableException::class)
     fun handleSiloNotReachableException(e: SiloNotReachableException): ErrorResponse {
         log.warn { "Caught SiloNotReachableException: ${e.message}" } // don't log stack trace for this common case
+
+        return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message)
+    }
+
+    @ExceptionHandler(SiloTimeoutException::class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    fun handleSiloTimeoutException(e: SiloTimeoutException): ErrorResponse {
+        log.warn { "Caught SiloTimeoutException: ${e.message}" } // don't log stack trace for this common case
 
         return responseEntity(HttpStatus.SERVICE_UNAVAILABLE, e.message)
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
@@ -7,6 +7,9 @@ import org.springframework.boot.health.contributor.Health
 import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.health.contributor.Status
 import org.springframework.stereotype.Component
+import java.time.Duration
+
+private val HEALTH_CHECK_TIMEOUT = Duration.ofMillis(100)
 
 @Component
 class SiloHealthIndicator(
@@ -17,7 +20,7 @@ class SiloHealthIndicator(
             .up() // LAPIS should always be "up", independent of SILO.
             .let {
                 try {
-                    val info = cachedSiloClient.callInfo()
+                    val info = cachedSiloClient.callInfo(HEALTH_CHECK_TIMEOUT)
                     it
                         .withDetail("siloStatus", Status.UP)
                         .withDetail("dataVersion", info.dataVersion)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/health/SiloHealthIndicator.kt
@@ -2,6 +2,7 @@ package org.genspectrum.lapis.health
 
 import org.genspectrum.lapis.silo.CachedSiloClient
 import org.genspectrum.lapis.silo.SiloNotReachableException
+import org.genspectrum.lapis.silo.SiloTimeoutException
 import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.boot.health.contributor.Health
 import org.springframework.boot.health.contributor.HealthIndicator
@@ -29,6 +30,11 @@ class SiloHealthIndicator(
                     it
                         .withDetail("siloStatus", Status.DOWN)
                         .withDetail("error", "SILO not reachable")
+                } catch (_: SiloTimeoutException) {
+                    // not DOWN: exceeding a 100ms budget says nothing about whether SILO is alive
+                    it
+                        .withDetail("siloStatus", Status.UNKNOWN)
+                        .withDetail("error", "SILO did not answer within the health check timeout")
                 } catch (e: SiloUnavailableException) {
                     it
                         .withDetail("siloStatus", Status.DOWN)

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
@@ -9,6 +9,10 @@ import org.genspectrum.lapis.silo.SiloException
 import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.genspectrum.lapis.silo.SiloQuery
 import org.springframework.stereotype.Component
+import java.time.Duration
+
+// only sets a response header, and failure is ignored below - don't stall a request on it
+private val DATA_VERSION_TIMEOUT = Duration.ofSeconds(1)
 
 @Component
 class QueryParseModel(
@@ -20,7 +24,7 @@ class QueryParseModel(
         doFullValidation: Boolean = false,
     ): List<ParsedQueryResult> {
         try {
-            siloClient.callInfo() // populates dataVersion.dataVersion
+            siloClient.callInfo(DATA_VERSION_TIMEOUT) // populates dataVersion.dataVersion
         } catch (_: Exception) {
             // If callInfo fails, log it and continue with null dataVersion
             log.warn { "Could not get current SILO data version" }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/QueryParseModel.kt
@@ -25,9 +25,9 @@ class QueryParseModel(
     ): List<ParsedQueryResult> {
         try {
             siloClient.callInfo(DATA_VERSION_TIMEOUT) // populates dataVersion.dataVersion
-        } catch (_: Exception) {
-            // If callInfo fails, log it and continue with null dataVersion
-            log.warn { "Could not get current SILO data version" }
+        } catch (e: Exception) {
+            // continue with a null data version: the queries can still be parsed without it
+            log.warn { "Could not get current SILO data version: $e" }
         }
         return queries.map { query -> parseSingleQuery(query, doFullValidation) }
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/model/mutationsOverTime/QueriesOverTimeModel.kt
@@ -31,12 +31,16 @@ import org.genspectrum.lapis.silo.SiloFilterExpression
 import org.genspectrum.lapis.silo.SiloQuery
 import org.genspectrum.lapis.silo.WithDataVersion
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.LocalDate
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 private const val QUERY_TIMEOUT_SECONDS = 60L
+
+// only sets a response header on an otherwise empty result - don't stall a request on it
+private val DATA_VERSION_TIMEOUT = Duration.ofSeconds(1)
 
 @Schema(
     description = "The result in tabular format with mutations as rows (outer array) and date ranges as " +
@@ -262,7 +266,7 @@ class QueriesOverTimeModel(
         remainingRetries: Int = 1,
     ): QueriesOverTimeResult {
         if (queryItems.isEmpty() || dateRanges.isEmpty()) {
-            siloClient.callInfo() // populates dataVersion.dataVersion
+            siloClient.callInfo(DATA_VERSION_TIMEOUT) // populates dataVersion.dataVersion
             return QueriesOverTimeResult(
                 queries = queryItems.map { it.displayLabel },
                 dateRanges = dateRanges,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
@@ -31,7 +31,7 @@ class DataVersionCacheInvalidator(
         val info = try {
             cachedSiloClient.callInfo(INFO_TIMEOUT)
         } catch (e: SiloUnavailableException) {
-            log.debug { "Caught ${SiloUnavailableException::class.java} $e" }
+            log.info { "SILO is not available yet: $e" }
             InfoData(
                 dataVersion = "currently unavailable",
                 siloVersion = null,

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
@@ -9,7 +9,11 @@ import org.genspectrum.lapis.silo.SiloUnavailableException
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.util.concurrent.TimeUnit
+
+// polls once a second on the single scheduler thread - one hung call must not stall all scheduled work
+private val INFO_TIMEOUT = Duration.ofSeconds(2)
 
 @Component
 class DataVersionCacheInvalidator(
@@ -25,7 +29,7 @@ class DataVersionCacheInvalidator(
         log.debug { "checking for data version change" }
 
         val info = try {
-            cachedSiloClient.callInfo()
+            cachedSiloClient.callInfo(INFO_TIMEOUT)
         } catch (e: SiloUnavailableException) {
             log.debug { "Caught ${SiloUnavailableException::class.java} $e" }
             InfoData(

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/scheduler/DataVersionCacheInvalidator.kt
@@ -37,7 +37,8 @@ class DataVersionCacheInvalidator(
                 siloVersion = null,
             )
         } catch (e: Exception) {
-            log.debug { "Failed to call info: $e" }
+            // this stops cache invalidation entirely, so it must not be invisible at the default log level
+            log.warn { "Failed to call info: $e" }
             return
         }
         if (info.dataVersion != currentlyCachedDataVersion) {

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -21,11 +21,16 @@ import tools.jackson.module.kotlin.readValue
 import java.io.IOException
 import java.io.InputStream
 import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.PortUnreachableException
 import java.net.URI
+import java.net.UnknownHostException
 import java.net.http.HttpClient
+import java.net.http.HttpConnectTimeoutException
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandlers
+import java.net.http.HttpTimeoutException
 import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.stream.Stream
@@ -231,6 +236,8 @@ open class CachedSiloClient(
             }
             .build()
 
+        val startedAtNanos = System.nanoTime()
+
         val response = try {
             try {
                 httpClient.send(request, bodyHandler)
@@ -245,12 +252,20 @@ open class CachedSiloClient(
                     throw ioException
                 }
             }
-        } catch (connectException: ConnectException) {
-            val message = "Could not connect to silo: ${connectException::class} ${connectException.message}"
-            throw SiloNotReachableException(message)
         } catch (exception: Exception) {
-            val message = "Could not connect to silo: ${exception::class} ${exception.message}"
-            throw RuntimeException(message, exception)
+            throw when (exception) {
+                is HttpTimeoutException -> SiloTimeoutException(siloTimeoutMessage(uri, startedAtNanos, exception))
+
+                // siblings of ConnectException, not subtypes, so catching ConnectException alone missed them
+                is ConnectException,
+                is UnknownHostException,
+                is NoRouteToHostException,
+                is PortUnreachableException,
+                -> SiloNotReachableException(siloNotReachableMessage(uri, exception))
+
+                // we don't know what went wrong here, so don't claim that we couldn't connect
+                else -> RuntimeException(siloErrorMessage(uri, exception), exception)
+            }
         }
 
         if (!uri.toString().endsWith("info")) {
@@ -276,6 +291,28 @@ open class CachedSiloClient(
         }
 
         return response
+    }
+
+    private fun siloNotReachableMessage(
+        uri: URI,
+        exception: Exception,
+    ) = "Could not connect to silo at $uri: ${exception::class} ${exception.message}"
+
+    private fun siloErrorMessage(
+        uri: URI,
+        exception: Exception,
+    ) = "Error talking to silo at $uri: ${exception::class} ${exception.message}"
+
+    private fun siloTimeoutMessage(
+        uri: URI,
+        startedAtNanos: Long,
+        exception: HttpTimeoutException,
+    ): String {
+        val elapsedMillis = (System.nanoTime() - startedAtNanos) / 1_000_000
+        return when (exception) {
+            is HttpConnectTimeoutException -> "Timed out connecting to silo at $uri after ${elapsedMillis}ms"
+            else -> "Timed out waiting for a response from silo at $uri after ${elapsedMillis}ms"
+        }
     }
 
     private fun tryToReadSiloErrorFromString(responseBody: String) =
@@ -310,6 +347,14 @@ class SiloException(
 class SiloUnavailableException(
     override val message: String,
     val retryAfter: String?,
+) : Exception(message)
+
+/**
+ * Indicates that SILO did not answer within the timeout that LAPIS set for the request.
+ * SILO may well be reachable and healthy - the request simply outlived its budget.
+ */
+class SiloTimeoutException(
+    override val message: String,
 ) : Exception(message)
 
 /**

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -65,10 +65,10 @@ class SiloClient(
     /**
      * returns the info object and sets the dataVersion.dataVersion.
      */
-    fun callInfo(): InfoData {
+    fun callInfo(timeout: Duration? = null): InfoData {
         log.info { "Calling SILO info" }
 
-        val info = cachedSiloClient.callInfo()
+        val info = cachedSiloClient.callInfo(timeout)
         dataVersion.dataVersion = info.dataVersion
         return info
     }

--- a/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
+++ b/lapis/src/main/kotlin/org/genspectrum/lapis/silo/SiloClient.kt
@@ -170,13 +170,15 @@ open class CachedSiloClient(
             }
     }
 
-    fun callInfo(): InfoData {
+    fun callInfo(timeout: Duration? = null): InfoData {
         val response = send(
             uri = siloUris.info,
             bodyHandler = BodyHandlers.ofString(),
             tryToReadSiloErrorFromBody = ::tryToReadSiloErrorFromString,
         ) {
-            it.timeout(Duration.ofMillis(100)) // this should never take long, make sure we don't block anything else
+            if (timeout != null) {
+                it.timeout(timeout)
+            }
             it.GET()
         }
 

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueryControllerTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/controller/QueryControllerTest.kt
@@ -39,7 +39,7 @@ class QueryControllerTest(
     @BeforeEach
     fun setup() {
         every {
-            siloClient.callInfo()
+            siloClient.callInfo(any())
         } answers {
             dataVersion.dataVersion = "1234"
             InfoData("1234", null)
@@ -205,7 +205,7 @@ class QueryControllerTest(
             .andExpect(jsonPath("$.data[0].type").value("success"))
 
         verify(exactly = 0) { siloClient.sendQuery(query = any<SiloQuery<AggregationData>>(), any()) }
-        verify(exactly = 1) { siloClient.callInfo() }
+        verify(exactly = 1) { siloClient.callInfo(any()) }
     }
 
     @Test
@@ -219,7 +219,7 @@ class QueryControllerTest(
             .andExpect(jsonPath("$.data[0].type").value("success"))
 
         verify(exactly = 0) { siloClient.sendQuery(query = any<SiloQuery<AggregationData>>(), any()) }
-        verify(exactly = 1) { siloClient.callInfo() }
+        verify(exactly = 1) { siloClient.callInfo(any()) }
     }
 
     @Test

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/Helpers.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/model/mutationsOverTime/Helpers.kt
@@ -56,7 +56,7 @@ fun mockSiloCallInfo(
     dataVersion: DataVersion,
 ) {
     every {
-        siloClient.callInfo()
+        siloClient.callInfo(any())
     } answers {
         dataVersion.dataVersion = DUMMY_DATA_VERSION
         InfoData(DUMMY_DATA_VERSION, null)

--- a/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
+++ b/lapis/src/test/kotlin/org/genspectrum/lapis/silo/SiloClientTest.kt
@@ -42,7 +42,9 @@ import tools.jackson.databind.node.DoubleNode
 import tools.jackson.databind.node.IntNode
 import tools.jackson.databind.node.NullNode
 import tools.jackson.databind.node.StringNode
+import java.time.Duration
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 private const val MOCK_SERVER_PORT = 1080
 
@@ -834,6 +836,24 @@ class SiloClientAndCacheInvalidatorTest(
 
         val exception = assertThrows<SiloException> { siloClient.sendQuery(someQuery).toList() }
         assertThat(exception.message, containsString(errorMessage))
+    }
+
+    @Test
+    fun `GIVEN silo answers info too slowly THEN throws SiloTimeoutException naming the timeout`() {
+        MockServerClient("localhost", MOCK_SERVER_PORT)
+            .`when`(request().withMethod("GET").withPath("/info"))
+            .respond(
+                response()
+                    .withStatusCode(200)
+                    .withHeader(DATA_VERSION_HEADER, "1234")
+                    .withBody("""{"version": "1.2.3"}""")
+                    .withDelay(TimeUnit.MILLISECONDS, 500),
+            )
+
+        val exception = assertThrows<SiloTimeoutException> { siloClient.callInfo(Duration.ofMillis(50)) }
+
+        assertThat(exception.message, containsString("Timed out"))
+        assertThat(exception.message, containsString("/info"))
     }
 
     private fun expectInfoCallThatReturnsSiloUnavailable() {


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #1868 and #1870 — please merge those first.**
> This branch is based on #1870, so the diff here currently contains their commits too. 
>
> To see **only** this PR's change, diffed against the branch it is stacked on:
> https://github.com/corneliusroemer-agent/LAPIS/compare/silo-info-timeouts...silo-timeout-exception

## Why

Every failure to reach SILO except a refused connection was reported with the same sentence: "Could not connect to silo" when in fact the underlying problem might be something else. Different possible failures:
- A SILO request that ran out of time was reported as a connection failure when it could just be slow silo.
- `UnknownHostException`, `NoRouteToHostException` and `PortUnreachableException` fell into the catch-all, became a plain `RuntimeException`, and were answered with a **500** instead of the **503** that a refused connection gets
- The catch-all claimed a cause it does not know. By construction it is the branch for failures we could not classify, so "Could not connect to silo" is a guess presented as a fact.

## What changes for someone reading logs or health output

| situation | before | after |
| --- | --- | --- |
| request outlived its timeout | "Could not connect to silo", 503 | "Timed out waiting for a response from silo at `<uri>` after `<n>`ms", 503 |
| DNS / no route / port unreachable | "Could not connect to silo", **500** | "Could not connect to silo at `<uri>`", **503** |
| anything else | "Could not connect to silo", 500 | "Error talking to silo at `<uri>`", 500 |

`/actuator/health` changes too: A timeout used to fall through to the indicator's catch-all and report `"Unexpected error checking SILO"` with `siloStatus: DOWN`. But a call exceeding 100 ms is no certain evidence that SILO is down, just that it's slow on this particular call. It now reports `siloStatus: UNKNOWN`. The component itself stays `UP` as before — LAPIS's own health never depended on SILO — so no status code and no probe behaviour changes. A DNS or routing failure used to reach that same catch-all and now correctly says "SILO not reachable".

Two log lines were actively unhelpful during exactly the incidents you would want them for. `QueryParseModel` warned "Could not get current SILO data version" and discarded the cause, so it could not tell you whether SILO was slow, refused, or erroring; it now includes it, and after #1870 that is the warning most likely to appear. The data version poller logged its failures at `debug`, which means a SILO that merely answers slowly stops cache invalidation entirely with nothing visible at the default log level; it warns now.

## Judgement calls

`UNKNOWN` rather than `DOWN` for a timeout in the health details, on the grounds that 100 ms elapsing tells you nothing certain about SILO's state. `DOWN` is defensible if anything out there alerts on that field and you would rather it not go quiet.

## Not done here

Cache eviction is deliberately untouched. The poller substitutes a sentinel data version, and so clears the cache, only for `SiloUnavailableException`. `SiloTimeoutException` and `SiloNotReachableException` both extend `Exception` directly, so neither evicts — exactly as before this change. Evicting on a timeout in particular would be harmful: it would dump the cache precisely when SILO is already struggling, and send every subsequent query straight back at it.

https://claude.ai/code/session_0164mSDmZH2xfds5wZr3VVLx

